### PR TITLE
Fix wiki link can have same title as alternative text

### DIFF
--- a/docs/demo/markdown.md
+++ b/docs/demo/markdown.md
@@ -8,6 +8,11 @@ page:
 
 Emanote notes are written in Markdown format. A tutorial is [available here](https://commonmark.org/help/tutorial/). Below we shall highlight some of the commonmark extensions that Emanote supports on top of standard Mardown syntax.
 
+## Links
+
+You can link to a document by doing this `[[neuron]]` and it will be rendered as [[neuron]]. See that it is using the title defined in the document,
+but you can specify an alternative title as well like this [[neuron|Neuron guide]] or any other text [[neuron|neuron]].
+
 ## Emojis
 
 :smile:

--- a/src/Emanote/Pandoc/Filter/Url.hs
+++ b/src/Emanote/Pandoc/Filter/Url.hs
@@ -76,8 +76,8 @@ replaceLinkNodeWithRoute ::
   ([B.Inline], Text)
 replaceLinkNodeWithRoute emaAction model (r, mTime) (inner, url) =
   let finalInner =
-        if url == plainify inner -- It's a wiki-link with no custom text
-          then fromMaybe inner $ siteRouteDefaultInnerText r
+        if null inner -- It's a wiki-link with no custom text
+          then fromMaybe [B.Str url] $ siteRouteDefaultInnerText r
           else inner
    in ( finalInner,
         foldUrlTime (SR.siteRouteUrl model r) mTime
@@ -93,7 +93,7 @@ replaceLinkNodeWithRoute emaAction model (r, mTime) (inner, url) =
                       )
                   `h` ( \(_ :: R.StaticFileRoute, _ :: FilePath) ->
                           -- Just append a file: prefix, to existing wiki-link.
-                          pure $ B.Str "File:" : inner
+                          pure $ B.Str "File:" : [B.Str url]
                       )
             )
         `h` (\(_ :: SR.VirtualRoute) -> Nothing)

--- a/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
+++ b/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
@@ -102,10 +102,10 @@ htmlAttr :: Text
 htmlAttr = "data-wikilink-type"
 
 class HasWikiLink il where
-  wikilink :: WikiLinkType -> Text -> il -> il
+  wikilink :: WikiLinkType -> Text -> Maybe il -> il
 
 instance HasWikiLink (CP.Cm b B.Inlines) where
-  wikilink typ t il = CP.Cm $ B.linkWith attrs t "" $ CP.unCm il
+  wikilink typ t il = CP.Cm $ B.linkWith attrs t "" $ maybe mempty CP.unCm il
     where
       attrs = ("", [], [(htmlAttr, show typ)])
 
@@ -143,11 +143,11 @@ wikilinkSpec =
                 )
             )
       title <-
-        M.option url $
+        M.optional $
           -- TODO: Should parse as inline so link text can be formatted?
           CM.untokenize
             <$> ( CT.symbol '|'
                     *> many (CT.satisfyTok (not . CT.hasType (CM.Symbol ']')))
                 )
       replicateM_ 2 $ CT.symbol ']'
-      return $ wikilink typ url (CM.str title)
+      return $ wikilink typ url (fmap CM.str title)


### PR DESCRIPTION
Resolves https://github.com/srid/emanote/issues/77