### PR TITLE
Better missing link handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ emanote -C /path/to/notebook gen /tmp/output
 
 Emanote is suitable for creating ...
 * ... **project** sites, such as: [ema.srid.ca](https://ema.srid.ca) (view [source](https://github.com/srid/emanote/tree/master/docs)).
-* ... **knowledgebase** sites, such as: [Haskell KB](https://taylor.fausak.me/haskell-knowledge-base/) (view [source](https://github.com/tfausak/haskell-knowledge-base))
 * ... **wiki**/**Zettelkasten** sites, such as: [Unofficial r/TheMotte Wiki](https://themotte.zettel.page/) (view [source](https://github.com/Kuratoro/TheMotte.zettel.page))
-* ... even **personal website**/**blogs**, such as: [www.srid.ca](https://www.srid.ca/) (view [source](https://github.com/srid/www.srid.ca))
+* ... **personal website**/**blogs**, such as: [www.srid.ca](https://www.srid.ca/) (view [source](https://github.com/srid/www.srid.ca))
 
 ## Developing
 

--- a/default/index.yaml
+++ b/default/index.yaml
@@ -31,7 +31,6 @@ pandoc:
     emanote:inline-tag: font-bold bg-gray-100 py-1 px-2 rounded-lg
     # Broken links are wrapped in a <span> with this class. Add its tailwind style here.
     emanote:broken-link: line-through italic
-    emanote:broken-image: line-through italic
     # You can also add your own class -> style mappings.
 
 # Put page-specific metadata here. Override them in Markdown frontmatter or

--- a/default/index.yaml
+++ b/default/index.yaml
@@ -30,7 +30,8 @@ pandoc:
     # TODO: Should these be done instead on Heist (pandoc.tpl)?
     emanote:inline-tag: font-bold bg-gray-100 py-1 px-2 rounded-lg
     # Broken links are wrapped in a <span> with this class. Add its tailwind style here.
-    emanote:broken-link: line-through italic bg-${theme}-100
+    emanote:broken-link: line-through italic
+    emanote:broken-image: line-through italic
     # You can also add your own class -> style mappings.
 
 # Put page-specific metadata here. Override them in Markdown frontmatter or

--- a/docs/guide/neuron.md
+++ b/docs/guide/neuron.md
@@ -5,7 +5,7 @@ TODO
 Neuron notes should mostly work, except for the below:
 
 - No uptree or folgezettel, yet.
-- Replace `z:zettels` with Obsidian-style queries
+- Replace `z:zettels` with Obsidian-style queries ([[demo|see demo]])
   - Query results do not impact graph connections (thus backlinks). If you want to establish connections to multiple notes, do it by explicitly linking to them individually. Emanote chose this option, because it was simpler to implement. Users are encouraged to try to persuade the author otherwise if there is a compelling rationale.
 - No RSS support yet.
 

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.1.0.4
+version:            0.1.1.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/Model/Link/Rel.hs
+++ b/src/Emanote/Model/Link/Rel.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Emanote.Model.Link.Rel where
 
@@ -22,7 +21,7 @@ import qualified Network.URI.Encode as UE
 import qualified Text.Pandoc.Definition as B
 import qualified Text.Pandoc.LinkContext as LC
 
--- | A relation from one note to any other file (note or static file)
+-- | A relation from one note to anywhere in the model.
 --
 -- Target will remain unresolved in the `Rel`, and can be resolved at a latter
 -- time (eg: during rendering).
@@ -36,7 +35,7 @@ data Rel = Rel
   }
   deriving (Eq, Ord, Show)
 
--- | A link target that has not been resolved (using model) yet.
+-- | A link target to somewhere in model that has not been resolved (using model) yet.
 type UnresolvedRelTarget = Either (WL.WikiLinkType, WL.WikiLink) LinkableRoute
 
 type RelIxs = '[LinkableLMLRoute, UnresolvedRelTarget]
@@ -68,7 +67,7 @@ unresolvedRelsTo r =
   (Left <$> toList (WL.allowedWikiLinks r))
     <> [Right r]
 
--- | Parse a URL string for later resolution.
+-- | Parse a relative URL string for later resolution.
 parseUnresolvedRelTarget :: [(Text, Text)] -> Text -> Maybe UnresolvedRelTarget
 parseUnresolvedRelTarget attrs url = do
   guard $ not $ "://" `T.isInfixOf` url

--- a/src/Emanote/Model/Link/Rel.hs
+++ b/src/Emanote/Model/Link/Rel.hs
@@ -37,7 +37,7 @@ data Rel = Rel
   deriving (Eq, Ord, Show)
 
 -- | A link target that has not been resolved (using model) yet.
-type UnresolvedRelTarget = Either WL.WikiLink LinkableRoute
+type UnresolvedRelTarget = Either (WL.WikiLinkType, WL.WikiLink) LinkableRoute
 
 type RelIxs = '[LinkableLMLRoute, UnresolvedRelTarget]
 
@@ -72,7 +72,7 @@ unresolvedRelsTo r =
 parseUnresolvedRelTarget :: [(Text, Text)] -> Text -> Maybe UnresolvedRelTarget
 parseUnresolvedRelTarget attrs url = do
   guard $ not $ "://" `T.isInfixOf` url
-  fmap (Left . snd) (WL.mkWikiLinkFromUrlAndAttrs attrs url)
+  fmap Left (WL.mkWikiLinkFromUrlAndAttrs attrs url)
     <|> fmap
       Right
       (R.mkLinkableRouteFromFilePath $ UE.decode (toString url))

--- a/src/Emanote/Model/Link/Rel.hs
+++ b/src/Emanote/Model/Link/Rel.hs
@@ -35,8 +35,19 @@ data Rel = Rel
   }
   deriving (Eq, Ord, Show)
 
--- | A link target to somewhere in model that has not been resolved (using model) yet.
-type UnresolvedRelTarget = Either (WL.WikiLinkType, WL.WikiLink) LinkableRoute
+-- | A link target that has not been resolved (using model) yet.
+--
+-- Resolving this may or may not result in a resource in the model. In some
+-- cases, the link may point to something else entirely (see
+-- `decodeNonResourceRoute`).
+--
+-- TODO: This information should ideally be captured at the type-level. ie. have
+-- /@index/.. and /@tags/.. captured as their own route type. Them open-union
+-- them all in `SiteRoute.
+type UnresolvedRelTarget =
+  Either
+    (WL.WikiLinkType, WL.WikiLink)
+    LinkableRoute
 
 type RelIxs = '[LinkableLMLRoute, UnresolvedRelTarget]
 

--- a/src/Emanote/Model/Note.hs
+++ b/src/Emanote/Model/Note.hs
@@ -69,7 +69,8 @@ instance Indexable NoteIxs Note where
 -- | All possible wiki-links that refer to this note.
 noteSelfRefs :: Note -> [WL.WikiLink]
 noteSelfRefs =
-  WL.allowedWikiLinks
+  fmap snd
+    . WL.allowedWikiLinks
     . (R.liftLinkableRoute . R.linkableLMLRouteCase)
     . _noteRoute
 

--- a/src/Emanote/Model/StaticFile.hs
+++ b/src/Emanote/Model/StaticFile.hs
@@ -34,7 +34,8 @@ instance Indexable StaticFileIxs StaticFile where
 
 staticFileSelfRefs :: StaticFile -> [WL.WikiLink]
 staticFileSelfRefs =
-  WL.allowedWikiLinks
+  fmap snd
+    . WL.allowedWikiLinks
     . R.liftLinkableRoute
     . _staticFileRoute
 

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -26,7 +26,6 @@ import Emanote.Model.SData (IxSData, SData, sdataRoute)
 import Emanote.Model.StaticFile
   ( IxStaticFile,
     StaticFile (StaticFile),
-    staticFileRoute,
   )
 import qualified Emanote.Pandoc.Markdown.Syntax.HashTag as HT
 import qualified Emanote.Pandoc.Markdown.Syntax.WikiLink as WL
@@ -129,15 +128,16 @@ modelLookupTitle :: LinkableLMLRoute -> Model -> Text
 modelLookupTitle r =
   maybe (R.routeBaseName $ R.linkableLMLRouteCase r) N.noteTitle . modelLookupNoteByRoute r
 
-modelResolveWikiLink :: WL.WikiLink -> Model -> [LinkableRoute]
-modelResolveWikiLink wl model =
-  let noteRoutes =
-        fmap (R.liftLinkableRoute . R.linkableLMLRouteCase . (^. N.noteRoute)) . Ix.toList $
+-- Lookup the wiki-link and return its candidates in the model.
+modelWikiLinkTargets :: WL.WikiLink -> Model -> [Either Note StaticFile]
+modelWikiLinkTargets wl model =
+  let notes =
+        Ix.toList $
           (model ^. modelNotes) @= wl
-      staticRoutes =
-        fmap (R.liftLinkableRoute . (^. staticFileRoute)) . Ix.toList $
+      staticFiles =
+        Ix.toList $
           (model ^. modelStaticFiles) @= wl
-   in staticRoutes <> noteRoutes
+   in fmap Right staticFiles <> fmap Left notes
 
 modelLookupBacklinks :: LinkableRoute -> Model -> [(LinkableLMLRoute, [B.Block])]
 modelLookupBacklinks r model =

--- a/src/Emanote/Pandoc/Filter/Url.hs
+++ b/src/Emanote/Pandoc/Filter/Url.hs
@@ -83,7 +83,7 @@ resolveUnresolvedRelTarget ::
 resolveUnresolvedRelTarget model = \case
   Right r ->
     pure <$> resolveLinkableRoute r
-  Left wl ->
+  Left (wlType, wl) ->
     case nonEmpty (M.modelResolveWikiLink wl model) of
       Nothing -> do
         pure $ throwError "Unresolved wiki-link"

--- a/src/Emanote/Pandoc/Filter/Url.hs
+++ b/src/Emanote/Pandoc/Filter/Url.hs
@@ -46,7 +46,6 @@ urlResolvingSplice emaAction model (ctxSansCustomSplicing -> ctx) inl =
       [] -> one $ B.Str fn
       x -> x
     brokenLinkSpanWrapper err inline =
-      -- FIXME: The "title" here doesn't have effect if the inline is a <a> with its own title.
       HP.rpInline ctx $
         B.Span ("", one "emanote:broken-link", one ("title", err)) $
           one inline
@@ -101,7 +100,7 @@ resolveUnresolvedRelTarget model = \case
     resolveWikiLinkMustExist wl =
       case nonEmpty (M.modelWikiLinkTargets wl model) of
         Nothing -> do
-          throwError "Wiki-link does not resolve to any known file"
+          throwError "Wiki-link does not refer to any known file"
         Just (target :| []) ->
           pure target
         Just targets -> do
@@ -117,7 +116,7 @@ resolveUnresolvedRelTarget model = \case
     resolveLinkableRouteMustExist r =
       case resolveLinkableRoute model r of
         Nothing ->
-          Left "Link does not resolve to any known file"
+          Left "Link does not refer to any known file"
         Just v -> Right v
 
 resolveLinkableRoute :: Model -> R.LinkableRoute -> Maybe (SiteRoute, Maybe UTCTime)

--- a/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
+++ b/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
@@ -44,7 +44,7 @@ instance Show WikiLink where
 
 mkWikiLinkFromUrlAndAttrs :: [(Text, Text)] -> Text -> Maybe (WikiLinkType, WikiLink)
 mkWikiLinkFromUrlAndAttrs (Map.fromList -> attrs) s = do
-  wlType :: WikiLinkType <- readMaybe . toString <=< Map.lookup "title" $ attrs
+  wlType :: WikiLinkType <- readMaybe . toString <=< Map.lookup htmlAttr $ attrs
   wl <- mkWikiLinkFromUrl s
   pure (wlType, wl)
   where
@@ -99,11 +99,17 @@ instance Read WikiLinkType where
     | s == show WikiLinkEmbed = [(WikiLinkEmbed, "")]
     | otherwise = []
 
+-- | The HTML 'data attribute' storing the wiki-link type.
+htmlAttr :: Text
+htmlAttr = "data-wikilink-type"
+
 class HasWikiLink il where
   wikilink :: WikiLinkType -> Text -> il -> il
 
 instance HasWikiLink (CP.Cm b B.Inlines) where
-  wikilink typ t il = CP.Cm $ B.link t (show typ) $ CP.unCm il
+  wikilink typ t il = CP.Cm $ B.linkWith attrs t "" $ CP.unCm il
+    where
+      attrs = ("", [], [(htmlAttr, show typ)])
 
 -- | Like `Commonmark.Extensions.Wikilinks.wikilinkSpec` but Zettelkasten-friendly.
 --

--- a/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
+++ b/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Emanote.Pandoc.Markdown.Syntax.WikiLink
-  ( WikiLink,
+  ( WikiLink (unWikiLink),
     WikiLinkType,
     wikilinkSpec,
     mkWikiLinkFromUrlAndAttrs,
@@ -22,20 +22,25 @@ import Data.Data (Data)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
-import Ema (Slug)
+import Ema (Slug (unSlug))
 import qualified Ema
 import Emanote.Route (LinkableRoute, R (unRoute), linkableLMLRouteCase, linkableRouteCase)
 import qualified Text.Megaparsec as M
 import qualified Text.Pandoc.Builder as B
 import qualified Text.Parsec as P
 import Text.Read (Read (readsPrec))
+import qualified Text.Show (Show (show))
 
 -- | Represents the "Foo" in [[Foo]]
 --
 -- As wiki links may contain multiple path components, it can also represent
 -- [[Foo/Bar]], hence we use nonempty slug list.
 newtype WikiLink = WikiLink {unWikiLink :: NonEmpty Slug}
-  deriving (Eq, Show, Ord, Typeable, Data)
+  deriving (Eq, Ord, Typeable, Data)
+
+instance Show WikiLink where
+  show (WikiLink (toList . fmap unSlug -> slugs)) =
+    toString $ "[[" <> T.intercalate "/" slugs <> "]]"
 
 mkWikiLinkFromUrlAndAttrs :: [(Text, Text)] -> Text -> Maybe (WikiLinkType, WikiLink)
 mkWikiLinkFromUrlAndAttrs (Map.fromList -> attrs) s = do

--- a/src/Emanote/Route/Linkable.hs
+++ b/src/Emanote/Route/Linkable.hs
@@ -31,6 +31,7 @@ type LMLRoutes =
   '[ R ('LMLType 'Md)
    ]
 
+-- | A "route" into the `Model`.
 type Routes =
   R 'AnyExt
     ': LMLRoutes

--- a/src/Heist/Extra/Splices/Pandoc/Attr.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Attr.hs
@@ -9,14 +9,14 @@ rpAttr (id', classes, attrs) =
   let cls = T.intercalate " " classes
    in unlessNull id' [("id", id')]
         <> unlessNull cls [("class", cls)]
-        <> mconcat (fmap (\(k, v) -> [(k, v)]) attrs)
+        <> concat (mapMaybe (\(k, v) -> unlessNull v $ pure [(k, v)]) attrs)
   where
     unlessNull x f =
       if T.null x then mempty else f
 
 -- | Merge two XmlHtml attributes set
-addAttr :: B.Attr -> B.Attr -> B.Attr
-addAttr (id1, cls1, attr1) (id2, cls2, attr2) =
+concatAttr :: B.Attr -> B.Attr -> B.Attr
+concatAttr (id1, cls1, attr1) (id2, cls2, attr2) =
   (pickNonNull id1 id2, cls1 <> cls2, attr1 <> attr2)
   where
     pickNonNull x "" = x

--- a/src/Heist/Extra/Splices/Pandoc/Ctx.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Ctx.hs
@@ -48,6 +48,14 @@ mkRenderCtx node classMap bS iS footnotes = do
           footnotes
    in ctx
 
+-- | Strip any custom splicing out of the given render context
+ctxSansCustomSplicing :: RenderCtx n -> RenderCtx n
+ctxSansCustomSplicing ctx =
+  ctx
+    { blockSplice = const Nothing,
+      inlineSplice = const Nothing
+    }
+
 rewriteClass :: Monad n => RenderCtx n -> B.Attr -> B.Attr
 rewriteClass RenderCtx {..} (id', cls, attr) =
   let cls' = maybe cls T.words $ Map.lookup (T.intercalate " " cls) classMap

--- a/src/Heist/Extra/Splices/Pandoc/Ctx.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Ctx.hs
@@ -5,7 +5,7 @@ module Heist.Extra.Splices.Pandoc.Ctx where
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Heist as H
-import Heist.Extra.Splices.Pandoc.Attr (addAttr)
+import Heist.Extra.Splices.Pandoc.Attr (concatAttr)
 import qualified Heist.Interpreted as HI
 import qualified Text.Pandoc.Builder as B
 import qualified Text.XmlHtml as X
@@ -83,7 +83,7 @@ inlineLookupAttr node = \case
     fromMaybe B.nullAttr $ do
       link <- X.childElementTag "PandocLink" node
       let innerTag = if "://" `T.isInfixOf` url then "External" else "Internal"
-      pure $ attrFromNode link `addAttr` childTagAttr link innerTag
+      pure $ attrFromNode link `concatAttr` childTagAttr link innerTag
   _ -> B.nullAttr
 
 -- | Useful for running a splice against an arbitrary node (such as that pulled from pandoc.tpl)


### PR DESCRIPTION
Also prepare by refactoring ahead of #24 

- Refactor
- Propagate wiki link type wherever it will be needed
- Handle missing relative links for non-wikilinks too
- Display filename struck out for broken image links
- Unify broken-link classes
- Remove inactive example
- Refactor for clarity
- Handle links to @index,etc. in "resolution" stage
- Handle ambiguous wiki-links
- Avoid redundant 'title' attr in Image
- Use a data attribute for wiki-links
