### PR TITLE
Restore automatic image (etc) refresh in live server

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - remove-exe
 jobs:
 
   build:

--- a/docs/demo/embed.md
+++ b/docs/demo/embed.md
@@ -24,7 +24,7 @@ Embedding of [[file-links]], as indicated in the aforementioned Obsidian help pa
 See https://github.com/srid/emanote/issues/24 for progress.
 ### Images 
 
-Embedding image files as, say, `![[disaster-girl.jpg]]` is equivalent to `![](path/to/disaster-girl.jpg))`.  See also the tip: [[adding-images]].
+Embedding image files as, say, `![[disaster-girl.jpg]]` is equivalent to `![](path/to/disaster-girl.jpg))` (this example links to [[disaster-girl.jpg|this image]]).  See also the tip: [[adding-images]].
 
 ![[disaster-girl.jpg]]
 

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.3.3.1
+version:            0.3.4.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/Model/Link/Resolve.hs
+++ b/src/Emanote/Model/Link/Resolve.hs
@@ -16,7 +16,7 @@ import Relude
 resolveUnresolvedRelTarget ::
   Model ->
   Rel.UnresolvedRelTarget ->
-  Rel.ResolvedRelTarget (SR.SiteRoute, Maybe UTCTime)
+  Rel.ResolvedRelTarget SR.SiteRoute
 resolveUnresolvedRelTarget model = \case
   Rel.URTWikiLink (_wlType, wl) -> do
     resolveWikiLinkMustExist model wl
@@ -29,7 +29,6 @@ resolveUnresolvedRelTarget model = \case
       SR.SiteRoute
         ( openUnionLift virtualRoute
         )
-        & (,Nothing)
 
 resolveWikiLinkMustExist ::
   Model -> WL.WikiLink -> Rel.ResolvedRelTarget (Either MN.Note SF.StaticFile)
@@ -45,11 +44,6 @@ resolveModelRoute model lr =
     (R.modelRouteCase lr)
     & maybe Rel.RRTMissing Rel.RRTFound
 
-resourceSiteRoute :: Either MN.Note SF.StaticFile -> (SR.SiteRoute, Maybe UTCTime)
-resourceSiteRoute = \case
-  Left note ->
-    SR.noteFileSiteRoute note
-      & (,Nothing)
-  Right sf ->
-    SR.staticFileSiteRoute sf
-      & (,Just $ sf ^. SF.staticFileTime)
+resourceSiteRoute :: Either MN.Note SF.StaticFile -> SR.SiteRoute
+resourceSiteRoute =
+  either SR.noteFileSiteRoute SR.staticFileSiteRoute

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -15,6 +15,7 @@ import qualified Data.IxSet.Typed as Ix
 import Data.Time (UTCTime)
 import Data.Tree (Tree)
 import Ema (Slug)
+import qualified Ema.CLI
 import qualified Ema.Helper.PathTree as PathTree
 import Emanote.Model.Link.Rel (IxRel)
 import qualified Emanote.Model.Link.Rel as Rel
@@ -41,6 +42,7 @@ data Status = Status_Loading | Status_Ready
 
 data Model = Model
   { _modelStatus :: Status,
+    _modelEmaCLIAction :: Ema.CLI.Action,
     _modelNotes :: IxNote,
     _modelRels :: IxRel,
     _modelSData :: IxSData,
@@ -56,9 +58,9 @@ data Model = Model
 
 makeLenses ''Model
 
-emptyModel :: Model
-emptyModel =
-  Model Status_Loading Ix.empty Ix.empty Ix.empty mempty mempty def
+emptyModel :: Ema.CLI.Action -> Model
+emptyModel act =
+  Model Status_Loading act Ix.empty Ix.empty Ix.empty mempty mempty def
 
 modelReadyForView :: Model -> Model
 modelReadyForView =

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -66,6 +66,10 @@ modelReadyForView :: Model -> Model
 modelReadyForView =
   modelStatus .~ Status_Ready
 
+-- | Are we running in live server, or statically generated website?
+inLiveServer :: Model -> Bool
+inLiveServer = (== Ema.CLI.Run) . _modelEmaCLIAction
+
 modelInsertNote :: Note -> Model -> Model
 modelInsertNote note =
   modelNotes

--- a/src/Emanote/Pandoc/Renderer.hs
+++ b/src/Emanote/Pandoc/Renderer.hs
@@ -17,7 +17,6 @@ module Emanote.Pandoc.Renderer
   )
 where
 
-import qualified Ema.CLI
 import Emanote.Model.Type (Model)
 import Heist (HeistT)
 import qualified Heist.Extra.Splices.Pandoc as Splices
@@ -30,7 +29,6 @@ import qualified Text.Pandoc.Definition as B
 --
 -- The `x` selects between `i` (inline) and `b` (block) types.
 type PandocRenderF astType n i b x =
-  Ema.CLI.Action ->
   Model ->
   PandocRenderers n i b ->
   Splices.RenderCtx n ->
@@ -52,21 +50,20 @@ mkRenderCtxWithPandocRenderers ::
   (Monad m, Monad n) =>
   PandocRenderers n i b ->
   Map Text Text ->
-  Ema.CLI.Action ->
   Model ->
   i ->
   b ->
   HeistT n m (Splices.RenderCtx n)
-mkRenderCtxWithPandocRenderers nr@PandocRenderers {..} classRules emaAction model i b =
+mkRenderCtxWithPandocRenderers nr@PandocRenderers {..} classRules model i b =
   Splices.mkRenderCtx
     classRules
     ( \ctx blk ->
         asum $
           pandocBlockRenderers <&> \f ->
-            f emaAction model nr ctx b blk
+            f model nr ctx b blk
     )
     ( \ctx blk ->
         asum $
           pandocInlineRenderers <&> \f ->
-            f emaAction model nr ctx i blk
+            f model nr ctx i blk
     )

--- a/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -28,7 +28,7 @@ import qualified Text.Pandoc.Definition as B
 
 embedBlockWikiLinkResolvingSplice ::
   Monad n => PandocBlockRenderer n i b
-embedBlockWikiLinkResolvingSplice emaAction model _nf ctx _ = \case
+embedBlockWikiLinkResolvingSplice model _nf ctx _ = \case
   B.Para [inl] -> do
     (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
     guard $ inlRef == Link.InlineLink
@@ -36,19 +36,19 @@ embedBlockWikiLinkResolvingSplice emaAction model _nf ctx _ = \case
       Rel.parseUnresolvedRelTarget (otherAttrs <> one ("title", tit)) url
     let rRel = Resolve.resolveWikiLinkMustExist model wl
     let f = embedBlockSiteRoute model ctx
-    RenderedUrl.renderSomeInlineRefWith f Resolve.resourceSiteRoute (is, (url, tit)) rRel emaAction model ctx inl
+    RenderedUrl.renderSomeInlineRefWith f Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl
   _ ->
     Nothing
 
 embedInlineWikiLinkResolvingSplice ::
   Monad n => PandocInlineRenderer n i b
-embedInlineWikiLinkResolvingSplice emaAction model _nf ctx _ inl = do
+embedInlineWikiLinkResolvingSplice model _nf ctx _ inl = do
   (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
   guard $ inlRef == Link.InlineLink
   Rel.URTWikiLink (WL.WikiLinkEmbed, wl) <- Rel.parseUnresolvedRelTarget (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveWikiLinkMustExist model wl
       f = embedInlineSiteRoute wl
-  RenderedUrl.renderSomeInlineRefWith f Resolve.resourceSiteRoute (is, (url, tit)) rRel emaAction model ctx inl
+  RenderedUrl.renderSomeInlineRefWith f Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl
 
 embedBlockSiteRoute :: Monad n => Model -> HP.RenderCtx n -> Either MN.Note SF.StaticFile -> Maybe (HI.Splice n)
 embedBlockSiteRoute model ctx = either (embedResourceRoute model ctx) (const Nothing)

--- a/src/Emanote/Pandoc/Renderer/Query.hs
+++ b/src/Emanote/Pandoc/Renderer/Query.hs
@@ -27,7 +27,7 @@ import Relude
 import qualified Text.Pandoc.Definition as B
 
 queryResolvingSplice :: forall n i. Monad n => PandocBlockRenderer n i LMLRoute
-queryResolvingSplice _emaAction model _nr ctx noteRoute blk = do
+queryResolvingSplice model _nr ctx noteRoute blk = do
   B.CodeBlock
     (_id', classes, _attrs)
     (Q.parseQuery -> Just q) <-

--- a/src/Emanote/View/Common.hs
+++ b/src/Emanote/View/Common.hs
@@ -95,12 +95,11 @@ _pandocBlockRenderers =
 commonSplices ::
   Monad n =>
   ((RenderCtx n -> HI.Splice n) -> HI.Splice n) ->
-  Ema.CLI.Action ->
   Model ->
   Aeson.Value ->
   Tit.Title ->
   H.Splices (HI.Splice n)
-commonSplices withCtx emaAction model meta routeTitle = do
+commonSplices withCtx model meta routeTitle = do
   let siteTitle = fromString . toString $ MN.lookupAeson @Text "Emabook Site" ("page" :| ["siteTitle"]) meta
       routeTitleFull =
         if routeTitle == siteTitle
@@ -112,7 +111,7 @@ commonSplices withCtx emaAction model meta routeTitle = do
   -- Add tailwind css shim
   "tailwindCssShim"
     ## pure
-      (RX.renderHtmlNodes $ twindShim emaAction)
+      (RX.renderHtmlNodes $ twindShim $ model ^. M.modelEmaCLIAction)
   "ema:version"
     ## HI.textSplice (toText $ showVersion Paths_emanote.version)
   "ema:metadata"
@@ -152,7 +151,6 @@ commonSplices withCtx emaAction model meta routeTitle = do
 -- the associated data arguments.
 mkRendererFromMeta ::
   (Monad m, Monad n) =>
-  Ema.CLI.Action ->
   Model ->
   Aeson.Value ->
   ( PandocRenderers n i b ->
@@ -161,13 +159,12 @@ mkRendererFromMeta ::
     (RenderCtx n -> H.HeistT n m x) ->
     H.HeistT n m x
   )
-mkRendererFromMeta emaAction model routeMeta =
+mkRendererFromMeta model routeMeta =
   let classRules = MN.lookupAeson @(Map Text Text) mempty ("pandoc" :| ["rewriteClass"]) routeMeta
-   in mkRendererWith emaAction model classRules
+   in mkRendererWith model classRules
 
 mkRendererWith ::
   (Monad m, Monad n) =>
-  Ema.CLI.Action ->
   Model ->
   Map Text Text ->
   ( PandocRenderers n i b ->
@@ -176,22 +173,21 @@ mkRendererWith ::
     (RenderCtx n -> H.HeistT n m x) ->
     H.HeistT n m x
   )
-mkRendererWith emaAction model classRules =
+mkRendererWith model classRules =
   let withNoteRenderer nr i b f = do
         renderCtx <-
           Renderer.mkRenderCtxWithPandocRenderers
             nr
             classRules
-            emaAction
             model
             i
             b
         f renderCtx
    in withNoteRenderer
 
-renderModelTemplate :: Ema.CLI.Action -> Model -> Tmpl.TemplateName -> H.Splices (HI.Splice Identity) -> LByteString
-renderModelTemplate emaAction model templateName =
-  let handleErr = case emaAction of
+renderModelTemplate :: Model -> Tmpl.TemplateName -> H.Splices (HI.Splice Identity) -> LByteString
+renderModelTemplate model templateName =
+  let handleErr = case model ^. M.modelEmaCLIAction of
         Ema.CLI.Run -> Ema.emaErrorHtmlResponse
         -- When staticaly generating, we must fail asap on template errors.
         _ -> error

--- a/src/Emanote/View/Common.hs
+++ b/src/Emanote/View/Common.hs
@@ -187,10 +187,11 @@ mkRendererWith model classRules =
 
 renderModelTemplate :: Model -> Tmpl.TemplateName -> H.Splices (HI.Splice Identity) -> LByteString
 renderModelTemplate model templateName =
-  let handleErr = case model ^. M.modelEmaCLIAction of
-        Ema.CLI.Run -> Ema.emaErrorHtmlResponse
-        -- When staticaly generating, we must fail asap on template errors.
-        _ -> error
+  let handleErr =
+        if M.inLiveServer model
+          then Ema.emaErrorHtmlResponse
+          else -- When staticaly generating, we must fail asap on template errors.
+            error
    in -- Until Ema's error handling improves ...
       either handleErr id
         . flip (Tmpl.renderHeistTemplate templateName) (model ^. M.modelHeistTemplate)

--- a/src/Emanote/View/TagIndex.hs
+++ b/src/Emanote/View/TagIndex.hs
@@ -74,15 +74,15 @@ mkTagIndex model tagPath' =
           subForest <- Tree.subForest <$> List.find (\(Tree.Node lbl _) -> fst lbl == k) trees
           lookupForest ks subForest
 
-renderTagIndex :: Ema.CLI.Action -> Model -> [HT.TagNode] -> LByteString
-renderTagIndex emaAction model tagPath = do
+renderTagIndex :: Model -> [HT.TagNode] -> LByteString
+renderTagIndex model tagPath = do
   let meta = Meta.getIndexYamlMeta model
-      withNoteRenderer = mkRendererFromMeta emaAction model meta
+      withNoteRenderer = mkRendererFromMeta model meta
       withInlineCtx =
         withNoteRenderer inlineRenderers () ()
       tagIdx = mkTagIndex model tagPath
-  renderModelTemplate emaAction model "templates/special/tagindex" $ do
-    commonSplices ($ emptyRenderCtx) emaAction model meta $ fromString . toString $ tagIndexTitle tagIdx
+  renderModelTemplate model "templates/special/tagindex" $ do
+    commonSplices ($ emptyRenderCtx) model meta $ fromString . toString $ tagIndexTitle tagIdx
     "ema:tag:title" ## HI.textSplice (maybe "/" (HT.unTagNode . last) $ nonEmpty tagPath)
     "ema:tag:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.tagIndexRoute tagPath)
     let parents = maybe [] (inits . init) $ nonEmpty (tagIndexPath tagIdx)

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -43,8 +43,8 @@ import qualified Shower
 import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Definition (Pandoc (..))
 
-render :: Ema.CLI.Action -> Model -> SR.SiteRoute -> Ema.Asset LByteString
-render emaAction m (SR.SiteRoute sr) =
+render :: Model -> SR.SiteRoute -> Ema.Asset LByteString
+render m (SR.SiteRoute sr) =
   let setErrorPageMeta =
         MN.noteMeta .~ SData.mergeAesons (withTemplateName "/templates/error" :| [withSiteTitle "Emanote Error"])
    in sr
@@ -55,25 +55,25 @@ render emaAction m (SR.SiteRoute sr) =
                       MN.missingNote hereRoute (toText urlPath)
                         & setErrorPageMeta
                         & MN.noteTitle .~ "! Missing link"
-                Ema.AssetGenerated Ema.Html $ renderLmlHtml emaAction m note404
+                Ema.AssetGenerated Ema.Html $ renderLmlHtml m note404
             )
         `h` ( \(SR.AmbiguousR (urlPath, notes)) -> do
                 let noteAmb =
                       MN.ambiguousNoteURL urlPath notes
                         & setErrorPageMeta
                         & MN.noteTitle .~ "! Ambiguous link"
-                Ema.AssetGenerated Ema.Html $ renderLmlHtml emaAction m noteAmb
+                Ema.AssetGenerated Ema.Html $ renderLmlHtml m noteAmb
             )
-        `h` renderResourceRoute emaAction m
-        `h` renderVirtualRoute emaAction m
+        `h` renderResourceRoute m
+        `h` renderVirtualRoute m
 
-renderResourceRoute :: Ema.CLI.Action -> Model -> SR.ResourceRoute -> Ema.Asset LByteString
-renderResourceRoute emaAction m =
+renderResourceRoute :: Model -> SR.ResourceRoute -> Ema.Asset LByteString
+renderResourceRoute m =
   absurdUnion
     `h` ( \(r :: R.LMLRoute) -> do
             case M.modelLookupNoteByRoute r m of
               Just note ->
-                Ema.AssetGenerated Ema.Html $ renderLmlHtml emaAction m note
+                Ema.AssetGenerated Ema.Html $ renderLmlHtml m note
               Nothing ->
                 -- This should never be reached because decodeRoute looks up the model.
                 error $ "Bad route: " <> show r
@@ -82,35 +82,35 @@ renderResourceRoute emaAction m =
             Ema.AssetStatic fpAbs
         )
 
-renderVirtualRoute :: Ema.CLI.Action -> Model -> SR.VirtualRoute -> Ema.Asset LByteString
-renderVirtualRoute emaAction m =
+renderVirtualRoute :: Model -> SR.VirtualRoute -> Ema.Asset LByteString
+renderVirtualRoute m =
   absurdUnion
     `h` ( \(SR.TagIndexR mtag) ->
-            Ema.AssetGenerated Ema.Html $ TagIndex.renderTagIndex emaAction m mtag
+            Ema.AssetGenerated Ema.Html $ TagIndex.renderTagIndex m mtag
         )
     `h` ( \SR.IndexR ->
-            Ema.AssetGenerated Ema.Html $ renderSRIndex emaAction m
+            Ema.AssetGenerated Ema.Html $ renderSRIndex m
         )
 
-renderSRIndex :: Ema.CLI.Action -> Model -> LByteString
-renderSRIndex emaAction model = do
+renderSRIndex :: Model -> LByteString
+renderSRIndex model = do
   let meta = Meta.getIndexYamlMeta model
-      withNoteRenderer = mkRendererFromMeta emaAction model meta
+      withNoteRenderer = mkRendererFromMeta model meta
       withInlineCtx =
         withNoteRenderer linkInlineRenderers () ()
-  renderModelTemplate emaAction model "templates/special/index" $ do
-    commonSplices ($ emptyRenderCtx) emaAction model meta "Index"
+  renderModelTemplate model "templates/special/index" $ do
+    commonSplices ($ emptyRenderCtx) model meta "Index"
     routeTreeSplice withInlineCtx Nothing model
 
 loaderHead :: LByteString
 loaderHead =
   "<em style='font-size: 400%; border-bottom: 1px solid; margin-bottom: 4em; '>Union mounting notebook layers; please wait ...</em>"
 
-renderLmlHtml :: Ema.CLI.Action -> Model -> MN.Note -> LByteString
-renderLmlHtml emaAction model note = do
+renderLmlHtml :: Model -> MN.Note -> LByteString
+renderLmlHtml model note = do
   let r = note ^. MN.noteRoute
       meta = Meta.getEffectiveRouteMetaWith (note ^. MN.noteMeta) r model
-      withNoteRenderer = mkRendererFromMeta emaAction model meta
+      withNoteRenderer = mkRendererFromMeta model meta
       withInlineCtx =
         withNoteRenderer inlineRenderers () ()
       withLinkInlineCtx =
@@ -119,11 +119,11 @@ renderLmlHtml emaAction model note = do
         withNoteRenderer noteRenderers () r
       templateName = lookupTemplateName meta
       withLoadingMessage =
-        if emaAction == Ema.CLI.Run && model ^. M.modelStatus == M.Status_Loading
+        if (model ^. M.modelEmaCLIAction) == Ema.CLI.Run && model ^. M.modelStatus == M.Status_Loading
           then (loaderHead <>)
           else id
-  withLoadingMessage . renderModelTemplate emaAction model templateName $ do
-    commonSplices withLinkInlineCtx emaAction model meta (note ^. MN.noteTitle)
+  withLoadingMessage . renderModelTemplate model templateName $ do
+    commonSplices withLinkInlineCtx model meta (note ^. MN.noteTitle)
     -- TODO: We should be using withInlineCtx, so as to make the wikilink render in note title.
     let titleSplice titleDoc = withLinkInlineCtx $ \x ->
           Tit.titleSplice x (preparePandoc model) titleDoc

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -119,7 +119,7 @@ renderLmlHtml model note = do
         withNoteRenderer noteRenderers () r
       templateName = lookupTemplateName meta
       withLoadingMessage =
-        if (model ^. M.modelEmaCLIAction) == Ema.CLI.Run && model ^. M.modelStatus == M.Status_Loading
+        if M.inLiveServer model && model ^. M.modelStatus == M.Status_Loading
           then (loaderHead <>)
           else id
   withLoadingMessage . renderModelTemplate model templateName $ do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -14,5 +14,5 @@ main :: IO ()
 main =
   withUtf8 $ do
     cli <- CLI.parseCli
-    Ema.runEmaWithCli (CLI.emaCli cli) View.render $ \_act m ->
-      Source.emanate (CLI.layers cli) m Model.emptyModel
+    Ema.runEmaWithCli (CLI.emaCli cli) (const View.render) $ \act m ->
+      Source.emanate (CLI.layers cli) m (Model.emptyModel act)


### PR DESCRIPTION
The `?t=..` suffix in static file links got broken for the embed case. This PR fixes it, after refactoring the affected code.