### PR TITLE
[MVP] Basic Pandoc lua filters

### DIFF
--- a/default/index.yaml
+++ b/default/index.yaml
@@ -50,7 +50,7 @@ pandoc:
     # in the generic class.
     emanote:inline-tag:a/red/tag: bg-red-100
     emanote:placeholder-message: text-gray-400 border-t-2 inline-block pt-0.5
-    emanote:error: text-l bg-red-200 p-2 border-2 border-black m-2 font-mono
+    emanote:error: text-l bg-red-100 p-2 border-2 border-black m-2 font-mono
     emanote:error:aside: font-mono align-top text-xs mr-1 tracking-tighter opacity-50 hover:opacity-100 
     # You can also add your own class -> style mappings. We provide a sample below.
     sticky-note: px-3 py-1 rounded shadow bg-yellow-100 mx-2 transform -skew-y-1 scale-95 hover:scale-100 hover:border-yellow-400 hover:shadow-lg border-t-8 border-yellow-200 mb-8 mt-8

--- a/default/index.yaml
+++ b/default/index.yaml
@@ -50,7 +50,8 @@ pandoc:
     # in the generic class.
     emanote:inline-tag:a/red/tag: bg-red-100
     emanote:placeholder-message: text-gray-400 border-t-2 inline-block pt-0.5
-    emanote:error:aside: font-mono align-top text-xs mr-1 tracking-tighter opacity-50 hover:opacity-100
+    emanote:error: text-l bg-red-200 p-2 border-2 border-black m-2 font-mono
+    emanote:error:aside: font-mono align-top text-xs mr-1 tracking-tighter opacity-50 hover:opacity-100 
     # You can also add your own class -> style mappings. We provide a sample below.
     sticky-note: px-3 py-1 rounded shadow bg-yellow-100 mx-2 transform -skew-y-1 scale-95 hover:scale-100 hover:border-yellow-400 hover:shadow-lg border-t-8 border-yellow-200 mb-8 mt-8
     note: p-2 mb-3 rounded shadow bg-gray-100 w-full float-none md:float-right md:w-1/2 md:clear-both 

--- a/docs/demo/lua-filters.md
+++ b/docs/demo/lua-filters.md
@@ -1,0 +1,27 @@
+---
+pandoc:
+  filters:
+    - docs/filters/list-table.lua
+---
+
+# Pandoc Lua filters
+
+WIP
+
+## Examples
+
+### `list-table.lua`
+
+:::list-table
+   * - row 1, column 1
+     - row 1, column 2
+     - row 1, column 3
+
+   * - row 2, column 1
+     -
+     - row 2, column 3
+
+   * - row 3, column 1
+     - row 3, column 2
+     - Well!
+:::

--- a/docs/demo/lua-filters.md
+++ b/docs/demo/lua-filters.md
@@ -4,11 +4,25 @@ pandoc:
     - filters/list-table.lua
 ---
 
-# Pandoc Lua filters
+# Pandoc Lua Filters
 
-WIP
+**WARNING**: This is an ==🧪 experimental 🧪== feature and may change in future. It is being made available so users can try it out and give feedback to the author.
 
-## Examples
+See https://github.com/srid/emanote/issues/263
+
+To enable a [Pandoc Lua filter](https://pandoc.org/lua-filters.html) for a particular Markdown file, put that filter in your notebook and add the following to the Markdown file's YAML frontmatter:
+
+```yaml
+pandoc:
+  filters:
+    - path/to/your.lua
+```
+
+See [here](https://github.com/srid/emanote/pull/278#issue-1207537343) for known limitations.
+
+## Demo
+
+This uses the [list table](https://github.com/pandoc/lua-filters/tree/master/list-table) filter (copied as [[list-table.lua]]):
 
 ### `list-table.lua`
 

--- a/docs/demo/lua-filters.md
+++ b/docs/demo/lua-filters.md
@@ -1,7 +1,7 @@
 ---
 pandoc:
   filters:
-    - docs/filters/list-table.lua
+    - filters/list-table.lua
 ---
 
 # Pandoc Lua filters

--- a/docs/filters/list-table.lua
+++ b/docs/filters/list-table.lua
@@ -1,0 +1,164 @@
+-- lua filter for RST-like list-tables in Markdown.
+-- Copyright (C) 2021 Martin Fischer, released under MIT license
+
+if PANDOC_VERSION and PANDOC_VERSION.must_be_at_least then
+    PANDOC_VERSION:must_be_at_least("2.11")
+else
+    error("pandoc version >=2.11 is required")
+end
+
+-- Get the list of cells in a row.
+local row_cells = function (row) return row.cells end
+
+-- "Polyfill" for older pandoc versions.
+if PANDOC_VERSION <= '2.16.2' then
+  -- previous pandoc versions used simple Attr/list pairs
+  pandoc.Row = function (cells) return {{}, cells} end
+  pandoc.TableHead = function (rows) return {{}, rows or {}} end
+  pandoc.TableFoot = function (rows) return {{}, rows or {}} end
+  pandoc.Cell = function (contents, align, rowspan, colspan, attr)
+    return {
+      attr = attr or pandoc.Attr(),
+      alignment = align or pandoc.AlignDefault,
+      contents = contents or {},
+      col_span = colspan or 1,
+      row_span = rowspan or 1
+    }
+  end
+  row_cells = function (row) return row[2] end
+end
+
+local alignments = {
+    d = 'AlignDefault',
+    l = 'AlignLeft',
+    r = 'AlignRight',
+    c = 'AlignCenter'
+}
+
+local function get_colspecs(div_attributes, column_count)
+    -- list of (align, width) pairs
+    local colspecs = {}
+
+    for i = 1, column_count do
+        table.insert(colspecs, {pandoc.AlignDefault, nil})
+    end
+
+    if div_attributes.aligns then
+        local i = 1
+        for a in div_attributes.aligns:gmatch('[^,]') do
+            assert(alignments[a] ~= nil,
+                   "unknown column alignment " .. tostring(a))
+            colspecs[i][1] = alignments[a]
+            i = i + 1
+        end
+        div_attributes.aligns = nil
+    end
+
+    if div_attributes.widths then
+        local total = 0
+        local widths = {}
+        for w in div_attributes.widths:gmatch('[^,]') do
+            table.insert(widths, tonumber(w))
+            total = total + tonumber(w)
+        end
+        for i = 1, column_count do
+            colspecs[i][2] = widths[i] / total
+        end
+        div_attributes.widths = nil
+    end
+
+    return colspecs
+end
+
+local function  new_table_body(rows, header_col_count)
+    return {
+        attr = {},
+        body = rows,
+        head = {},
+        row_head_columns = header_col_count
+    }
+end
+
+local function new_cell(contents)
+    local attr = {}
+    local colspan = 1
+    local rowspan = 1
+    local align = pandoc.AlignDefault
+
+    -- At the time of writing this Pandoc does not support attributes
+    -- on list items, so we use empty spans as a workaround.
+    if contents[1] and contents[1].content then
+        if contents[1].content[1] and contents[1].content[1].t == "Span" then
+            if #contents[1].content[1].content == 0 then
+                attr = contents[1].content[1].attr
+                table.remove(contents[1].content, 1)
+                colspan = attr.attributes.colspan or 1
+                attr.attributes.colspan = nil
+                rowspan = attr.attributes.rowspan or 1
+                attr.attributes.rowspan = nil
+                align = alignments[attr.attributes.align] or pandoc.AlignDefault
+                attr.attributes.align = nil
+            end
+        end
+    end
+
+    return pandoc.Cell(contents, align, rowspan, colspan, attr)
+end
+
+local function process(div)
+    if div.attr.classes[1] ~= "list-table" then return nil end
+    table.remove(div.attr.classes, 1)
+
+    local caption = {}
+
+    if div.content[1].t == "Para" then
+        local para = table.remove(div.content, 1)
+        caption = {pandoc.Plain(para.content)}
+    end
+
+    assert(div.content[1].t == "BulletList",
+           "expected bullet list, found " .. div.content[1].t)
+    local list = div.content[1]
+
+    local rows = {}
+
+    for i = 1, #list.content do
+        assert(#list.content[i] == 1, "expected item to contain only one block")
+        assert(list.content[i][1].t == "BulletList",
+               "expected bullet list, found " .. list.content[i][1].t)
+        local cells = {}
+        for _, cell_content in pairs(list.content[i][1].content) do
+            table.insert(cells, new_cell(cell_content))
+        end
+        local row = pandoc.Row(cells)
+        table.insert(rows, row)
+    end
+
+    local header_row_count = tonumber(div.attr.attributes['header-rows']) or 1
+    div.attr.attributes['header-rows'] = nil
+
+    local header_col_count = tonumber(div.attr.attributes['header-cols']) or 0
+    div.attr.attributes['header-cols'] = nil
+
+    local column_count = 0
+    for i = 1, #row_cells(rows[1] or {}) do
+        column_count = column_count + row_cells(rows[1])[i].col_span
+    end
+
+    local colspecs = get_colspecs(div.attr.attributes, column_count)
+    local thead_rows = {}
+    for i = 1, header_row_count do
+        table.insert(thead_rows, table.remove(rows, 1))
+    end
+
+    return pandoc.Table(
+        {long = caption, short = {}},
+        colspecs,
+        pandoc.TableHead(thead_rows),
+        {new_table_body(rows, header_col_count)},
+        pandoc.TableFoot(),
+        div.attr
+    )
+end
+
+return {{Div = process}}

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.6.1.1
+version:            0.6.2.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca
@@ -121,6 +121,7 @@ common library-common
     , optics-core
     , optics-th
     , optparse-applicative
+    , pandoc
     , pandoc-link-context    >=1.4.0
     , pandoc-types
     , parsec

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -163,6 +163,7 @@ library
     Emanote.Model.Link.Resolve
     Emanote.Model.Meta
     Emanote.Model.Note
+    Emanote.Model.Note.Filter
     Emanote.Model.Query
     Emanote.Model.QuerySpec
     Emanote.Model.SData

--- a/src/Emanote/Model/Note/Filter.hs
+++ b/src/Emanote/Model/Note/Filter.hs
@@ -7,28 +7,23 @@ import Relude
 import System.Directory (doesFileExist)
 import System.FilePath (takeExtension)
 import Text.Pandoc (runIO)
-import Text.Pandoc.Builder qualified as B
 import Text.Pandoc.Definition (Pandoc (..))
 import Text.Pandoc.Filter qualified as PF
 
 -- TODO: The inline errors should be gathered in model, and reported during
 -- static site generation.
-applyPandocFilters :: MonadIO m => [FilePath] -> Pandoc -> m Pandoc
+applyPandocFilters :: (MonadIO m, MonadWriter [Text] m) => [FilePath] -> Pandoc -> m Pandoc
 applyPandocFilters paths doc = do
-  (doc', errs :: [Text]) <- runWriterT $ do
-    res <- traverse mkLuaFilter paths
-    forM_ (lefts res) $ \err ->
-      tell [err]
-    case rights res of
-      [] ->
-        pure doc
-      filters ->
-        applyPandocLuaFilters filters doc >>= \case
-          Left err -> tell [err] >> pure doc
-          Right x -> pure x
-  if null errs
-    then pure doc'
-    else pure $ pandocPrepend (errorDiv errs) doc'
+  res <- traverse mkLuaFilter paths
+  forM_ (lefts res) $ \err ->
+    tell [err]
+  case rights res of
+    [] ->
+      pure doc
+    filters ->
+      applyPandocLuaFilters filters doc >>= \case
+        Left err -> tell [err] >> pure doc
+        Right x -> pure x
 
 mkLuaFilter :: MonadIO m => FilePath -> m (Either Text PF.Filter)
 mkLuaFilter relPath = do
@@ -44,18 +39,3 @@ applyPandocLuaFilters filters x = do
   liftIO (runIO $ PF.applyFilters def filters ["markdown"] x) >>= \case
     Left err -> pure $ Left (show err)
     Right x' -> pure $ Right x'
-
--- | Prepend to block to the beginning of a Pandoc document (never before H1)
-pandocPrepend :: B.Block -> Pandoc -> Pandoc
-pandocPrepend prefix (Pandoc meta blocks) =
-  let blocks' = case blocks of
-        (h1@(B.Header 1 _ _) : rest) ->
-          h1 : prefix : rest
-        _ -> prefix : blocks
-   in Pandoc meta blocks'
-
-errorDiv :: [Text] -> B.Block
-errorDiv s =
-  B.Div (cls "emanote:error") $ B.Para [B.Strong $ one $ B.Str "Emanote Errors"] : (B.Para . one . B.Str <$> s)
-  where
-    cls x = ("", one x, mempty) :: B.Attr

--- a/src/Emanote/Model/Note/Filter.hs
+++ b/src/Emanote/Model/Note/Filter.hs
@@ -1,0 +1,61 @@
+module Emanote.Model.Note.Filter (applyPandocFilters) where
+
+import Control.Monad.Except
+import Control.Monad.Writer.Strict
+import Data.Default (def)
+import Relude
+import System.Directory (doesFileExist)
+import System.FilePath (takeExtension)
+import Text.Pandoc (runIO)
+import Text.Pandoc.Builder qualified as B
+import Text.Pandoc.Definition (Pandoc (..))
+import Text.Pandoc.Filter qualified as PF
+
+-- TODO: The inline errors should be gathered in model, and reported during
+-- static site generation.
+applyPandocFilters :: MonadIO m => [FilePath] -> Pandoc -> m Pandoc
+applyPandocFilters paths doc = do
+  (doc', errs :: [Text]) <- runWriterT $ do
+    res <- traverse mkLuaFilter paths
+    forM_ (lefts res) $ \err ->
+      tell [err]
+    case rights res of
+      [] ->
+        pure doc
+      filters ->
+        applyPandocLuaFilters filters doc >>= \case
+          Left err -> tell [err] >> pure doc
+          Right x -> pure x
+  if null errs
+    then pure doc'
+    else pure $ pandocPrepend (errorDiv errs) doc'
+
+mkLuaFilter :: MonadIO m => FilePath -> m (Either Text PF.Filter)
+mkLuaFilter relPath = do
+  if takeExtension relPath == ".lua"
+    then do
+      liftIO (doesFileExist relPath) >>= \case
+        True -> pure $ Right $ PF.LuaFilter relPath
+        False -> pure $ Left $ toText $ relPath <> " is missing"
+    else pure $ Left $ "Unsupported filter: " <> toText relPath
+
+applyPandocLuaFilters :: (MonadIO m) => [PF.Filter] -> Pandoc -> m (Either Text Pandoc)
+applyPandocLuaFilters filters x = do
+  liftIO (runIO $ PF.applyFilters def filters ["markdown"] x) >>= \case
+    Left err -> pure $ Left (show err)
+    Right x' -> pure $ Right x'
+
+-- | Prepend to block to the beginning of a Pandoc document (never before H1)
+pandocPrepend :: B.Block -> Pandoc -> Pandoc
+pandocPrepend prefix (Pandoc meta blocks) =
+  let blocks' = case blocks of
+        (h1@(B.Header 1 _ _) : rest) ->
+          h1 : prefix : rest
+        _ -> prefix : blocks
+   in Pandoc meta blocks'
+
+errorDiv :: [Text] -> B.Block
+errorDiv s =
+  B.Div (cls "emanote:error") $ B.Para [B.Strong $ one $ B.Str "Emanote Errors"] : (B.Para . one . B.Str <$> s)
+  where
+    cls x = ("", one x, mempty) :: B.Attr

--- a/src/Emanote/Model/Note/Filter.hs
+++ b/src/Emanote/Model/Note/Filter.hs
@@ -12,8 +12,6 @@ import Text.Pandoc (runIO)
 import Text.Pandoc.Definition (Pandoc (..))
 import Text.Pandoc.Filter qualified as PF
 
--- TODO: The inline errors should be gathered in model, and reported during
--- static site generation.
 applyPandocFilters :: (MonadIO m, MonadLogger m, MonadWriter [Text] m) => [FilePath] -> Pandoc -> m Pandoc
 applyPandocFilters paths doc = do
   res <- traverse mkLuaFilter paths
@@ -39,6 +37,7 @@ mkLuaFilter relPath = do
 applyPandocLuaFilters :: (MonadIO m, MonadLogger m) => [PF.Filter] -> Pandoc -> m (Either Text Pandoc)
 applyPandocLuaFilters filters x = do
   logW $ "[Experimental feature] Applying pandoc filters: " <> show filters
+  -- TODO: Can we constrain this to run Lua code purely (embedded) without using IO?
   liftIO (runIO $ PF.applyFilters def filters ["markdown"] x) >>= \case
     Left err -> pure $ Left (show err)
     Right x' -> pure $ Right x'

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -12,7 +12,7 @@ import Data.Some (Some)
 import Data.Time (UTCTime)
 import Data.Tree (Tree)
 import Data.Tree.Path qualified as PathTree
-import Data.UUID hiding (null)
+import Data.UUID (UUID)
 import Ema.CLI qualified
 import Ema.Route.Encoder (RouteEncoder)
 import Emanote.Model.Link.Rel (IxRel)

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -12,7 +12,7 @@ import Data.Some (Some)
 import Data.Time (UTCTime)
 import Data.Tree (Tree)
 import Data.Tree.Path qualified as PathTree
-import Data.UUID
+import Data.UUID hiding (null)
 import Ema.CLI qualified
 import Ema.Route.Encoder (RouteEncoder)
 import Emanote.Model.Link.Rel (IxRel)
@@ -209,3 +209,11 @@ modelNoteMetas model =
   Map.fromList $
     Ix.toList (_modelNotes model) <&> \note ->
       (note ^. N.noteRoute, (note ^. N.noteTitle, note ^. N.noteRoute, note ^. N.noteMeta))
+
+modelNoteErrors :: Model -> Map LMLRoute [Text]
+modelNoteErrors model =
+  Map.fromList $
+    flip mapMaybe (Ix.toList (_modelNotes model)) $ \note -> do
+      let errs = note ^. N.noteErrors
+      guard $ not $ null errs
+      pure (note ^. N.noteRoute, errs)

--- a/src/Emanote/Source/Dynamic.hs
+++ b/src/Emanote/Source/Dynamic.hs
@@ -39,9 +39,13 @@ emanoteModelDynamic cliAct enc cli = do
       Pattern.filePatterns
       Pattern.ignorePatterns
       initialModel
-      (mapFsChanges Patch.patchModel)
+      (mapFsChanges $ Patch.patchModel layers)
 
-type ChangeHandler tag model m = tag -> FilePath -> UM.FileAction (NonEmpty (Loc, FilePath)) -> m (model -> model)
+type ChangeHandler tag model m =
+  tag ->
+  FilePath ->
+  UM.FileAction (NonEmpty (Loc, FilePath)) ->
+  m (model -> model)
 
 mapFsChanges :: (MonadIO m, MonadLogger m) => ChangeHandler tag model m -> UM.Change Loc tag -> m (model -> model)
 mapFsChanges h ch = do

--- a/src/Emanote/Source/Loc.hs
+++ b/src/Emanote/Source/Loc.hs
@@ -10,9 +10,14 @@ module Emanote.Source.Loc
     -- * Using a `Loc`
     locResolve,
     locPath,
+
+    -- * Dealing with layers of locs
+    LocLayers,
+    immediateLayer,
   )
 where
 
+import Data.Set qualified as Set
 import Relude
 import System.FilePath ((</>))
 
@@ -25,6 +30,12 @@ data Loc
   | -- | The default location (ie., emanote default layer)
     LocDefault FilePath
   deriving stock (Eq, Ord, Show)
+
+type LocLayers = Set Loc
+
+-- | Return the `Loc` with highest precedence.
+immediateLayer :: HasCallStack => LocLayers -> Loc
+immediateLayer = Set.findMin
 
 defaultLayer :: FilePath -> Loc
 defaultLayer = LocDefault

--- a/src/Emanote/Source/Patch.hs
+++ b/src/Emanote/Source/Patch.hs
@@ -73,9 +73,9 @@ patchModel' fpType fp action = do
           UM.Refresh refreshAction overlays -> do
             let fpAbs = locResolve $ head overlays
             s <- readRefreshedFile refreshAction fpAbs
-            case N.parseNote r fpAbs (decodeUtf8 s) of
-              Left e ->
-                throw $ BadInput e
+            runExceptT (N.parseNote r fpAbs (decodeUtf8 s)) >>= \case
+              Left e -> do
+                throw e
               Right note ->
                 pure $ M.modelInsertNote note
           UM.Delete -> do

--- a/src/Emanote/Source/Patch.hs
+++ b/src/Emanote/Source/Patch.hs
@@ -81,7 +81,7 @@ patchModel' layers fpType fp action = do
             s <- readRefreshedFile refreshAction fpAbs
             runExceptT (N.parseNote currentLayerPath r fpAbs (decodeUtf8 s)) >>= \case
               Left e -> do
-                throw e
+                throw $ BadInput e
               Right note ->
                 pure $ M.modelInsertNote note
           UM.Delete -> do

--- a/src/Emanote/Source/Patch.hs
+++ b/src/Emanote/Source/Patch.hs
@@ -25,7 +25,7 @@ import Emanote.Prelude
 import Emanote.Route (liftLMLRoute)
 import Emanote.Route qualified as R
 import Emanote.Route.SiteRoute.Class (indexRoute)
-import Emanote.Source.Loc (Loc, locResolve)
+import Emanote.Source.Loc (Loc, LocLayers, immediateLayer, locPath, locResolve)
 import Emanote.Source.Pattern (filePatterns, ignorePatterns)
 import Heist.Extra.TemplateState qualified as T
 import Optics.Operators ((%~))
@@ -38,6 +38,7 @@ import UnliftIO.Directory (doesDirectoryExist)
 -- | Map a filesystem change to the corresponding model change.
 patchModel ::
   (MonadIO m, MonadLogger m, MonadLoggerIO m) =>
+  LocLayers ->
   -- | Type of the file being changed
   R.FileType R.SourceExt ->
   -- | Path to the file being changed
@@ -45,17 +46,18 @@ patchModel ::
   -- | Specific change to the file, along with its paths from other "layers"
   UM.FileAction (NonEmpty (Loc, FilePath)) ->
   m (Model -> Model)
-patchModel fpType fp action = do
+patchModel layers fpType fp action = do
   logger <- askLoggerIO
   now <- liftIO getCurrentTime
   -- Prefix all patch logging with timestamp.
   let newLogger loc src lvl s =
         logger loc src lvl $ fromString (formatTime defaultTimeLocale "[%H:%M:%S] " now) <> s
-  runLoggingT (patchModel' fpType fp action) newLogger
+  runLoggingT (patchModel' layers fpType fp action) newLogger
 
 -- | Map a filesystem change to the corresponding model change.
 patchModel' ::
   (MonadIO m, MonadLogger m) =>
+  LocLayers ->
   -- | Type of the file being changed
   R.FileType R.SourceExt ->
   -- | Path to the file being changed
@@ -63,7 +65,7 @@ patchModel' ::
   -- | Specific change to the file, along with its paths from other "layers"
   UM.FileAction (NonEmpty (Loc, FilePath)) ->
   m (Model -> Model)
-patchModel' fpType fp action = do
+patchModel' layers fpType fp action = do
   case fpType of
     R.LMLType R.Md ->
       case fmap liftLMLRoute . R.mkRouteFromFilePath @_ @('R.LMLType 'R.Md) $ fp of
@@ -72,8 +74,12 @@ patchModel' fpType fp action = do
         Just r -> case action of
           UM.Refresh refreshAction overlays -> do
             let fpAbs = locResolve $ head overlays
+                -- TODO: This should automatically be computed, instead of being passed.
+                -- We need to access to the model though! With dependency management to boot.
+                -- Until this, `layers` is threaded through as a hack.
+                currentLayerPath = locPath $ immediateLayer layers
             s <- readRefreshedFile refreshAction fpAbs
-            runExceptT (N.parseNote r fpAbs (decodeUtf8 s)) >>= \case
+            runExceptT (N.parseNote currentLayerPath r fpAbs (decodeUtf8 s)) >>= \case
               Left e -> do
                 throw e
               Right note ->


### PR DESCRIPTION
A start at #263 

**Goal**: Add very basic support for [Pandoc lua filters](https://pandoc.org/lua-filters.html) in this PR, so that we can start playing with it from today.  Advanced functionality will be implemented in a later PR at a later time (after user feedback, and further architectural thinking).

Limitations:
- Lua file path can be specified in frontmatter only. 
  - In the advanced version, we should support yaml data cascading.
- Lua file path ~~is resolved relative to the current directory~~ should be ~~relative to the highest precedent layer (notebook path, typically).~~
  - [x] In the advanced version, we should look it up in all layers (just as we do for Heist template files). 
- Changes to the Lua file don't necessarily hot-reload the model. Workaround: `touch` the .md file in question. 
  - In the advanced version, this should just work without any workarounds.

Resolving all of the above is outside of the scope of this PR. Doing them will require us to think about dependency handling in the model, which is complex to implement and needs to be thought about carefully. This will all be addressed in the advanced version.

This PR should allow people to transform their Markdown notes dynamically in Lua, experiment willy-nilly and give early feedback to shape final Lua support in Emanote.

Test with filters here: https://github.com/pandoc/lua-filters