### PR TITLE
Fix: wiki-links (etc.) in title being hidden

### DIFF
--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.1.39.0
+version:            0.1.40.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/Model/Title.hs
+++ b/src/Emanote/Model/Title.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Emanote.Model.Title
@@ -24,6 +25,7 @@ import qualified Heist.Extra.Splices.Pandoc.Ctx as HP
 import Heist.Extra.Splices.Pandoc.Render (plainify)
 import qualified Heist.Interpreted as HI
 import qualified Text.Pandoc.Definition as B
+import qualified Text.Pandoc.Walk as W
 
 data Title
   = TitlePlain Text
@@ -69,12 +71,18 @@ toPlain = \case
   TitlePlain s -> s
   TitlePandoc is -> plainify is
 
-titleSplice :: Monad n => HP.RenderCtx n -> (B.Pandoc -> B.Pandoc) -> Title -> HI.Splice n
+titleSplice ::
+  forall b n.
+  (Monad n, W.Walkable B.Inline b, b ~ [B.Inline]) =>
+  HP.RenderCtx n ->
+  (b -> b) ->
+  Title ->
+  HI.Splice n
 titleSplice ctx f = \case
   TitlePlain x ->
     HI.textSplice x
   TitlePandoc is -> do
-    let titleDoc = f $ B.Pandoc mempty $ one $ B.Plain is
+    let titleDoc = B.Pandoc mempty $ one $ B.Plain $ f is
     HP.pandocSplice ctx titleDoc
 
 _mkEmptyRenderCtx :: (Monad m, Monad n) => HeistT n m (HP.RenderCtx n)

--- a/src/Emanote/Model/Title.hs
+++ b/src/Emanote/Model/Title.hs
@@ -19,9 +19,7 @@ where
 
 import Data.Aeson (ToJSON)
 import qualified Emanote.Route as R
-import Heist (HeistT)
 import qualified Heist.Extra.Splices.Pandoc as HP
-import qualified Heist.Extra.Splices.Pandoc.Ctx as HP
 import Heist.Extra.Splices.Pandoc.Render (plainify)
 import qualified Heist.Interpreted as HI
 import qualified Text.Pandoc.Definition as B
@@ -84,10 +82,6 @@ titleSplice ctx f = \case
   TitlePandoc is -> do
     let titleDoc = B.Pandoc mempty $ one $ B.Plain $ f is
     HP.pandocSplice ctx titleDoc
-
-_mkEmptyRenderCtx :: (Monad m, Monad n) => HeistT n m (HP.RenderCtx n)
-_mkEmptyRenderCtx =
-  HP.mkRenderCtx mempty (const . const $ Nothing) (const . const $ Nothing)
 
 titleSpliceNoHtml :: Monad n => Title -> HI.Splice n
 titleSpliceNoHtml =

--- a/src/Emanote/Model/Title.hs
+++ b/src/Emanote/Model/Title.hs
@@ -18,6 +18,7 @@ where
 
 import Data.Aeson (ToJSON)
 import qualified Emanote.Route as R
+import Heist (HeistT)
 import qualified Heist.Extra.Splices.Pandoc as HP
 import qualified Heist.Extra.Splices.Pandoc.Ctx as HP
 import Heist.Extra.Splices.Pandoc.Render (plainify)
@@ -68,18 +69,17 @@ toPlain = \case
   TitlePlain s -> s
   TitlePandoc is -> plainify is
 
-titleSplice :: Monad n => (B.Pandoc -> B.Pandoc) -> Title -> HI.Splice n
-titleSplice f = \case
+titleSplice :: Monad n => HP.RenderCtx n -> (B.Pandoc -> B.Pandoc) -> Title -> HI.Splice n
+titleSplice ctx f = \case
   TitlePlain x ->
     HI.textSplice x
   TitlePandoc is -> do
     let titleDoc = f $ B.Pandoc mempty $ one $ B.Plain is
-    ctx <- mkEmptyRenderCtx
     HP.pandocSplice ctx titleDoc
-  where
-    -- TODO: We probably *do* want inline splicing here, and classMap here.
-    mkEmptyRenderCtx =
-      HP.mkRenderCtx mempty (const . const $ Nothing) (const . const $ Nothing)
+
+_mkEmptyRenderCtx :: (Monad m, Monad n) => HeistT n m (HP.RenderCtx n)
+_mkEmptyRenderCtx =
+  HP.mkRenderCtx mempty (const . const $ Nothing) (const . const $ Nothing)
 
 titleSpliceNoHtml :: Monad n => Title -> HI.Splice n
 titleSpliceNoHtml =

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -40,6 +40,10 @@ data Model = Model
     _modelRels :: IxRel,
     _modelSData :: IxSData,
     _modelStaticFiles :: IxStaticFile,
+    -- TODO: Avoid incremental building (which is complex), and compute this on
+    -- demand like `modelTags`? Use memoization to avoid repeat computation if
+    -- model hasn't changed. NOTE: Recomputation on single-file change will be
+    -- O(n), so maybe this is not a good idea.
     _modelNav :: [Tree Slug],
     _modelHeistTemplate :: TemplateState
   }

--- a/src/Emanote/Pandoc/Renderer.hs
+++ b/src/Emanote/Pandoc/Renderer.hs
@@ -18,18 +18,18 @@ import qualified Heist.Interpreted as HI
 import qualified Text.Pandoc.Definition as B
 
 -- | Custom Heist renderer for specific Pandoc AST nodes
-type PandocRenderer astType n x =
+type PandocRenderer astType n i b x =
   Ema.CLI.Action ->
   Model ->
-  NoteRenderers n ->
+  NoteRenderers n i b ->
   Splices.RenderCtx n ->
   x ->
   astType ->
   Maybe (HI.Splice n)
 
-type PandocInlineRenderer n x = PandocRenderer B.Inline n x
+type PandocInlineRenderer n i b x = PandocRenderer B.Inline n i b x
 
-type PandocBlockRenderer n x = PandocRenderer B.Block n x
+type PandocBlockRenderer n i b x = PandocRenderer B.Block n i b x
 
 -- | Custom render logic for a note (available at a LMLRoute)
 --
@@ -40,29 +40,31 @@ type PandocBlockRenderer n x = PandocRenderer B.Block n x
 --
 -- So we expect the extensions to be in Haskell, however external script may be
 -- supported using a traditional whole-AST extension API.
-data NoteRenderers n = NoteRenderers
-  { noteInlineRenderers :: [PandocInlineRenderer n LMLRoute],
-    noteBlockRenderers :: [PandocBlockRenderer n LMLRoute]
+data NoteRenderers n i b = NoteRenderers
+  { noteInlineRenderers :: [PandocInlineRenderer n i b i],
+    noteBlockRenderers :: [PandocBlockRenderer n i b b]
   }
 
 mkRenderCtxWithNoteRenderers ::
+  forall i b m n.
   (Monad m, Monad n) =>
-  NoteRenderers n ->
+  NoteRenderers n i b ->
   Map Text Text ->
   Ema.CLI.Action ->
   Model ->
-  LMLRoute ->
+  i ->
+  b ->
   HeistT n m (Splices.RenderCtx n)
-mkRenderCtxWithNoteRenderers nf@NoteRenderers {..} classRules emaAction model x =
+mkRenderCtxWithNoteRenderers nr@NoteRenderers {..} classRules emaAction model i b =
   Splices.mkRenderCtx
     classRules
     ( \ctx blk ->
         asum $
           noteBlockRenderers <&> \f ->
-            f emaAction model nf ctx x blk
+            f emaAction model nr ctx b blk
     )
     ( \ctx blk ->
         asum $
           noteInlineRenderers <&> \f ->
-            f emaAction model nf ctx x blk
+            f emaAction model nr ctx i blk
     )

--- a/src/Emanote/Pandoc/Renderer.hs
+++ b/src/Emanote/Pandoc/Renderer.hs
@@ -4,15 +4,12 @@ module Emanote.Pandoc.Renderer
   ( NoteRenderers (..),
     PandocInlineRenderer,
     PandocBlockRenderer,
-    noteSpliceWith,
     mkRenderCtxWithNoteRenderers,
   )
 where
 
 import qualified Ema.CLI
-import qualified Emanote.Model.Note as MN
 import Emanote.Model.Type (Model)
-import Emanote.Pandoc.BuiltinFilters (prepareNoteDoc)
 import Emanote.Route (LMLRoute)
 import Heist (HeistT)
 import qualified Heist.Extra.Splices.Pandoc as Splices
@@ -69,32 +66,3 @@ mkRenderCtxWithNoteRenderers nf@NoteRenderers {..} classRules emaAction model x 
           noteInlineRenderers <&> \f ->
             f emaAction model nf ctx x blk
     )
-
--- | Like `pandocSpliceWith` but when it is known that we are rendering a `Note`
---
--- The note will be processed ahead using `prepareNoteDoc`.
-noteSpliceWith ::
-  Monad n =>
-  NoteRenderers n ->
-  Map Text Text ->
-  Ema.CLI.Action ->
-  Model ->
-  MN.Note ->
-  HI.Splice n
-noteSpliceWith nr rules act model note =
-  pandocSpliceWith nr rules act model (MN._noteRoute note) $
-    prepareNoteDoc model $
-      MN._noteDoc note
-
-pandocSpliceWith ::
-  Monad n =>
-  NoteRenderers n ->
-  Map Text Text ->
-  Ema.CLI.Action ->
-  Model ->
-  LMLRoute ->
-  B.Pandoc ->
-  HI.Splice n
-pandocSpliceWith nr classRules emaAction model x doc = do
-  ctx <- mkRenderCtxWithNoteRenderers nr classRules emaAction model x
-  Splices.pandocSplice ctx doc

--- a/src/Emanote/Pandoc/Renderer.hs
+++ b/src/Emanote/Pandoc/Renderer.hs
@@ -4,8 +4,8 @@ module Emanote.Pandoc.Renderer
   ( NoteRenderers (..),
     PandocInlineRenderer,
     PandocBlockRenderer,
-    pandocSpliceWith,
     noteSpliceWith,
+    mkRenderCtxWithNoteRenderers,
   )
 where
 
@@ -70,19 +70,6 @@ mkRenderCtxWithNoteRenderers nf@NoteRenderers {..} classRules emaAction model x 
             f emaAction model nf ctx x blk
     )
 
-pandocSpliceWith ::
-  Monad n =>
-  NoteRenderers n ->
-  Map Text Text ->
-  Ema.CLI.Action ->
-  Model ->
-  LMLRoute ->
-  B.Pandoc ->
-  HI.Splice n
-pandocSpliceWith nr classRules emaAction model x doc = do
-  ctx <- mkRenderCtxWithNoteRenderers nr classRules emaAction model x
-  Splices.pandocSplice ctx doc
-
 -- | Like `pandocSpliceWith` but when it is known that we are rendering a `Note`
 --
 -- The note will be processed ahead using `prepareNoteDoc`.
@@ -98,3 +85,16 @@ noteSpliceWith nr rules act model note =
   pandocSpliceWith nr rules act model (MN._noteRoute note) $
     prepareNoteDoc model $
       MN._noteDoc note
+
+pandocSpliceWith ::
+  Monad n =>
+  NoteRenderers n ->
+  Map Text Text ->
+  Ema.CLI.Action ->
+  Model ->
+  LMLRoute ->
+  B.Pandoc ->
+  HI.Splice n
+pandocSpliceWith nr classRules emaAction model x doc = do
+  ctx <- mkRenderCtxWithNoteRenderers nr classRules emaAction model x
+  Splices.pandocSplice ctx doc

--- a/src/Emanote/Pandoc/Renderer.hs
+++ b/src/Emanote/Pandoc/Renderer.hs
@@ -10,7 +10,6 @@ where
 
 import qualified Ema.CLI
 import Emanote.Model.Type (Model)
-import Emanote.Route (LMLRoute)
 import Heist (HeistT)
 import qualified Heist.Extra.Splices.Pandoc as Splices
 import qualified Heist.Extra.Splices.Pandoc.Ctx as Splices
@@ -18,6 +17,8 @@ import qualified Heist.Interpreted as HI
 import qualified Text.Pandoc.Definition as B
 
 -- | Custom Heist renderer for specific Pandoc AST nodes
+--
+-- The `x` selects between `i` (inline) and `b` (block) types.
 type PandocRenderer astType n i b x =
   Ema.CLI.Action ->
   Model ->
@@ -27,9 +28,9 @@ type PandocRenderer astType n i b x =
   astType ->
   Maybe (HI.Splice n)
 
-type PandocInlineRenderer n i b x = PandocRenderer B.Inline n i b x
+type PandocInlineRenderer n i b = PandocRenderer B.Inline n i b i
 
-type PandocBlockRenderer n i b x = PandocRenderer B.Block n i b x
+type PandocBlockRenderer n i b = PandocRenderer B.Block n i b b
 
 -- | Custom render logic for a note (available at a LMLRoute)
 --
@@ -41,8 +42,8 @@ type PandocBlockRenderer n i b x = PandocRenderer B.Block n i b x
 -- So we expect the extensions to be in Haskell, however external script may be
 -- supported using a traditional whole-AST extension API.
 data NoteRenderers n i b = NoteRenderers
-  { noteInlineRenderers :: [PandocInlineRenderer n i b i],
-    noteBlockRenderers :: [PandocBlockRenderer n i b b]
+  { noteInlineRenderers :: [PandocInlineRenderer n i b],
+    noteBlockRenderers :: [PandocBlockRenderer n i b]
   }
 
 mkRenderCtxWithNoteRenderers ::

--- a/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -24,7 +24,7 @@ import qualified Heist.Interpreted as HI
 import qualified Text.Pandoc.Definition as B
 
 embedWikiLinkResolvingSplice ::
-  Monad n => PandocBlockRenderer n i b x
+  Monad n => PandocBlockRenderer n i b
 embedWikiLinkResolvingSplice _emaAction model _nf (ctxSansCustomSplicing -> ctx) _ blk =
   case blk of
     B.Para [B.Link (_id, _class, otherAttrs) _is (url, tit)] -> do

--- a/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -44,10 +44,10 @@ embedWikiLinkResolvingSplice emaAction model nf (ctxSansCustomSplicing -> ctx) _
           one block
 
 embedSiteRoute :: Monad n => Ema.CLI.Action -> Model -> NoteRenderers n -> HP.RenderCtx n -> WL.WikiLink -> Either MN.Note SF.StaticFile -> Maybe (HI.Splice n)
-embedSiteRoute emaAction model nf RenderCtx {..} wl = \case
+embedSiteRoute emaAction model nf ctx@RenderCtx {..} wl = \case
   Left note -> do
     pure . runEmbedTemplate "note" $ do
-      "ema:note:title" ## Tit.titleSplice (preparePandoc model) (MN._noteTitle note)
+      "ema:note:title" ## Tit.titleSplice ctx (preparePandoc model) (MN._noteTitle note)
       "ema:note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute $ note ^. MN.noteRoute)
       "ema:note:pandoc"
         ## noteSpliceWith nf classMap emaAction model note

--- a/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -24,7 +24,7 @@ import qualified Heist.Interpreted as HI
 import qualified Text.Pandoc.Definition as B
 
 embedWikiLinkResolvingSplice ::
-  Monad n => PandocBlockRenderer n x
+  Monad n => PandocBlockRenderer n i b x
 embedWikiLinkResolvingSplice _emaAction model _nf (ctxSansCustomSplicing -> ctx) _ blk =
   case blk of
     B.Para [B.Link (_id, _class, otherAttrs) _is (url, tit)] -> do

--- a/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -5,27 +5,27 @@ module Emanote.Pandoc.Renderer.Embed where
 import Control.Lens.Operators ((^.))
 import Data.Map.Syntax ((##))
 import qualified Data.Text as T
-import qualified Ema.CLI
 import Emanote.Model (Model)
 import qualified Emanote.Model.Link.Rel as Rel
 import qualified Emanote.Model.Note as MN
 import qualified Emanote.Model.StaticFile as SF
 import qualified Emanote.Model.Title as Tit
-import Emanote.Pandoc.BuiltinFilters (preparePandoc)
+import Emanote.Pandoc.BuiltinFilters (prepareNoteDoc, preparePandoc)
 import qualified Emanote.Pandoc.Markdown.Syntax.WikiLink as WL
-import Emanote.Pandoc.Renderer (NoteRenderers, PandocBlockRenderer, noteSpliceWith)
+import Emanote.Pandoc.Renderer (PandocBlockRenderer)
 import qualified Emanote.Pandoc.Renderer.Url as Url
 import qualified Emanote.Route as R
 import qualified Emanote.Route.SiteRoute as SR
 import qualified Heist.Extra as HE
+import Heist.Extra.Splices.Pandoc (pandocSplice)
 import qualified Heist.Extra.Splices.Pandoc as HP
-import Heist.Extra.Splices.Pandoc.Ctx (RenderCtx (..), ctxSansCustomSplicing)
+import Heist.Extra.Splices.Pandoc.Ctx (ctxSansCustomSplicing)
 import qualified Heist.Interpreted as HI
 import qualified Text.Pandoc.Definition as B
 
 embedWikiLinkResolvingSplice ::
   Monad n => PandocBlockRenderer n x
-embedWikiLinkResolvingSplice emaAction model nf (ctxSansCustomSplicing -> ctx) _ blk =
+embedWikiLinkResolvingSplice _emaAction model _nf (ctxSansCustomSplicing -> ctx) _ blk =
   case blk of
     B.Para [B.Link (_id, _class, otherAttrs) _is (url, tit)] -> do
       Rel.URTWikiLink (WL.WikiLinkEmbed, wl) <-
@@ -34,7 +34,7 @@ embedWikiLinkResolvingSplice emaAction model nf (ctxSansCustomSplicing -> ctx) _
         Left err ->
           pure $ brokenLinkDivWrapper err blk
         Right res -> do
-          embedSiteRoute emaAction model nf ctx wl res
+          embedSiteRoute model ctx wl res
     _ ->
       Nothing
   where
@@ -43,14 +43,14 @@ embedWikiLinkResolvingSplice emaAction model nf (ctxSansCustomSplicing -> ctx) _
         B.Div (Url.brokenLinkAttr err) $
           one block
 
-embedSiteRoute :: Monad n => Ema.CLI.Action -> Model -> NoteRenderers n -> HP.RenderCtx n -> WL.WikiLink -> Either MN.Note SF.StaticFile -> Maybe (HI.Splice n)
-embedSiteRoute emaAction model nf ctx@RenderCtx {..} wl = \case
+embedSiteRoute :: Monad n => Model -> HP.RenderCtx n -> WL.WikiLink -> Either MN.Note SF.StaticFile -> Maybe (HI.Splice n)
+embedSiteRoute model ctx wl = \case
   Left note -> do
     pure . runEmbedTemplate "note" $ do
       "ema:note:title" ## Tit.titleSplice ctx (preparePandoc model) (MN._noteTitle note)
       "ema:note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute $ note ^. MN.noteRoute)
       "ema:note:pandoc"
-        ## noteSpliceWith nf classMap emaAction model note
+        ## pandocSplice ctx (prepareNoteDoc model $ MN._noteDoc note)
   Right staticFile -> do
     let r = staticFile ^. SF.staticFileRoute
         fp = staticFile ^. SF.staticFilePath

--- a/src/Emanote/Pandoc/Renderer/Query.hs
+++ b/src/Emanote/Pandoc/Renderer/Query.hs
@@ -25,7 +25,7 @@ import qualified Heist.Interpreted as HI
 import qualified Heist.Splices.Json as HJ
 import qualified Text.Pandoc.Definition as B
 
-queryResolvingSplice :: forall n i b. Monad n => PandocBlockRenderer n i LMLRoute
+queryResolvingSplice :: forall n i. Monad n => PandocBlockRenderer n i LMLRoute
 queryResolvingSplice _emaAction model _nr ctx noteRoute blk = do
   B.CodeBlock
     (_id', classes, _attrs)

--- a/src/Emanote/Pandoc/Renderer/Query.hs
+++ b/src/Emanote/Pandoc/Renderer/Query.hs
@@ -20,12 +20,13 @@ import Emanote.Route (LMLRoute)
 import qualified Emanote.Route.SiteRoute as SR
 import qualified Heist as H
 import qualified Heist.Extra as HE
+import Heist.Extra.Splices.Pandoc (RenderCtx)
 import qualified Heist.Interpreted as HI
 import qualified Heist.Splices.Json as HJ
 import qualified Text.Pandoc.Definition as B
 
-queryResolvingSplice :: Monad n => PandocBlockRenderer n LMLRoute
-queryResolvingSplice _ model _nf _ctx noteRoute blk = do
+queryResolvingSplice :: forall n. Monad n => PandocBlockRenderer n LMLRoute
+queryResolvingSplice _emaAction model _nr ctx noteRoute blk = do
   B.CodeBlock
     (_id', classes, _attrs)
     (Q.parseQuery -> Just q) <-
@@ -39,11 +40,11 @@ queryResolvingSplice _ model _nf _ctx noteRoute blk = do
       "query"
         ## HI.textSplice (show q)
       "result"
-        ## (HI.runChildrenWith . noteSpliceMap model) `foldMapM` Q.runQuery noteRoute model q
+        ## (HI.runChildrenWith . noteSpliceMap ctx model) `foldMapM` Q.runQuery noteRoute model q
 
 -- TODO: Reuse this elsewhere
-noteSpliceMap :: Monad n => Model -> MN.Note -> H.Splices (HI.Splice n)
-noteSpliceMap model note = do
-  "ema:note:title" ## Tit.titleSplice (preparePandoc model) (MN._noteTitle note)
+noteSpliceMap :: Monad n => RenderCtx n -> Model -> MN.Note -> H.Splices (HI.Splice n)
+noteSpliceMap ctx model note = do
+  "ema:note:title" ## Tit.titleSplice ctx (preparePandoc model) (MN._noteTitle note)
   "ema:note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute $ note ^. MN.noteRoute)
   "ema:note:metadata" ## HJ.bindJson (note ^. MN.noteMeta)

--- a/src/Emanote/Pandoc/Renderer/Query.hs
+++ b/src/Emanote/Pandoc/Renderer/Query.hs
@@ -25,7 +25,7 @@ import qualified Heist.Interpreted as HI
 import qualified Heist.Splices.Json as HJ
 import qualified Text.Pandoc.Definition as B
 
-queryResolvingSplice :: forall n i b. Monad n => PandocBlockRenderer n i b LMLRoute
+queryResolvingSplice :: forall n i b. Monad n => PandocBlockRenderer n i LMLRoute
 queryResolvingSplice _emaAction model _nr ctx noteRoute blk = do
   B.CodeBlock
     (_id', classes, _attrs)

--- a/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/src/Emanote/Pandoc/Renderer/Url.hs
@@ -28,7 +28,7 @@ import qualified Text.Pandoc.Definition as B
 
 -- | Resolve all URLs in inlines (<a> and <img>)
 urlResolvingSplice ::
-  Monad n => PandocInlineRenderer n i b x
+  Monad n => PandocInlineRenderer n i b
 urlResolvingSplice emaAction model _nf (ctxSansCustomSplicing -> ctx) _ inl =
   case inl of
     B.Link attr@(_id, _class, otherAttrs) is (url, tit) -> do

--- a/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/src/Emanote/Pandoc/Renderer/Url.hs
@@ -1,5 +1,6 @@
 module Emanote.Pandoc.Renderer.Url
   ( urlResolvingSplice,
+    plainifyWikiLinkSplice,
     brokenLinkAttr,
     resolveWikiLinkMustExist,
   )
@@ -27,8 +28,7 @@ import Heist.Extra.Splices.Pandoc.Ctx (ctxSansCustomSplicing)
 import qualified Text.Pandoc.Definition as B
 
 -- | Resolve all URLs in inlines (<a> and <img>)
-urlResolvingSplice ::
-  Monad n => PandocInlineRenderer n i b
+urlResolvingSplice :: Monad n => PandocInlineRenderer n i b
 urlResolvingSplice emaAction model _nf (ctxSansCustomSplicing -> ctx) _ inl =
   case inl of
     B.Link attr@(_id, _class, otherAttrs) is (url, tit) -> do
@@ -64,6 +64,11 @@ urlResolvingSplice emaAction model _nf (ctxSansCustomSplicing -> ctx) _ inl =
     brokenLinkSpanWrapper err inline =
       HP.rpInline ctx $
         B.Span (brokenLinkAttr err) $ one inline
+
+plainifyWikiLinkSplice :: Monad n => PandocInlineRenderer n i b
+plainifyWikiLinkSplice _emaAction _model _nf (ctxSansCustomSplicing -> ctx) _ inl = do
+  wl <- WL.inlineToWikiLink inl
+  pure $ HP.rpInline ctx $ B.Str $ show wl
 
 brokenLinkAttr :: Text -> B.Attr
 brokenLinkAttr err =

--- a/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/src/Emanote/Pandoc/Renderer/Url.hs
@@ -28,7 +28,7 @@ import qualified Text.Pandoc.Definition as B
 
 -- | Resolve all URLs in inlines (<a> and <img>)
 urlResolvingSplice ::
-  Monad n => PandocInlineRenderer n x
+  Monad n => PandocInlineRenderer n i b x
 urlResolvingSplice emaAction model _nf (ctxSansCustomSplicing -> ctx) _ inl =
   case inl of
     B.Link attr@(_id, _class, otherAttrs) is (url, tit) -> do

--- a/src/Emanote/View/Common.hs
+++ b/src/Emanote/View/Common.hs
@@ -59,7 +59,7 @@ inlineNoteRenderers =
     -- content (eg: backlinks and titles)
     mempty
 
-pandocInlineRenderers :: Monad n => [PandocInlineRenderer n i b x]
+pandocInlineRenderers :: Monad n => [PandocInlineRenderer n i b]
 pandocInlineRenderers =
   [ PF.urlResolvingSplice
   ]

--- a/src/Emanote/View/Common.hs
+++ b/src/Emanote/View/Common.hs
@@ -7,6 +7,7 @@ module Emanote.View.Common
     mkRendererFromMeta,
     noteRenderers,
     inlineRenderers,
+    linkInlineRenderers,
   )
 where
 
@@ -55,10 +56,28 @@ inlineRenderers =
     _pandocInlineRenderers
     mempty
 
+-- | Like `inlineRenderers` but suitable for use inside links (<a> tags).
+linkInlineRenderers :: Monad n => PandocRenderers n i b
+linkInlineRenderers =
+  PandocRenderers
+    _pandocLinkInlineRenderers
+    mempty
+
 _pandocInlineRenderers :: Monad n => [PandocInlineRenderer n i b]
 _pandocInlineRenderers =
   [ PF.urlResolvingSplice
   ]
+    <> _pandocInlineRenderersCommon
+
+_pandocLinkInlineRenderers :: Monad n => [PandocInlineRenderer n i b]
+_pandocLinkInlineRenderers =
+  [ PF.plainifyWikiLinkSplice
+  ]
+    <> _pandocInlineRenderersCommon
+
+_pandocInlineRenderersCommon :: Monad n => [PandocInlineRenderer n i b]
+_pandocInlineRenderersCommon =
+  []
 
 _pandocBlockRenderers :: Monad n => [PandocBlockRenderer n i LMLRoute]
 _pandocBlockRenderers =

--- a/src/Emanote/View/TagIndex.hs
+++ b/src/Emanote/View/TagIndex.hs
@@ -17,7 +17,7 @@ import qualified Emanote.Model.Note as MN
 import qualified Emanote.Pandoc.Markdown.Syntax.HashTag as HT
 import qualified Emanote.Pandoc.Renderer.Query as PF
 import qualified Emanote.Route.SiteRoute.Class as SR
-import Emanote.View.Common (commonSplices, getRouteContexts, inlineNoteRenderers)
+import Emanote.View.Common (commonSplices, inlineRenderers, mkRendererFromMeta)
 import qualified Heist.Extra.Splices.List as Splices
 import Heist.Extra.Splices.Pandoc.Ctx (emptyRenderCtx)
 import qualified Heist.Extra.TemplateState as Tmpl
@@ -78,9 +78,9 @@ mkTagIndex model tagPath' =
 renderTagIndex :: Ema.CLI.Action -> Model -> [HT.TagNode] -> LByteString
 renderTagIndex emaAction model tagPath = do
   let meta = Meta.getIndexYamlMeta model
-      withNoteRenderer = getRouteContexts emaAction model meta
+      withNoteRenderer = mkRendererFromMeta emaAction model meta
       withInlineCtx =
-        withNoteRenderer inlineNoteRenderers () ()
+        withNoteRenderer inlineRenderers () ()
       tagIdx = mkTagIndex model tagPath
   flip (Tmpl.renderHeistTemplate "templates/special/tagindex") (model ^. M.modelHeistTemplate) $ do
     commonSplices ($ emptyRenderCtx) emaAction model meta $ fromString . toString $ tagIndexTitle tagIdx

--- a/src/Emanote/View/TagIndex.hs
+++ b/src/Emanote/View/TagIndex.hs
@@ -17,7 +17,7 @@ import qualified Emanote.Model.Note as MN
 import qualified Emanote.Pandoc.Markdown.Syntax.HashTag as HT
 import qualified Emanote.Pandoc.Renderer.Query as PF
 import qualified Emanote.Route.SiteRoute.Class as SR
-import Emanote.View.Common (commonSplices)
+import Emanote.View.Common (commonSplices, getRouteContexts, inlineNoteRenderers)
 import qualified Heist.Extra.Splices.List as Splices
 import Heist.Extra.Splices.Pandoc.Ctx (emptyRenderCtx)
 import qualified Heist.Extra.TemplateState as Tmpl
@@ -78,6 +78,9 @@ mkTagIndex model tagPath' =
 renderTagIndex :: Ema.CLI.Action -> Model -> [HT.TagNode] -> LByteString
 renderTagIndex emaAction model tagPath = do
   let meta = Meta.getIndexYamlMeta model
+      withNoteRenderer = getRouteContexts emaAction model meta
+      withInlineCtx =
+        withNoteRenderer inlineNoteRenderers () ()
       tagIdx = mkTagIndex model tagPath
   flip (Tmpl.renderHeistTemplate "templates/special/tagindex") (model ^. M.modelHeistTemplate) $ do
     commonSplices ($ emptyRenderCtx) emaAction model meta $ fromString . toString $ tagIndexTitle tagIdx
@@ -101,7 +104,7 @@ renderTagIndex emaAction model tagPath = do
     "ema:notes"
       ## Splices.listSplice (tagIndexNotes tagIdx) "ema:each-note"
       $ \note ->
-        PF.noteSpliceMap undefined model note
+        PF.noteSpliceMap withInlineCtx model note
 
 tagNodesText :: NonEmpty HT.TagNode -> Text
 tagNodesText =

--- a/src/Emanote/View/TagIndex.hs
+++ b/src/Emanote/View/TagIndex.hs
@@ -19,6 +19,7 @@ import qualified Emanote.Pandoc.Renderer.Query as PF
 import qualified Emanote.Route.SiteRoute.Class as SR
 import Emanote.View.Common (commonSplices)
 import qualified Heist.Extra.Splices.List as Splices
+import Heist.Extra.Splices.Pandoc.Ctx (emptyRenderCtx)
 import qualified Heist.Extra.TemplateState as Tmpl
 import qualified Heist.Interpreted as HI
 
@@ -79,7 +80,7 @@ renderTagIndex emaAction model tagPath = do
   let meta = Meta.getIndexYamlMeta model
       tagIdx = mkTagIndex model tagPath
   flip (Tmpl.renderHeistTemplate "templates/special/tagindex") (model ^. M.modelHeistTemplate) $ do
-    commonSplices emaAction model meta $ fromString . toString $ tagIndexTitle tagIdx
+    commonSplices ($ emptyRenderCtx) emaAction model meta $ fromString . toString $ tagIndexTitle tagIdx
     "ema:tag:title" ## HI.textSplice (maybe "/" (HT.unTagNode . last) $ nonEmpty tagPath)
     "ema:tag:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.tagIndexRoute tagPath)
     let parents = maybe [] (inits . init) $ nonEmpty (tagIndexPath tagIdx)
@@ -100,7 +101,7 @@ renderTagIndex emaAction model tagPath = do
     "ema:notes"
       ## Splices.listSplice (tagIndexNotes tagIdx) "ema:each-note"
       $ \note ->
-        PF.noteSpliceMap model note
+        PF.noteSpliceMap undefined model note
 
 tagNodesText :: NonEmpty HT.TagNode -> Text
 tagNodesText =

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -6,7 +6,6 @@
 module Emanote.View.Template (render) where
 
 import Control.Lens.Operators ((^.))
-import Data.Aeson (Value)
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Syntax ((##))
 import Data.WorldPeace.Union
@@ -21,12 +20,11 @@ import qualified Emanote.Model.Meta as Meta
 import qualified Emanote.Model.Note as MN
 import qualified Emanote.Model.Title as Tit
 import Emanote.Pandoc.BuiltinFilters (prepareNoteDoc, preparePandoc)
-import qualified Emanote.Pandoc.Renderer as Renderer
 import Emanote.Prelude (h)
 import Emanote.Route (FileType (LMLType), LML (Md))
 import qualified Emanote.Route as R
 import qualified Emanote.Route.SiteRoute as SR
-import Emanote.View.Common (commonSplices, getRouteContexts, inlineNoteRenderers, noteRenderers)
+import Emanote.View.Common (commonSplices, inlineRenderers, mkRendererFromMeta, noteRenderers)
 import qualified Emanote.View.TagIndex as TagIndex
 import qualified Heist as H
 import qualified Heist.Extra.Splices.List as Splices
@@ -80,9 +78,9 @@ renderVirtualRoute emaAction m =
 renderSRIndex :: Ema.CLI.Action -> Model -> LByteString
 renderSRIndex emaAction model = do
   let meta = Meta.getIndexYamlMeta model
-      withNoteRenderer = getRouteContexts emaAction model meta
+      withNoteRenderer = mkRendererFromMeta emaAction model meta
       withInlineCtx =
-        withNoteRenderer inlineNoteRenderers () ()
+        withNoteRenderer inlineRenderers () ()
   flip (Tmpl.renderHeistTemplate "templates/special/index") (model ^. M.modelHeistTemplate) $ do
     commonSplices ($ emptyRenderCtx) emaAction model meta "Index"
     routeTreeSplice withInlineCtx Nothing model
@@ -91,9 +89,9 @@ renderLmlHtml :: Ema.CLI.Action -> Model -> MN.Note -> LByteString
 renderLmlHtml emaAction model note = do
   let r = note ^. MN.noteRoute
       meta = Meta.getEffectiveRouteMeta r model
-      withNoteRenderer = getRouteContexts emaAction model meta
+      withNoteRenderer = mkRendererFromMeta emaAction model meta
       withInlineCtx =
-        withNoteRenderer inlineNoteRenderers () ()
+        withNoteRenderer inlineRenderers () ()
       withBlockCtx =
         withNoteRenderer noteRenderers () r
       templateName = MN.lookupAeson @Text "templates/layouts/book" ("template" :| ["name"]) meta

--- a/src/Heist/Extra/Splices/Pandoc/Ctx.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Ctx.hs
@@ -3,6 +3,7 @@
 module Heist.Extra.Splices.Pandoc.Ctx
   ( RenderCtx (..),
     mkRenderCtx,
+    emptyRenderCtx,
     rewriteClass,
     ctxSansCustomSplicing,
     concatSpliceFunc,
@@ -18,7 +19,9 @@ import qualified Text.Pandoc.Builder as B
 import qualified Text.XmlHtml as X
 
 data RenderCtx n = RenderCtx
-  { rootNode :: X.Node,
+  { -- The XML node which contains individual AST rendering definitions
+    -- This corresponds to pandoc.tpl
+    rootNode :: Maybe X.Node,
     -- Attributes for a given AST node.
     bAttr :: B.Block -> B.Attr,
     iAttr :: B.Inline -> B.Attr,
@@ -57,13 +60,17 @@ mkRenderCtxWith ::
 mkRenderCtxWith node classMap bS iS = do
   let ctx =
         RenderCtx
-          node
+          (Just node)
           (blockLookupAttr node)
           (inlineLookupAttr node)
           classMap
           (bS ctx)
           (iS ctx)
    in ctx
+
+emptyRenderCtx :: RenderCtx n
+emptyRenderCtx =
+  RenderCtx Nothing (const B.nullAttr) (const B.nullAttr) mempty (const Nothing) (const Nothing)
 
 -- | Strip any custom splicing out of the given render context
 ctxSansCustomSplicing :: RenderCtx n -> RenderCtx n

--- a/src/Heist/Extra/Splices/Pandoc/Footnotes.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Footnotes.hs
@@ -32,7 +32,7 @@ renderFootnotesWith :: forall n. Monad n => RenderCtx n -> Footnotes -> HI.Splic
 renderFootnotesWith ctx fs' =
   fromMaybe (pure []) $ do
     fs <- toList <$> nonEmpty fs'
-    renderNode <- fmap head . nonEmpty $ X.childElementsTag "Note:List" (rootNode ctx)
+    renderNode <- fmap head . nonEmpty $ maybe [] (X.childElementsTag "Note:List") $ rootNode ctx
     let footnotesWithIdx = zip [1 :: Int ..] fs
     Just $
       runCustomNode renderNode $ do
@@ -55,7 +55,7 @@ footnoteRefSplice :: Monad n => RenderCtx n -> [[B.Block]] -> B.Inline -> Maybe 
 footnoteRefSplice ctx footnotes inline = do
   B.Note bs <- pure inline
   let idx = lookupFootnote bs footnotes
-  renderNode <- fmap head . nonEmpty $ X.childElementsTag "Note:Ref" (rootNode ctx)
+  renderNode <- fmap head . nonEmpty $ maybe [] (X.childElementsTag "Note:Ref") (rootNode ctx)
   Just $
     runCustomNode renderNode $
       footnoteSplices ctx idx bs

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -39,7 +39,7 @@ rpBlock ctx@RenderCtx {..} b = do
 -- | Render using user override in pandoc.tpl, falling back to default HTML.
 withTplTag :: Monad n => RenderCtx n -> Text -> H.Splices (HI.Splice n) -> HI.Splice n -> HI.Splice n
 withTplTag RenderCtx {..} name splices default_ =
-  case X.childElementTag name rootNode of
+  case X.childElementTag name =<< rootNode of
     Nothing -> default_
     Just node -> runCustomNode node splices
 

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -15,6 +15,7 @@ where
 
 import Data.Map.Syntax ((##))
 import qualified Data.Text as T
+import qualified Emanote.Pandoc.Markdown.Syntax.WikiLink as WL
 import qualified Heist as H
 import Heist.Extra (runCustomNode)
 import Heist.Extra.Splices.Pandoc.Attr (concatAttr, rpAttr)
@@ -283,4 +284,6 @@ plainify = W.query $ \case
   B.Math _mathTyp s -> s
   -- Ignore the rest of AST nodes, as they are recursively defined in terms of
   -- `Inline` which `W.query` will traverse again.
+  (WL.inlineToWikiLink -> Just wl) ->
+    show wl
   _ -> ""


### PR DESCRIPTION
As a follow up to #62.

A consequence of #92 is that wiki-links become hidden when used in note-title. This PR addresses (while revamping the renderer types). Note that it doesn't render the wiki-links in title as they normally as rendered in note body; simply plainifies them. Rendering can be dealt with in a different PR.

- [x] MVP
- [x] Unlinkify wiki-links (and put back brackets) when the title is already linked (ie., in sidebar and index and links, but not in note title)
- [ ] Refactor and document