### PR TITLE
Simplify MathJax code

### DIFF
--- a/default/index.yaml
+++ b/default/index.yaml
@@ -89,18 +89,14 @@ js:
     </script>
   mathjax: |
     <script>
-      window.mathjaxInitialTypesetDone = false;
       window.MathJax = {
         startup: {
           ready: () => {
             MathJax.startup.defaultReady();
-            MathJax.startup.promise.then(() => {
-              console.log('MathJax typesetting complete');
-              window.mathjaxInitialTypesetDone = true;
-            });
           }
         }
       };
     </script>
     <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
 

--- a/docs/tips/js/math.md
+++ b/docs/tips/js/math.md
@@ -15,15 +15,10 @@ page:
     page:
       headHtml: |
         <script>
-          window.mathjaxInitialTypesetDone = false;
           window.MathJax = {
             startup: {
               ready: () => {
                 MathJax.startup.defaultReady();
-                MathJax.startup.promise.then(() => {
-                  console.log('MathJax typesetting complete');
-                  window.mathjaxInitialTypesetDone = true;
-                });
               }
             }
           };

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.4.8.1
+version:            0.4.8.2
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
The MathJax config can be simpler than what we have now.

Especially the `mathjaxInitialTypesetDone` variable, which I had been using with the functionality implemented in #67. But as you pointed out to me, that turned out to not be the fix.

Did you want to keep the log message? If so we can edit the PR, but we should at least git rid of my unneeded global variable :P 

Thanks for the efforts! Now that math is mostly sorted, Im really appreciating Emanote