### PR TITLE
"edit this page" links

### DIFF
--- a/default/templates/components/footer.tpl
+++ b/default/templates/components/footer.tpl
@@ -27,6 +27,16 @@
         </path>
       </svg>
     </a>
+  </div>
+  <div>
+    <a href="${ema:note:editUrl}" title="Edit this page" rel="edit">
+      <svg style="width: 1rem;" class="hover:text-${theme}-700" fill="none" stroke="currentColor"
+        viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path fill-rule="evenodd"
+          d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+          clip-rule="evenodd"></path>
+      </svg>
+    </a>
 
   </div>
 </footer>

--- a/default/templates/components/footer.tpl
+++ b/default/templates/components/footer.tpl
@@ -30,13 +30,11 @@
   </div>
   <div>
     <a href="${ema:note:editUrl}" title="Edit this page" rel="edit">
-      <svg style="width: 1rem;" class="hover:text-${theme}-700" fill="none" stroke="currentColor"
-        viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path fill-rule="evenodd"
-          d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-          clip-rule="evenodd"></path>
+      <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor">
+        <path
+          d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z">
+        </path>
       </svg>
     </a>
-
   </div>
 </footer>

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -7,6 +7,9 @@ page:
   headHtml: |
     <snippet var="js.prism" />
 
+site:
+  editBaseUrl: https://github.com/srid/emanote/edit/master/docs/
+
 pandoc:
   rewriteClass:
     # For use in notes with Prism.JS disabled

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -164,6 +164,8 @@ renderLmlHtml model note = do
         "tree:open" ## Heist.ifElseISplice (not . null $ children)
     "ema:note:uptree:nonempty" ## Heist.ifElseISplice (not . null $ folgeAnc)
     "ema:note:uptreeStr" ## HI.textSplice (toText . Shower.shower $ folgeAnc)
+    "ema:note:editUrl"
+      ## HI.textSplice (MN.lookupAeson @Text "edit/" ("site" :| ["editBaseUrl"]) meta <> toText (R.encodeRoute $ R.lmlRouteCase r))
     "ema:note:pandoc"
       ## withBlockCtx
       $ \ctx ->


### PR DESCRIPTION
Implements an "Edit this page" link, a common feature for file-based static site gens.

I thought it would be good for me to start learning the template/view
end of the codebase so I can help myself more.

It's incomplete, but I wanted to get feedback.

#### Issues

- [x] ~~Rather than choosing our own key (I used `site.editBaseUrl`) find                                 
what other tools use and follow/boost convention.~~ *Results: looking at hugo (not builtin) mkdocs.yml (concat repo_url with [edit_uri](https://www.mkdocs.org/user-guide/configuration/#edit_uri)), and mdbook (`edit-url-template` in [TOML](edit-url-template)), there doesn't seem to be a convention.*
- [ ] I just dropped the link in the footer without thinking about it
much. Where should it appear? Structurally, should it be in its own template?
- [x] Needs svg edit icon data. I borrowed the breadcrumb data. @srid what's
your process for generating these?
- [ ] I want to make this template contingent on a non-empty `baseUrl` meta key, but didn't see how to do that. Seems like Heist wants conditionals in Haskell, so I guess that requires some extra rendering logic?