### PR TITLE
Add Garnix CI & cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      # TODO: Use garnix cache
       - uses: cachix/cachix-action@v10
         with:
           name: srid

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -9,8 +9,10 @@ order: 1
 Emanote is supported on all popular operating systems through [Nix].
 
 1. Install [Nix] (for Windows, see [[wsl]] or [the Docker approach](https://github.com/srid/emanote/issues/230))
-2. Optional: Use build cache: `nix-env -if cachix && cachix use srid`
+2. Optional: Use build cache[^cache]: `nix-env -if cachix && cachix use srid`
 3. Run `nix-env -if https://github.com/srid/emanote/archive/refs/heads/master.tar.gz` to install Emanote
+
+[^cache]: This cache works only on Linux. If you are on macOS, use the [garnix cache](https://garnix.io/docs/caching).
 
 To test your Emanote install,
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   description = "emanote";
   nixConfig = {
-    extra-substituters = "https://srid.cachix.org";
-    extra-trusted-public-keys = "srid.cachix.org-1:MTQ6ksbfz3LBMmjyPh0PLmos+1x+CdtJxA/J2W+PQxI=";
+    extra-substituters = "https://cache.garnix.io";
+    extra-trusted-public-keys = "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=";
   };
   inputs = {
     ema.url = "github:srid/ema/multisite";

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,7 @@
+builds:
+  include:
+    - 'packages.x86_64-linux.*'
+    - 'packages.aarch64-darwin.*'
+    - 'devShell.x86_64-linux'
+    - 'devShell.aarch64-darwin'
+  exclude: []

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -3,5 +3,4 @@ builds:
     - 'packages.x86_64-linux.*'
     - 'packages.aarch64-darwin.*'
     - 'devShell.x86_64-linux'
-    - 'devShell.aarch64-darwin'
   exclude: []


### PR DESCRIPTION
Unlike GitHub Actions + Cachix, the use of Garnix gives us Nix cache for macOS too.

https://garnix.io/docs/caching

