### PR TITLE
Relative link & anchors support; broken link detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
             -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 \
             -v $PWD/docs:/data \
             --tmpfs /tmp \
-            sridca/emanote emanote --layers /data gen /data/.ci/output
+            sridca/emanote emanote --layers /data --allow-broken-links gen /data/.ci/output
           cp -r ./docs/.ci .
       - name: Deploy to website to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
             -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 \
             -v $PWD/docs:/data \
             --tmpfs /tmp \
+            # demo.md has broken links for demo
             sridca/emanote emanote --layers /data --allow-broken-links gen /data/.ci/output
           cp -r ./docs/.ci .
       - name: Deploy to website to gh-pages 🚀

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.5.1.0
+version:            0.5.2.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -131,6 +131,7 @@ common library-common
     , tailwind
     , tasty
     , tasty-hedgehog
+    , tasty-hunit
     , tasty-quickcheck
     , text
     , time

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1648148690,
-        "narHash": "sha256-/YkF86lduofUG/3vvmYn06lWEPgFcptf6vM4JaiUUUo=",
+        "lastModified": 1648150821,
+        "narHash": "sha256-AGwZRHD2Gcn2kuT3FQCaQOoBhH1D+Blk0WXuEXWyr2c=",
         "owner": "srid",
         "repo": "ema",
-        "rev": "3686a8079fded5ca6586291c101cf2a8aefd87d1",
+        "rev": "624bcd5103e847fbbb9c59e39dab507424dd8299",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1648142177,
-        "narHash": "sha256-L+ejPXrbAiFCOXJQR5LPRBOLniIyole8RDiP3Q+zT/A=",
+        "lastModified": 1648148690,
+        "narHash": "sha256-/YkF86lduofUG/3vvmYn06lWEPgFcptf6vM4JaiUUUo=",
         "owner": "srid",
         "repo": "ema",
-        "rev": "74557c90eee52251dc251e5510f2ba06b477d531",
+        "rev": "3686a8079fded5ca6586291c101cf2a8aefd87d1",
         "type": "github"
       },
       "original": {

--- a/src/Emanote.hs
+++ b/src/Emanote.hs
@@ -3,7 +3,7 @@
 module Emanote (run) where
 
 import Control.Monad.Logger (runStderrLoggingT, runStdoutLoggingT)
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.Strict (MonadWriter (tell), WriterT (runWriterT))
 import Data.Default (def)
 import Data.Dependent.Sum (DSum ((:=>)))
 import Data.Map.Strict qualified as Map

--- a/src/Emanote.hs
+++ b/src/Emanote.hs
@@ -2,9 +2,11 @@
 
 module Emanote (run) where
 
-import Control.Monad.Logger (runStdoutLoggingT)
+import Control.Monad.Logger (runStderrLoggingT, runStdoutLoggingT)
+import Control.Monad.Writer.Strict
 import Data.Default (def)
 import Data.Dependent.Sum (DSum ((:=>)))
+import Data.Map.Strict qualified as Map
 import Ema
   ( CanGenerate (..),
     CanRender (..),
@@ -14,11 +16,14 @@ import Ema
   )
 import Ema.CLI qualified
 import Emanote.CLI qualified as CLI
+import Emanote.Model.Link.Rel (ResolvedRelTarget (..))
 import Emanote.Model.Type qualified as Model
+import Emanote.Prelude (logE, logW)
 import Emanote.Route.SiteRoute.Class (emanoteGeneratableRoutes, emanoteRouteEncoder)
 import Emanote.Route.SiteRoute.Type (SiteRoute)
 import Emanote.Source.Dynamic (emanoteModelDynamic)
 import Emanote.View.Common (generatedCssFile)
+import Emanote.View.Export qualified as Export
 import Emanote.View.Template qualified as View
 import Optics.Core ((%), (.~))
 import Relude
@@ -43,10 +48,28 @@ instance HasModel SiteRoute where
 run :: CLI.Cli -> IO ()
 run cli = do
   Ema.runSiteWithCli @SiteRoute (CLI.emaCli cli) cli >>= \case
-    Ema.CLI.Generate outPath :=> Identity genPaths ->
+    (model0, Ema.CLI.Generate outPath :=> Identity genPaths) -> do
       compileTailwindCss outPath genPaths
+      checkBrokenLinks model0
     _ ->
       pure ()
+
+checkBrokenLinks :: Model.Model -> IO ()
+checkBrokenLinks model = runStderrLoggingT $ do
+  ((), res :: Sum Int) <- runWriterT $
+    forM_ (Map.toList $ Export.modelRels model) $ \(noteRoute, rels) ->
+      forM_ rels $ \(Export.Link urt rrt) ->
+        case rrt of
+          RRTFound _ -> pure ()
+          RRTMissing -> do
+            logW $ "Broken link: " <> show noteRoute <> " -> " <> show urt
+            tell 1
+          RRTAmbiguous _ -> do
+            logW $ "Ambiguous link: " <> show noteRoute <> " -> " <> show urt
+            tell 1
+  unless (res == 0) $ do
+    logE $ "Found " <> show (getSum res) <> " broken links! Emanote generated the site, but the generated site has broken links."
+    exitFailure
 
 compileTailwindCss :: MonadUnliftIO m => FilePath -> [FilePath] -> m ()
 compileTailwindCss outPath genPaths = do

--- a/src/Emanote/CLI.hs
+++ b/src/Emanote/CLI.hs
@@ -18,6 +18,7 @@ import UnliftIO.Directory (getCurrentDirectory)
 data Cli = Cli
   { layers :: NonEmpty FilePath,
     test :: Bool,
+    allowBrokenLinks :: Bool,
     emaCli :: Ema.CLI.Cli
   }
 
@@ -25,6 +26,7 @@ cliParser :: FilePath -> Parser Cli
 cliParser cwd = do
   layers <- pathList (one cwd)
   test <- switch (long "test" <> help "Run tests")
+  allowBrokenLinks <- switch (long "allow-broken-links" <> help "Report but do not fail on broken links")
   emaCli <- Ema.CLI.cliParser
   pure Cli {..}
   where

--- a/src/Emanote/Model/Link/Rel.hs
+++ b/src/Emanote/Model/Link/Rel.hs
@@ -99,14 +99,21 @@ parseUnresolvedRelTarget baseDir attrs url = do
 
 relocateRelUrlUnder :: Maybe FilePath -> FilePath -> FilePath
 relocateRelUrlUnder mbase fp =
-  dropDotDot . normalise $
+  normalizeIgnoringSymlinks $
     case mbase of
       Nothing -> fp
       Just x -> x </> fp
 
+-- | Like `System.FilePath.normalise` but also normalises '..'
+normalizeIgnoringSymlinks :: FilePath -> FilePath
+normalizeIgnoringSymlinks = dropDotDot . normalise
+
 -- Remove '..' from path component.
--- We don't care about these, as there are no symlinks involved.
--- https://github.com/haskell/filepath/issues/87
+--
+-- `System.FilePath.normalize` ought to do this already, but it doesn't due to
+-- symlinks (which we don't use anyway.)
+--
+-- See https://github.com/haskell/filepath/issues/87
 dropDotDot :: FilePath -> FilePath
 dropDotDot =
   let go :: Int -> NonEmpty Text -> [Text]

--- a/src/Emanote/Model/Link/Rel.hs
+++ b/src/Emanote/Model/Link/Rel.hs
@@ -78,11 +78,10 @@ unresolvedRelsTo r =
         <> [URTResource r]
 
 -- | Parse a relative URL string for later resolution.
+--
+-- TODO: Need tests for this function.
 parseUnresolvedRelTarget :: Maybe (R.R 'R.Folder) -> [(Text, Text)] -> Text -> Maybe (UnresolvedRelTarget, Maybe WL.Anchor)
 parseUnresolvedRelTarget baseDir attrs url = do
-  -- FIXME: Dropping anchors is necessary to resolve correctly.
-  -- But we want to inject it back in HTML url for correct navigation.
-  -- Also see: https://github.com/srid/emanote/discussions/105
   (wlRes, manchor) <- WL.delineateLink attrs url
   res <- case wlRes of
     Left wl ->

--- a/src/Emanote/Model/Link/RelSpec.hs
+++ b/src/Emanote/Model/Link/RelSpec.hs
@@ -1,0 +1,36 @@
+module Emanote.Model.Link.RelSpec where
+
+import Emanote.Model.Link.Rel
+import Relude
+import Test.Tasty
+import Test.Tasty.HUnit
+
+spec :: TestTree
+spec =
+  testGroup
+    "Rel"
+    [ dropDotDot_spec
+    ]
+
+dropDotDot_spec :: TestTree
+dropDotDot_spec =
+  testGroup
+    "dropDotDot"
+    [ testCase "simple" $ do
+        dropDotDot "foo/bar/qux" @?= "foo/bar/qux"
+        dropDotDot "foo/../qux" @?= "qux"
+        dropDotDot "bar/foo/../qux" @?= "bar/qux"
+        dropDotDot "bar/foo/.." @?= "bar",
+      testCase "complex" $ do
+        dropDotDot "bar/foo/../../qux" @?= "qux"
+        dropDotDot "bar/foo/../../qux/../foo" @?= "foo",
+      testCase "beginning" $ do
+        dropDotDot "../../foo" @?= "foo"
+        dropDotDot "../foo" @?= "foo"
+        dropDotDot "./../foo" @?= "foo"
+        dropDotDot "./foo" @?= "./foo",
+      testCase "end" $ do
+        dropDotDot "foo/.." @?= ""
+        dropDotDot "foo/bar/.." @?= "foo"
+        dropDotDot "foo/bar/../.." @?= ""
+    ]

--- a/src/Emanote/Pandoc/Markdown/Parser.hs
+++ b/src/Emanote/Pandoc/Markdown/Parser.hs
@@ -24,6 +24,8 @@ parseMarkdown =
       <> gfmExtensionsSansPipeTable
       <> CE.pipeTableSpec
       <> WL.wikilinkSpec
+      -- ASK: Can we conditionally disable this?
+      -- cf. https://github.com/srid/emanote/issues/167
       <> IT.hashTagSpec
       <> IH.highlightSpec
   where

--- a/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
+++ b/src/Emanote/Pandoc/Markdown/Syntax/WikiLink.hs
@@ -113,6 +113,7 @@ delineateLink (Map.fromList -> attrs) url = do
       -- the user can do it using wiki-links.
       guard $ not $ ":" `T.isInfixOf` url
       let (s, manc) = dropUrlAnchor url
+      guard $ not $ T.null s -- Same page anchors
       pure (Right $ UE.decode (toString s), manc)
 
 -- ---------------------

--- a/src/Emanote/Prelude.hs
+++ b/src/Emanote/Prelude.hs
@@ -4,7 +4,7 @@
 -- here.
 module Emanote.Prelude where
 
-import Control.Monad.Logger (MonadLogger, logDebugNS, logErrorNS, logInfoNS)
+import Control.Monad.Logger (MonadLogger, logDebugNS, logErrorNS, logInfoNS, logWarnNS)
 import Data.WorldPeace.Union
   ( ElemRemove,
     OpenUnion,
@@ -41,6 +41,9 @@ logD = logDebugNS "emanote"
 
 logE :: MonadLogger m => Text -> m ()
 logE = logErrorNS "emanote"
+
+logW :: MonadLogger m => Text -> m ()
+logW = logWarnNS "emanote"
 
 -- OpenUnion
 

--- a/src/Emanote/View/Common.hs
+++ b/src/Emanote/View/Common.hs
@@ -49,7 +49,7 @@ import Text.Blaze.Html5 qualified as H
 import Text.Blaze.Html5.Attributes qualified as A
 import Text.Blaze.Renderer.XmlHtml qualified as RX
 
-noteRenderers :: Monad n => PandocRenderers n i LMLRoute
+noteRenderers :: Monad n => PandocRenderers n LMLRoute LMLRoute
 noteRenderers =
   PandocRenderers
     _pandocInlineRenderers
@@ -59,7 +59,7 @@ noteRenderers =
 --
 -- Backlinks and titles constitute an example of inline context, where we don't
 -- care about block elements.
-inlineRenderers :: Monad n => PandocRenderers n i b
+inlineRenderers :: Monad n => PandocRenderers n LMLRoute b
 inlineRenderers =
   PandocRenderers
     _pandocInlineRenderers
@@ -72,7 +72,7 @@ linkInlineRenderers =
     _pandocLinkInlineRenderers
     mempty
 
-_pandocInlineRenderers :: Monad n => [PandocInlineRenderer n i b]
+_pandocInlineRenderers :: Monad n => [PandocInlineRenderer n LMLRoute b]
 _pandocInlineRenderers =
   [ PF.embedInlineWikiLinkResolvingSplice, -- embedInlineWikiLinkResolvingSplice should be first to recognize inline Link elements first
     PF.urlResolvingSplice
@@ -110,11 +110,11 @@ mkTemplateRenderCtx ::
   TemplateRenderCtx n
 mkTemplateRenderCtx model r meta =
   let withInlineCtx =
-        mkRendererFromMeta model meta inlineRenderers () ()
+        mkRendererFromMeta model meta inlineRenderers r ()
       withLinkInlineCtx =
         mkRendererFromMeta model meta linkInlineRenderers () ()
       withBlockCtx =
-        mkRendererFromMeta model meta noteRenderers () r
+        mkRendererFromMeta model meta noteRenderers r r
       -- TODO: We should be using withInlineCtx, so as to make the wikilink render in note title.
       titleSplice titleDoc = withLinkInlineCtx $ \x ->
         Tit.titleSplice x preparePandoc titleDoc

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE DeriveAnyClass #-}
 
-module Emanote.View.Export (renderGraphExport) where
+module Emanote.View.Export
+  ( renderGraphExport,
+    Link (..),
+    modelRels,
+  )
+where
 
 import Data.Aeson (ToJSON)
 import Data.Aeson qualified as Aeson
@@ -62,17 +67,20 @@ renderGraphExport model =
                       meta_
                       (fromMaybe [] $ Map.lookup k rels)
             )
-      rels =
-        Map.fromListWith (<>) $
-          M.modelNoteRels model <&> \rel ->
-            let from_ = lmlRouteKey $ rel ^. Rel.relFrom
-                to_ = rel ^. Rel.relTo
-                toTarget =
-                  Resolve.resolveUnresolvedRelTarget model to_
-                    <&> SR.siteRouteUrlStatic model
-             in (from_, one $ Link to_ toTarget)
+      rels = modelRels model & Map.mapKeys lmlRouteKey
       export = Export currentVersion notes_
    in Aeson.encode export
+
+modelRels :: Model -> Map LMLRoute [Link]
+modelRels model =
+  Map.fromListWith (<>) $
+    M.modelNoteRels model <&> \rel ->
+      let from_ = rel ^. Rel.relFrom
+          to_ = rel ^. Rel.relTo
+          toTarget =
+            Resolve.resolveUnresolvedRelTarget model to_
+              <&> SR.siteRouteUrlStatic model
+       in (from_, one $ Link to_ toTarget)
 
 -- An unique key to represent this LMLRoute in the exported JSON
 --

--- a/src/Emanote/View/Export.hs
+++ b/src/Emanote/View/Export.hs
@@ -49,7 +49,7 @@ data Link = Link
   { unresolvedRelTarget :: Rel.UnresolvedRelTarget,
     resolvedRelTarget :: Rel.ResolvedRelTarget Text
   }
-  deriving stock (Generic)
+  deriving stock (Generic, Eq, Ord)
   deriving anyclass (ToJSON)
 
 renderGraphExport :: Model -> LByteString

--- a/src/Emanote/View/TagIndex.hs
+++ b/src/Emanote/View/TagIndex.hs
@@ -76,7 +76,7 @@ renderTagIndex model tagPath = do
   let meta = Meta.getIndexYamlMeta model
       withNoteRenderer = mkRendererFromMeta model meta
       withInlineCtx =
-        withNoteRenderer inlineRenderers () ()
+        withNoteRenderer inlineRenderers SR.indexLmlRoute SR.indexLmlRoute
       tagIdx = mkTagIndex model tagPath
   renderModelTemplate model "templates/special/tagindex" $ do
     commonSplices ($ emptyRenderCtx) model meta $ fromString . toString $ tagIndexTitle tagIdx

--- a/src/Spec.hs
+++ b/src/Spec.hs
@@ -1,5 +1,6 @@
 module Spec (main) where
 
+import Emanote.Model.Link.RelSpec qualified as RelSpec
 import Emanote.Model.QuerySpec qualified as QuerySpec
 import Relude
 import Test.Tasty
@@ -21,5 +22,6 @@ tests =
   localOption limit . localOption (HedgehogShrinkLimit (Just 2)) $
     testGroup
       "Tests"
-      [ QuerySpec.spec
+      [ QuerySpec.spec,
+        RelSpec.spec
       ]


### PR DESCRIPTION
Relative links now work, as well as links with anchors. So `[Foo](../qux/bar.md#Some-Section)` should work.

Resolves #249

cf. 168