### PR TITLE
Remove erroneous -L flag, clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ nix-env -if https://github.com/srid/emanote/archive/refs/heads/master.tar.gz
 cd /path/to/notebook
 PORT=8001 emanote
 
-# Generate static files
+# Or, to generate static files
 mkdir /tmp/output
-emanote -L /path/to/notebook gen /tmp/output
+emanote /path/to/notebook gen /tmp/output
 ```
 
 For other installation methods, see [here](https://note.ema.srid.ca/start/install).

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ nix-env -if https://github.com/srid/emanote/archive/refs/heads/master.tar.gz
 cd /path/to/notebook
 PORT=8001 emanote
 
-# Or, to generate static files
+# Or, to generate static files in /tmp/output
+cd /path/to/notebook
 mkdir /tmp/output
-emanote /path/to/notebook gen /tmp/output
+emanote gen /tmp/output
 ```
 
 For other installation methods, see [here](https://note.ema.srid.ca/start/install).


### PR DESCRIPTION
As can be seen from running emanote, there `-L` is an invalid option. This patch removes it from the README.

```
$  mkdir /tmp/output && emanote -L /home/simon/zettel gen /tmp/output                                                                                                                      
Invalid option `-L'

Usage: emanote [--version] [--layers LAYERS] [COMMAND]
  Emanote - A spiritual successor to Neuron
  ```