### PR TITLE
Dedicate a route to get the JSON of graph data

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           # Only needed for private caches
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - name: Build docker img
+      - name: Build as docker img
         id: build
         run: |
           nix-build -j auto docker.nix --argstr tag latest -o docker-img

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 jobs:
 
   build:
@@ -32,6 +33,7 @@ jobs:
           echo "::set-output name=docker-img::${DOCKERIMG}"
       - name: Upload docker image tgz
         uses: actions/upload-artifact@v2
+        if: github.ref == 'refs/heads/master'
         with:
           name: docker-img
           retention-days: 1
@@ -41,6 +43,7 @@ jobs:
   docker:
     needs: build
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     env:
       DOCKERTAG: latest
     steps:
@@ -58,6 +61,7 @@ jobs:
   website:
     needs: build
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - name: Download docker image

--- a/docs/demo/file-links.md
+++ b/docs/demo/file-links.md
@@ -7,6 +7,7 @@ For example,
 - Here is a link to some text file: [[Sample.txt]]
 - You can also specify the full, or subset of, the path: [[demo/Sample.txt]]
 - Of course, a custom link text may also be specified: [[Sample.txt|Some text file]]
+- All of this is equivalent to [normal linking](demo/Sample.txt).
 
 In the live server, links to static files will open in new browser tab.
 

--- a/docs/demo/markdown.md
+++ b/docs/demo/markdown.md
@@ -7,7 +7,7 @@ Emanote notes are written in Markdown format. A tutorial is [available here](htt
 You can link to a note by placing the filename (without extension) inside double square brackets. For example, `[[neuron]]` links to the file `neuron.md` and it will be rendered as [[neuron]]. Note that it is using the title of the note automatically;
 you can specify a custom title as `[[neuron|Moving off neuron]]` which renders as [[neuron|Moving off neuron]] or even force use of filename with `[[neuron|neuron]]` which renders as [[neuron|neuron]].
 
-Broken links render differently, for example: [[Foo bar]]
+Broken links render differently, for example: [[Foo bar]] (if a wiki-link) or [Foo bar](foo-bar.md) (if a regular Markdown link).
 
 ## Emojis
 

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.3.8.0
+version:            0.3.9.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -137,6 +137,7 @@ executable emanote
     Emanote.Source.Pattern
     Emanote.View
     Emanote.View.Common
+    Emanote.View.Export
     Emanote.View.LiveServerFiles
     Emanote.View.TagIndex
     Emanote.View.Template

--- a/src/Emanote/Model/Link/Rel.hs
+++ b/src/Emanote/Model/Link/Rel.hs
@@ -46,7 +46,7 @@ data UnresolvedRelTarget
   = URTWikiLink (WL.WikiLinkType, WL.WikiLink)
   | URTResource ModelRoute
   | URTVirtual SR.VirtualRoute
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, Generic, ToJSON)
 
 type RelIxs = '[LMLRoute, UnresolvedRelTarget]
 

--- a/src/Emanote/Model/Link/Rel.hs
+++ b/src/Emanote/Model/Link/Rel.hs
@@ -10,6 +10,7 @@ module Emanote.Model.Link.Rel where
 
 import Control.Lens.Operators as Lens ((^.))
 import Control.Lens.TH (makeLenses)
+import Data.Aeson (ToJSON)
 import Data.IxSet.Typed (Indexable (..), IxSet, ixFun, ixList)
 import qualified Data.IxSet.Typed as Ix
 import qualified Data.Map.Strict as Map
@@ -94,7 +95,7 @@ data ResolvedRelTarget a
   = RRTMissing
   | RRTAmbiguous (NonEmpty a)
   | RRTFound a
-  deriving (Eq, Show, Ord, Functor)
+  deriving (Eq, Show, Ord, Functor, Generic, ToJSON)
 
 resolvedRelTargetFromCandidates :: [a] -> ResolvedRelTarget a
 resolvedRelTargetFromCandidates xs =

--- a/src/Emanote/Model/Title.hs
+++ b/src/Emanote/Model/Title.hs
@@ -14,6 +14,7 @@ module Emanote.Model.Title
     -- * Rendering a Title
     titleSplice,
     titleSpliceNoHtml,
+    toPlain,
   )
 where
 

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -9,9 +9,11 @@ module Emanote.Model.Type where
 
 import Control.Lens.Operators as Lens ((%~), (.~), (^.))
 import Control.Lens.TH (makeLenses)
+import qualified Data.Aeson as Aeson
 import Data.Default (Default (def))
 import Data.IxSet.Typed ((@=))
 import qualified Data.IxSet.Typed as Ix
+import qualified Data.Map.Strict as Map
 import Data.Time (UTCTime)
 import Data.Tree (Tree)
 import Ema (Slug)
@@ -171,3 +173,9 @@ modelTags =
 modelNoteRels :: Model -> [Rel.Rel]
 modelNoteRels =
   Ix.toList . _modelRels
+
+modelNoteMetas :: Model -> Map LMLRoute (Tit.Title, LMLRoute, Aeson.Value)
+modelNoteMetas model =
+  Map.fromList $
+    Ix.toList (_modelNotes model) <&> \note ->
+      (note ^. N.noteRoute, (note ^. N.noteTitle, note ^. N.noteRoute, note ^. N.noteMeta))

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -179,8 +179,3 @@ modelNoteMetas model =
   Map.fromList $
     Ix.toList (_modelNotes model) <&> \note ->
       (note ^. N.noteRoute, (note ^. N.noteTitle, note ^. N.noteRoute, note ^. N.noteMeta))
-
-modelNoteRoutes :: Model -> [LMLRoute]
-modelNoteRoutes model =
-  Ix.toList (_modelNotes model) <&> \note ->
-    note ^. N.noteRoute

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -179,3 +179,8 @@ modelNoteMetas model =
   Map.fromList $
     Ix.toList (_modelNotes model) <&> \note ->
       (note ^. N.noteRoute, (note ^. N.noteTitle, note ^. N.noteRoute, note ^. N.noteMeta))
+
+modelNoteRoutes :: Model -> [LMLRoute]
+modelNoteRoutes model =
+  Ix.toList (_modelNotes model) <&> \note ->
+    note ^. N.noteRoute

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -167,3 +167,7 @@ modelLookupStaticFileByRoute r =
 modelTags :: Model -> [(HT.Tag, [Note])]
 modelTags =
   Ix.groupAscBy @HT.Tag . _modelNotes
+
+modelNoteRels :: Model -> [Rel.Rel]
+modelNoteRels =
+  Ix.toList . _modelRels

--- a/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
+++ b/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -22,6 +25,7 @@ import qualified Commonmark as CM
 import qualified Commonmark.Pandoc as CP
 import qualified Commonmark.TokParsers as CT
 import Control.Monad (liftM2)
+import Data.Aeson (ToJSON (toJSON))
 import Data.Data (Data)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -44,6 +48,9 @@ import qualified Text.Show (Show (show))
 -- [[Foo/Bar]], hence we use nonempty slug list.
 newtype WikiLink = WikiLink {unWikiLink :: NonEmpty Slug}
   deriving (Eq, Ord, Typeable, Data)
+
+instance ToJSON WikiLink where
+  toJSON = toJSON . show @Text
 
 instance Show WikiLink where
   show wl =
@@ -148,7 +155,7 @@ data WikiLinkType
     WikiLinkTag
   | -- | ![[Foo]]
     WikiLinkEmbed
-  deriving (Eq, Show, Ord, Typeable, Data, Enum, Bounded)
+  deriving (Eq, Show, Ord, Typeable, Data, Enum, Bounded, Generic, ToJSON)
 
 instance Read WikiLinkType where
   readsPrec _ s

--- a/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
+++ b/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
@@ -50,7 +50,7 @@ newtype WikiLink = WikiLink {unWikiLink :: NonEmpty Slug}
   deriving (Eq, Ord, Typeable, Data)
 
 instance ToJSON WikiLink where
-  toJSON = toJSON . show @Text
+  toJSON = toJSON . wikilinkUrl
 
 instance Show WikiLink where
   show wl =

--- a/src/Emanote/Route/R.hs
+++ b/src/Emanote/Route/R.hs
@@ -6,7 +6,7 @@
 
 module Emanote.Route.R where
 
-import Data.Aeson (ToJSON)
+import Data.Aeson (ToJSON (toJSON))
 import Data.Data (Data)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -20,7 +20,10 @@ import qualified Text.Show (Show (show))
 -- | Represents the relative path to some file (or its isomporphic URL
 -- represetation).
 newtype R (ext :: FileType) = R {unRoute :: NonEmpty Slug}
-  deriving (Eq, Ord, Typeable, Data, Generic, ToJSON)
+  deriving (Eq, Ord, Typeable, Data)
+
+instance HasExt ext => ToJSON (R ext) where
+  toJSON = toJSON . encodeRoute
 
 instance HasExt ext => Show (R ext) where
   show r =

--- a/src/Emanote/Route/SiteRoute.hs
+++ b/src/Emanote/Route/SiteRoute.hs
@@ -16,6 +16,7 @@ module Emanote.Route.SiteRoute
     staticFileSiteRoute,
     lmlSiteRoute,
     siteRouteUrl,
+    siteRouteUrlStatic,
   )
 where
 

--- a/src/Emanote/Route/SiteRoute.hs
+++ b/src/Emanote/Route/SiteRoute.hs
@@ -5,6 +5,7 @@
 module Emanote.Route.SiteRoute
   ( SiteRoute (..),
     IndexR (..),
+    ExportR (..),
     TagIndexR (..),
     MissingR (..),
     AmbiguousR (..),

--- a/src/Emanote/Route/SiteRoute/Class.hs
+++ b/src/Emanote/Route/SiteRoute/Class.hs
@@ -78,6 +78,7 @@ instance Ema Model SiteRoute where
                       tags <&> \(HT.deconstructTag -> tagPath) ->
                         NE.filter (not . null) $ NE.inits tagPath
            in openUnionLift IndexR :
+              openUnionLift ExportR :
               (openUnionLift . TagIndexR <$> toList tagPaths)
      in htmlRoutes
           <> staticRoutes

--- a/src/Emanote/Route/SiteRoute/Class.hs
+++ b/src/Emanote/Route/SiteRoute/Class.hs
@@ -12,6 +12,7 @@ module Emanote.Route.SiteRoute.Class
     indexRoute,
     tagIndexRoute,
     siteRouteUrl,
+    siteRouteUrlStatic,
     urlStrategySuffix,
   )
 where
@@ -141,11 +142,18 @@ staticFileSiteRoute =
     staticResourceRoute =
       openUnionLift
 
+-- | Like `siteRouteUrl` but avoids any dynamism in the URL
+siteRouteUrlStatic :: HasCallStack => Model -> SiteRoute -> Text
+siteRouteUrlStatic model =
+  Ema.routeUrlWith (urlStrategy model) model
+
 siteRouteUrl :: HasCallStack => Model -> SiteRoute -> Text
 siteRouteUrl model sr =
-  Ema.routeUrlWith (urlStrategy model) model sr
-    <> maybe "" (("?t=" <>) . toText . formatTime defaultTimeLocale "%s") staticFileModifiedTime
+  siteRouteUrlStatic model sr
+    <> siteRouteQuery
   where
+    siteRouteQuery =
+      maybe "" (("?t=" <>) . toText . formatTime defaultTimeLocale "%s") staticFileModifiedTime
     staticFileModifiedTime = do
       -- In live server model, we append a ?t=.. to trigger the browser into
       -- reloading (or invalidating its cache of) this embed static file.

--- a/src/Emanote/Route/SiteRoute/Type.hs
+++ b/src/Emanote/Route/SiteRoute/Type.hs
@@ -117,7 +117,7 @@ decodeIndexR fp = do
 
 decodeExportR :: FilePath -> Maybe ExportR
 decodeExportR fp = do
-  "-" :| "export" : ["graph.json"] <- R.unRoute <$> R.decodeAnyRoute fp
+  "-" :| ["export.json"] <- R.unRoute <$> R.decodeAnyRoute fp
   pure ExportR
 
 decodeTagIndexR :: FilePath -> Maybe TagIndexR
@@ -138,7 +138,7 @@ encodeVirtualRoute =
             R.encodeRoute $ R.R @'Ext.Html $ "-" :| ["all"]
         )
     `h` ( \ExportR ->
-            R.encodeRoute $ R.R @'Ext.AnyExt $ "-" :| "export" : ["graph.json"]
+            R.encodeRoute $ R.R @'Ext.AnyExt $ "-" :| ["graph.json"]
         )
 
 encodeTagIndexR :: TagIndexR -> R.R 'Ext.Html

--- a/src/Emanote/Route/SiteRoute/Type.hs
+++ b/src/Emanote/Route/SiteRoute/Type.hs
@@ -117,7 +117,7 @@ decodeIndexR fp = do
 
 decodeExportR :: FilePath -> Maybe ExportR
 decodeExportR fp = do
-  "-" :| ["export.json"] <- R.unRoute <$> R.decodeAnyRoute fp
+  "-" :| "export" : ["graph.json"] <- R.unRoute <$> R.decodeAnyRoute fp
   pure ExportR
 
 decodeTagIndexR :: FilePath -> Maybe TagIndexR
@@ -138,7 +138,7 @@ encodeVirtualRoute =
             R.encodeRoute $ R.R @'Ext.Html $ "-" :| ["all"]
         )
     `h` ( \ExportR ->
-            R.encodeRoute $ R.R @'Ext.AnyExt $ "-" :| ["export.json"]
+            R.encodeRoute $ R.R @'Ext.AnyExt $ "-" :| "export" : ["graph.json"]
         )
 
 encodeTagIndexR :: TagIndexR -> R.R 'Ext.Html

--- a/src/Emanote/Route/SiteRoute/Type.hs
+++ b/src/Emanote/Route/SiteRoute/Type.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -17,6 +19,7 @@ module Emanote.Route.SiteRoute.Type
   )
 where
 
+import Data.Aeson (ToJSON)
 import Data.WorldPeace.Union
   ( OpenUnion,
     absurdUnion,
@@ -32,13 +35,13 @@ import Relude hiding (show)
 import Text.Show (show)
 
 data IndexR = IndexR
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, Generic, ToJSON)
 
 newtype TagIndexR = TagIndexR [HT.TagNode]
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, Generic, ToJSON)
 
 data ExportR = ExportR
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, Generic, ToJSON)
 
 -- | A 404 route
 newtype MissingR = MissingR {unMissingR :: FilePath}

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -1,22 +1,42 @@
-module Emanote.View.Export where
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Emanote.View.Export (renderExport) where
 
 import Control.Lens ((^.))
+import Data.Aeson (ToJSON)
 import qualified Data.Aeson as Aeson
+import qualified Data.Map.Strict as Map
 import Emanote.Model (Model)
 import qualified Emanote.Model as M
 import qualified Emanote.Model.Link.Rel as Rel
 import qualified Emanote.Model.Link.Resolve as Resolve
-import qualified Emanote.Route as R
 import qualified Emanote.Route.SiteRoute as SR
+import Emanote.Route.SiteRoute.Class (lmlSiteRoute)
 import Relude
+
+data Export = Export
+  { version :: Int,
+    rels :: Map Text [Link]
+  }
+  deriving (Generic, ToJSON)
+
+data Link = Link
+  { unresolvedRelTarget :: Rel.UnresolvedRelTarget,
+    resolvedRelTarget :: Rel.ResolvedRelTarget Text
+  }
+  deriving (Generic, ToJSON)
 
 renderExport :: Model -> LByteString
 renderExport model =
-  Aeson.encode $
-    M.modelNoteRels model <&> \rel ->
-      let from_ = R.encodeRoute $ R.lmlRouteCase $ rel ^. Rel.relFrom
-          to = rel ^. Rel.relTo
-          toTarget =
-            Resolve.resolveUnresolvedRelTarget model to
-              <&> SR.siteRouteUrl model
-       in (from_, (to, toTarget))
+  let rels_ =
+        Map.fromListWith (<>) $
+          M.modelNoteRels model <&> \rel ->
+            let from_ = SR.siteRouteUrl model $ lmlSiteRoute $ rel ^. Rel.relFrom
+                to_ = rel ^. Rel.relTo
+                toTarget =
+                  Resolve.resolveUnresolvedRelTarget model to_
+                    <&> SR.siteRouteUrl model
+             in (from_, one $ Link to_ toTarget)
+      export = Export 1 rels_
+   in Aeson.encode export

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -21,8 +21,7 @@ import Relude
 
 data Export = Export
   { version :: Word,
-    linkGraph :: Graph,
-    urls :: Map Text Text
+    linkGraph :: Graph
   }
   deriving (Generic, ToJSON)
 
@@ -40,6 +39,7 @@ data Vertex = Vertex
   { title :: Text,
     source :: Text,
     parent :: Maybe Text,
+    url :: Text,
     meta :: Aeson.Value
   }
   deriving (Generic, ToJSON)
@@ -60,6 +60,7 @@ renderGraphExport model =
                   (Tit.toPlain tit)
                   (toText $ lmlSourcePath r)
                   (toText . lmlSourcePath <$> G.parentLmlRoute r)
+                  (SR.siteRouteUrl model $ lmlSiteRoute r)
                   meta_
             )
       rels_ =
@@ -73,9 +74,7 @@ renderGraphExport model =
              in (from_, one $ Link to_ toTarget)
       description_ = "Emanote Graph of all files and links between them"
       graph_ = Graph description_ notes_ rels_
-      urls_ =
-        Map.fromList $ M.modelNoteRoutes model <&> \r -> (lmlRouteKey r, SR.siteRouteUrl model $ lmlSiteRoute r)
-      export = Export currentVersion graph_ urls_
+      export = Export currentVersion graph_
    in Aeson.encode export
 
 -- An unique key to represent this LMLRoute in the exported JSON

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -9,6 +9,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
 import Emanote.Model (Model)
 import qualified Emanote.Model as M
+import qualified Emanote.Model.Graph as G
 import qualified Emanote.Model.Link.Rel as Rel
 import qualified Emanote.Model.Link.Resolve as Resolve
 import qualified Emanote.Model.Title as Tit
@@ -38,6 +39,7 @@ data Graph = Graph
 data Vertex = Vertex
   { title :: Text,
     source :: Text,
+    parent :: Maybe Text,
     meta :: Aeson.Value
   }
   deriving (Generic, ToJSON)
@@ -54,7 +56,11 @@ renderGraphExport model =
         M.modelNoteMetas model & Map.mapKeys lmlRouteKey
           & Map.map
             ( \(tit, r, meta_) ->
-                Vertex (Tit.toPlain tit) (toText $ lmlSourcePath r) meta_
+                Vertex
+                  (Tit.toPlain tit)
+                  (toText $ lmlSourcePath r)
+                  (toText . lmlSourcePath <$> G.parentLmlRoute r)
+                  meta_
             )
       rels_ =
         Map.fromListWith (<>) $

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -1,0 +1,20 @@
+module Emanote.View.Export where
+
+import Control.Lens ((^.))
+import qualified Data.Aeson as Aeson
+import Emanote.Model (Model)
+import qualified Emanote.Model as M
+import qualified Emanote.Model.Link.Rel as Rel
+import qualified Emanote.Model.Link.Resolve as Resolve
+import qualified Emanote.Route as R
+import qualified Emanote.Route.SiteRoute as SR
+import Relude
+
+renderExport :: Model -> LByteString
+renderExport model =
+  Aeson.encode $
+    M.modelNoteRels model <&> \rel ->
+      ( R.encodeRoute $ R.lmlRouteCase $ rel ^. Rel.relFrom,
+        Resolve.resolveUnresolvedRelTarget model (rel ^. Rel.relTo)
+          <&> SR.siteRouteUrl model
+      )

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 
-module Emanote.View.Export (renderExport) where
+module Emanote.View.Export (renderGraphExport) where
 
 import Control.Lens ((^.))
 import Data.Aeson (ToJSON)
@@ -40,8 +40,8 @@ data Link = Link
   }
   deriving (Generic, ToJSON)
 
-renderExport :: Model -> LByteString
-renderExport model =
+renderGraphExport :: Model -> LByteString
+renderGraphExport model =
   let notes_ =
         M.modelNoteMetas model & Map.mapKeys (lmlRouteUrl model)
           & Map.map

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -14,7 +14,9 @@ renderExport :: Model -> LByteString
 renderExport model =
   Aeson.encode $
     M.modelNoteRels model <&> \rel ->
-      ( R.encodeRoute $ R.lmlRouteCase $ rel ^. Rel.relFrom,
-        Resolve.resolveUnresolvedRelTarget model (rel ^. Rel.relTo)
-          <&> SR.siteRouteUrl model
-      )
+      let from_ = R.encodeRoute $ R.lmlRouteCase $ rel ^. Rel.relFrom
+          to = rel ^. Rel.relTo
+          toTarget =
+            Resolve.resolveUnresolvedRelTarget model to
+              <&> SR.siteRouteUrl model
+       in (from_, (to, toTarget))

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -11,13 +11,26 @@ import Emanote.Model (Model)
 import qualified Emanote.Model as M
 import qualified Emanote.Model.Link.Rel as Rel
 import qualified Emanote.Model.Link.Resolve as Resolve
+import qualified Emanote.Model.Title as Tit
+import Emanote.Route (LMLRoute, lmlRouteCase)
+import qualified Emanote.Route.R as R
 import qualified Emanote.Route.SiteRoute as SR
 import Emanote.Route.SiteRoute.Class (lmlSiteRoute)
 import Relude
 
+-- TODO: index.yaml and other per-route data?
+-- TODO: Non-note files (static files)?
 data Export = Export
   { version :: Int,
+    notes :: Map Text Vertex,
     rels :: Map Text [Link]
+  }
+  deriving (Generic, ToJSON)
+
+data Vertex = Vertex
+  { title :: Text,
+    source :: Text,
+    meta :: Aeson.Value
   }
   deriving (Generic, ToJSON)
 
@@ -29,14 +42,30 @@ data Link = Link
 
 renderExport :: Model -> LByteString
 renderExport model =
-  let rels_ =
+  let notes_ =
+        M.modelNoteMetas model & Map.mapKeys (lmlRouteUrl model)
+          & Map.map
+            ( \(tit, r, meta_) ->
+                Vertex (Tit.toPlain tit) (toText $ lmlSourcePath r) meta_
+            )
+      rels_ =
         Map.fromListWith (<>) $
           M.modelNoteRels model <&> \rel ->
-            let from_ = SR.siteRouteUrl model $ lmlSiteRoute $ rel ^. Rel.relFrom
+            let from_ = lmlRouteUrl model $ rel ^. Rel.relFrom
                 to_ = rel ^. Rel.relTo
                 toTarget =
                   Resolve.resolveUnresolvedRelTarget model to_
                     <&> SR.siteRouteUrl model
              in (from_, one $ Link to_ toTarget)
-      export = Export 1 rels_
+      export = Export 1 notes_ rels_
    in Aeson.encode export
+
+-- URL of generated LML note
+lmlRouteUrl :: Model -> LMLRoute -> Text
+lmlRouteUrl model =
+  SR.siteRouteUrl model . lmlSiteRoute
+
+-- Path of the LML note
+lmlSourcePath :: LMLRoute -> FilePath
+lmlSourcePath =
+  R.encodeRoute . lmlRouteCase

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -20,10 +20,11 @@ import Relude
 
 -- TODO: index.yaml and other per-route data?
 -- TODO: Non-note files (static files)?
-data Export = Export
+data Graph = Graph
   { version :: Int,
-    notes :: Map Text Vertex,
-    rels :: Map Text [Link]
+    description :: Text,
+    vertices :: Map Text Vertex,
+    edges :: Map Text [Link]
   }
   deriving (Generic, ToJSON)
 
@@ -58,7 +59,8 @@ renderGraphExport model =
                     -- TODO: avoid query param, like in "favicon.svg?t=1633978084"
                     <&> SR.siteRouteUrl model
              in (from_, one $ Link to_ toTarget)
-      export = Export 1 notes_ rels_
+      description_ = "Emanote Graph of all files and links between them"
+      export = Graph 1 description_ notes_ rels_
    in Aeson.encode export
 
 -- URL of generated LML note

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -21,19 +21,13 @@ import Relude
 
 data Export = Export
   { version :: Word,
-    linkGraph :: Graph
+    files :: Map Text Vertex,
+    links :: Map Text [Link]
   }
   deriving (Generic, ToJSON)
 
 currentVersion :: Word
 currentVersion = 1
-
-data Graph = Graph
-  { description :: Text,
-    vertices :: Map Text Vertex,
-    edges :: Map Text [Link]
-  }
-  deriving (Generic, ToJSON)
 
 data Vertex = Vertex
   { title :: Text,
@@ -72,9 +66,7 @@ renderGraphExport model =
                   Resolve.resolveUnresolvedRelTarget model to_
                     <&> SR.siteRouteUrlStatic model
              in (from_, one $ Link to_ toTarget)
-      description_ = "Emanote Graph of all files and links between them"
-      graph_ = Graph description_ notes_ rels_
-      export = Export currentVersion graph_
+      export = Export currentVersion notes_ rels_
    in Aeson.encode export
 
 -- An unique key to represent this LMLRoute in the exported JSON

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -18,8 +18,6 @@ import qualified Emanote.Route.SiteRoute as SR
 import Emanote.Route.SiteRoute.Class (lmlSiteRoute)
 import Relude
 
--- TODO: index.yaml and other per-route data?
--- TODO: Non-note files (static files)?
 data Graph = Graph
   { version :: Int,
     description :: Text,
@@ -56,8 +54,7 @@ renderGraphExport model =
                 to_ = rel ^. Rel.relTo
                 toTarget =
                   Resolve.resolveUnresolvedRelTarget model to_
-                    -- TODO: avoid query param, like in "favicon.svg?t=1633978084"
-                    <&> SR.siteRouteUrl model
+                    <&> SR.siteRouteUrlStatic model
              in (from_, one $ Link to_ toTarget)
       description_ = "Emanote Graph of all files and links between them"
       export = Graph 1 description_ notes_ rels_

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -55,6 +55,7 @@ renderExport model =
                 to_ = rel ^. Rel.relTo
                 toTarget =
                   Resolve.resolveUnresolvedRelTarget model to_
+                    -- TODO: avoid query param, like in "favicon.svg?t=1633978084"
                     <&> SR.siteRouteUrl model
              in (from_, one $ Link to_ toTarget)
       export = Export 1 notes_ rels_

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -6,7 +6,7 @@
 module Emanote.View.Template (render) where
 
 import Control.Lens ((.~), (^.))
-import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
 import Data.List (partition)
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Syntax ((##))

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -6,7 +6,7 @@
 module Emanote.View.Template (render) where
 
 import Control.Lens ((.~), (^.))
-import qualified Data.Aeson.Types as Aeson
+import qualified Data.Aeson as Aeson
 import Data.List (partition)
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Syntax ((##))
@@ -19,6 +19,8 @@ import Emanote.Model (Model)
 import qualified Emanote.Model as M
 import qualified Emanote.Model.Calendar as Calendar
 import qualified Emanote.Model.Graph as G
+import qualified Emanote.Model.Link.Rel as Rel
+import qualified Emanote.Model.Link.Resolve as Resolve
 import qualified Emanote.Model.Meta as Meta
 import qualified Emanote.Model.Note as MN
 import qualified Emanote.Model.SData as SData
@@ -90,6 +92,18 @@ renderVirtualRoute m =
     `h` ( \SR.IndexR ->
             Ema.AssetGenerated Ema.Html $ renderSRIndex m
         )
+    `h` ( \SR.ExportR ->
+            Ema.AssetGenerated Ema.Other $ renderExport m
+        )
+
+renderExport :: Model -> LByteString
+renderExport model =
+  Aeson.encode $
+    M.modelNoteRels model <&> \rel ->
+      ( R.encodeRoute $ R.lmlRouteCase $ rel ^. Rel.relFrom,
+        Resolve.resolveUnresolvedRelTarget model (rel ^. Rel.relTo)
+          <&> SR.siteRouteUrl model
+      )
 
 renderSRIndex :: Model -> LByteString
 renderSRIndex model = do

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -29,7 +29,7 @@ import Emanote.Route (FileType (LMLType), LML (Md))
 import qualified Emanote.Route as R
 import qualified Emanote.Route.SiteRoute as SR
 import Emanote.View.Common (commonSplices, inlineRenderers, linkInlineRenderers, mkRendererFromMeta, noteRenderers, renderModelTemplate)
-import Emanote.View.Export (renderExport)
+import Emanote.View.Export (renderGraphExport)
 import qualified Emanote.View.TagIndex as TagIndex
 import qualified Heist as H
 import qualified Heist.Extra.Splices.List as Splices
@@ -92,7 +92,7 @@ renderVirtualRoute m =
             Ema.AssetGenerated Ema.Html $ renderSRIndex m
         )
     `h` ( \SR.ExportR ->
-            Ema.AssetGenerated Ema.Other $ renderExport m
+            Ema.AssetGenerated Ema.Other $ renderGraphExport m
         )
 
 renderSRIndex :: Model -> LByteString

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -19,8 +19,6 @@ import Emanote.Model (Model)
 import qualified Emanote.Model as M
 import qualified Emanote.Model.Calendar as Calendar
 import qualified Emanote.Model.Graph as G
-import qualified Emanote.Model.Link.Rel as Rel
-import qualified Emanote.Model.Link.Resolve as Resolve
 import qualified Emanote.Model.Meta as Meta
 import qualified Emanote.Model.Note as MN
 import qualified Emanote.Model.SData as SData
@@ -31,6 +29,7 @@ import Emanote.Route (FileType (LMLType), LML (Md))
 import qualified Emanote.Route as R
 import qualified Emanote.Route.SiteRoute as SR
 import Emanote.View.Common (commonSplices, inlineRenderers, linkInlineRenderers, mkRendererFromMeta, noteRenderers, renderModelTemplate)
+import Emanote.View.Export (renderExport)
 import qualified Emanote.View.TagIndex as TagIndex
 import qualified Heist as H
 import qualified Heist.Extra.Splices.List as Splices
@@ -95,15 +94,6 @@ renderVirtualRoute m =
     `h` ( \SR.ExportR ->
             Ema.AssetGenerated Ema.Other $ renderExport m
         )
-
-renderExport :: Model -> LByteString
-renderExport model =
-  Aeson.encode $
-    M.modelNoteRels model <&> \rel ->
-      ( R.encodeRoute $ R.lmlRouteCase $ rel ^. Rel.relFrom,
-        Resolve.resolveUnresolvedRelTarget model (rel ^. Rel.relTo)
-          <&> SR.siteRouteUrl model
-      )
 
 renderSRIndex :: Model -> LByteString
 renderSRIndex model = do


### PR DESCRIPTION
For #161

- [x] MVP
- [x] Normalize paths to use slug always (helps with client-side scripting)
- [x] Add JSON version
- [ ] Include non-note files (static files) in vertex list
- [ ] Include per-route .yaml meta?
 - [ ] Make json keys and such concise enough, to reduce output size on large zks