### PR TITLE
add cache substituter to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,9 @@
 {
   description = "emanote";
+  nixConfig = {
+    extra-substituters = "https://srid.cachix.org";
+    extra-trusted-public-keys = "srid.cachix.org-1:MTQ6ksbfz3LBMmjyPh0PLmos+1x+CdtJxA/J2W+PQxI=";
+  };
   inputs = {
     ema.url = "github:srid/ema/multisite";
     nixpkgs.follows = "ema/nixpkgs";


### PR DESCRIPTION
Continued from https://github.com/srid/emanote-template/pull/4

Tested with direnv on NixOS system with `nix.settings.trusted-users = [ '@wheel' ];`