### PR TITLE
Fix ExecStart command in nix home-manager module

### DIFF
--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -107,7 +107,7 @@ in
       Service = {
         ExecStart = ''
           ${cfg.package}/bin/emanote \
-            --layers "${lib.concatStringsSep ";" layers}"
+            --layers "${lib.concatStringsSep ";" layers}" \
             run --host=${cfg.host} --port=${builtins.toString cfg.port}
         '';
       };


### PR DESCRIPTION
It just needs a backslash so that the host and port args are used.
