### PR TITLE
Custom Slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Milestone (notes.srid.ca),
     - [x] Query by tag (in code block)
     - [x] Date in queries (requires Heist withJson changes)
 - [ ] Theme touches
+  - dd styling
 - Nice to have, but not essential
   - [ ] RSS feeds
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ Before tests (tasks impacting the larger architectural context in code base),
 Milestone (notes.srid.ca),
 
 - [ ] Footnotes
-- [ ] Custom route slugs https://github.com/srid/emanote/discussions/42
+- [x] Custom route slugs https://github.com/srid/emanote/discussions/42
 - Blog post friendly
   - Queries
     - [x] Query by tag (in code block)
     - [x] Date in queries (requires Heist withJson changes)
+- [ ] Theme touches
 - Nice to have, but not essential
   - [ ] RSS feeds
 

--- a/src/Emanote/Class.hs
+++ b/src/Emanote/Class.hs
@@ -31,7 +31,7 @@ instance Ema Model Route where
     RLMLFile r ->
       R.encodeRoute $
         fromMaybe (coerce . R.someLinkableLMLRouteCase $ r) $ do
-          note <- M.modelLookupNote r model
+          note <- M.modelLookupNoteByRoute r model
           pure $ N.noteHtmlRoute note
     RStaticFile (r, _fpAbs) ->
       R.encodeRoute r
@@ -41,7 +41,7 @@ instance Ema Model Route where
       <|> fmap staticFileRoute (M.modelLookupStaticFile fp model)
       <|> fmap
         (RLMLFile . N._noteRoute)
-        (flip N.lookupNoteOrItsParent (model ^. M.modelNotes) =<< R.decodeHtmlRoute fp)
+        (flip M.modelLookupNoteByHtmlRoute model =<< R.decodeHtmlRoute fp)
 
   allRoutes model =
     let htmlRoutes =

--- a/src/Emanote/Class.hs
+++ b/src/Emanote/Class.hs
@@ -14,6 +14,9 @@ import qualified Emanote.Model.StaticFile as SF
 import Emanote.Route (FileType (AnyExt, Html, LMLType), LML (Md), LinkableLMLRoute, R)
 import qualified Emanote.Route as R
 
+-- TODO: Remove html route knolwedge from this type.
+-- This should only semantically act as a route to somewhere in `Model` (could
+-- reuse Route to source file wherever appropriate).
 data EmanoteRoute
   = ERIndex
   | ERNoteHtml (R 'Html)

--- a/src/Emanote/Model/Meta.hs
+++ b/src/Emanote/Model/Meta.hs
@@ -11,7 +11,7 @@ import Control.Lens.Operators as Lens ((^.))
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.IxSet.Typed as Ix
-import Emanote.Model (Model, modelLookupNote, modelSData)
+import Emanote.Model (Model, modelLookupNoteByRoute, modelSData)
 import Emanote.Model.Note (lookupAeson, noteMeta)
 import Emanote.Model.SData (sdataValue)
 import qualified Emanote.Model.SData as SData
@@ -32,7 +32,7 @@ getEffectiveRouteMeta mr model =
         guard $ v /= Aeson.Null
         pure v
       frontmatter = do
-        x <- (^. noteMeta) <$> modelLookupNote mr model
+        x <- (^. noteMeta) <$> modelLookupNoteByRoute mr model
         guard $ x /= Aeson.Null
         pure x
       metas = defaults <> maybe mempty one frontmatter

--- a/src/Emanote/Model/Note.hs
+++ b/src/Emanote/Model/Note.hs
@@ -12,8 +12,11 @@ import Control.Lens.Operators as Lens ((^.))
 import Control.Lens.TH (makeLenses)
 import qualified Data.Aeson as Aeson
 import Data.IxSet.Typed (Indexable (..), IxSet, ixFun, ixList)
+import qualified Data.IxSet.Typed as Ix
+import Ema (Slug)
 import qualified Ema.Helper.Markdown as Markdown
 import qualified Emanote.Prelude as EP
+import Emanote.Route (R)
 import qualified Emanote.Route as R
 import qualified Emanote.WikiLink as WL
 import Relude.Extra.Map (StaticMap (lookup))
@@ -23,7 +26,10 @@ data Note = Note
   { _noteDoc :: Pandoc,
     _noteMeta :: Aeson.Value,
     _noteTags :: [Text],
-    _noteRoute :: R.LinkableLMLRoute
+    _noteRoute :: R.LinkableLMLRoute,
+    -- | Custom slug set in frontmatter if any. Overrides _noteRoute for
+    -- determining the URL.
+    _noteSlug :: Maybe Slug
   }
   deriving (Eq, Ord, Show, Generic, Aeson.ToJSON)
 
@@ -34,7 +40,7 @@ noteSelfRefs =
     . (R.liftLinkableRoute . R.someLinkableLMLRouteCase)
     . _noteRoute
 
-type NoteIxs = '[R.LinkableLMLRoute, WL.WikiLink, Text]
+type NoteIxs = '[R.LinkableLMLRoute, WL.WikiLink, Text, Slug]
 
 type IxNote = IxSet NoteIxs Note
 
@@ -44,6 +50,7 @@ instance Indexable NoteIxs Note where
       (ixFun $ one . _noteRoute)
       (ixFun noteSelfRefs)
       (ixFun _noteTags)
+      (ixFun $ maybeToList . _noteSlug)
 
 makeLenses ''Note
 
@@ -52,6 +59,27 @@ noteTitle note =
   fromMaybe (R.routeBaseName . R.someLinkableLMLRouteCase $ note ^. noteRoute) $
     EP.getPandocTitle $ note ^. noteDoc
 
+noteHtmlRoute :: Note -> R 'R.Html
+noteHtmlRoute note =
+  -- Favour slug if one exixts, otherwise use the full path.
+  case lookupAeson @(Maybe Slug) Nothing (one "slug") (note ^. noteMeta) of
+    Nothing ->
+      coerce $ R.someLinkableLMLRouteCase (note ^. noteRoute)
+    Just slug ->
+      R.mkRouteFromSlug slug
+
+-- | TODO: Ditch this in favour of direct indexing in html route.
+lookupNote :: R 'R.Html -> IxNote -> Maybe Note
+lookupNote htmlRoute ns =
+  (Ix.getOne . Ix.getEQ (R.liftLinkableLMLRoute mdRoute)) ns
+    <|> (mSlug >>= \slug -> (Ix.getOne . Ix.getEQ slug) ns)
+  where
+    mSlug :: Maybe Slug = do
+      slug :| [] <- pure $ R.unRoute htmlRoute
+      pure slug
+    mdRoute :: R ('R.LMLType 'R.Md) =
+      coerce htmlRoute
+
 parseNote :: MonadIO m => R.LinkableLMLRoute -> FilePath -> m (Either Text Note)
 parseNote r fp = do
   !s <- readFileText fp
@@ -59,7 +87,8 @@ parseNote r fp = do
     (mMeta, doc) <- parseMarkdown fp s
     let meta = fromMaybe Aeson.Null mMeta
         tags = lookupAeson [] (one "tags") meta
-    pure $ Note doc meta tags r
+        mSlug = lookupAeson Nothing (one "slug") meta
+    pure $ Note doc meta tags r mSlug
   where
     parseMarkdown =
       Markdown.parseMarkdownWithFrontMatter @Aeson.Value $

--- a/src/Emanote/Route/Ext.hs
+++ b/src/Emanote/Route/Ext.hs
@@ -16,6 +16,7 @@ data FileType
   | Yaml
   | HeistTpl
   | Html
+  | Folder
   | -- | `AnyExt` has no *known* (at compile time) extension. It is used as a
     -- "catch all" type to capture files using an arbitrary.
     AnyExt
@@ -57,6 +58,11 @@ instance HasExt 'HeistTpl where
   fileType = HeistTpl
   withExt = flip FP.addExtension ".tpl"
   withoutKnownExt = fpWithoutExt ".tpl"
+
+instance HasExt 'Folder where
+  fileType = Folder
+  withExt = id
+  withoutKnownExt = pure
 
 -- | The AnyExt instance ignores explicitly dealing with extensions, expecting
 -- the user to explicitly encode the extension in their value tpye.

--- a/src/Emanote/Route/R.hs
+++ b/src/Emanote/Route/R.hs
@@ -36,6 +36,10 @@ mkRouteFromFilePath fp = do
   let slugs = fromString . toString . T.dropWhileEnd (== '/') . toText <$> splitPath base
   R <$> nonEmpty slugs
 
+mkRouteFromSlug :: forall ext. HasExt ext => Slug -> R ext
+mkRouteFromSlug =
+  R . one
+
 -- | The base name of the route without its parent path.
 routeBaseName :: R ext -> Text
 routeBaseName =

--- a/src/Emanote/Route/R.hs
+++ b/src/Emanote/Route/R.hs
@@ -12,7 +12,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Ema (Slug)
 import qualified Ema
-import Emanote.Route.Ext (FileType (Html), HasExt (..))
+import Emanote.Route.Ext (FileType (Folder, Html), HasExt (..))
 import System.FilePath (splitPath)
 import qualified Text.Show (Show (show))
 
@@ -44,6 +44,10 @@ mkRouteFromSlug =
 routeBaseName :: R ext -> Text
 routeBaseName =
   Ema.unSlug . head . NE.reverse . unRoute
+
+routeParent :: R ext -> Maybe (R 'Folder)
+routeParent =
+  fmap R . nonEmpty . NE.init . unRoute
 
 -- | For use in breadcrumbs
 routeInits :: R ext -> NonEmpty (R ext)

--- a/src/Emanote/Source/Patch.hs
+++ b/src/Emanote/Source/Patch.hs
@@ -111,3 +111,6 @@ transformAction src fps = do
     R.Html -> do
       -- HTML is handled by AnyExt above, beause we are not passing this to `unionMount`
       pure id
+    R.Folder -> do
+      -- Unused! But maybe we should ... TODO:
+      pure id

--- a/src/Emanote/Template.hs
+++ b/src/Emanote/Template.hs
@@ -50,7 +50,7 @@ render emaAction m = \case
   RStaticFile (_r, fpAbs) ->
     Ema.AssetStatic fpAbs
   RLMLFile lmlRoute -> do
-    case MN.lookupNoteOrItsParent (coerce $ R.someLinkableLMLRouteCase lmlRoute) (m ^. M.modelNotes) of
+    case M.modelLookupNoteByRoute lmlRoute m of
       Just note ->
         Ema.AssetGenerated Ema.Html $ renderLmlHtml emaAction m note
       Nothing ->
@@ -133,7 +133,7 @@ routeTreeSplice mr model = do
     ## ( let tree = PathTree.treeDeleteChild "index" $ model ^. M.modelNav
              getOrder tr =
                ( Meta.lookupMeta @Int 0 (one "order") tr model,
-                 maybe (R.routeBaseName . R.someLinkableLMLRouteCase $ tr) MN.noteTitle $ M.modelLookupNote tr model
+                 maybe (R.routeBaseName . R.someLinkableLMLRouteCase $ tr) MN.noteTitle $ M.modelLookupNoteByRoute tr model
                )
              getCollapsed tr =
                Meta.lookupMeta @Bool True ("template" :| ["sidebar", "collapsed"]) tr model
@@ -200,7 +200,7 @@ resolveUrl emaAction model linkAttrs x@(inner, url) =
             guard $ plainify inner == url
             case r of
               RLMLFile lmlR -> do
-                one . B.Str . MN.noteTitle <$> M.modelLookupNote lmlR model
+                one . B.Str . MN.noteTitle <$> M.modelLookupNoteByRoute lmlR model
               RStaticFile _ -> do
                 -- Just append a file: prefix.
                 pure $ B.Str "File: " : inner


### PR DESCRIPTION
Support neuron-like slugs so individual notes may specify their own top-level URL slug.

This PR does nothing sophisticated, and simply aims to mimic the neuron behaviour. Advanced mechanisms may be designed and added later.
﻿
