### PR TITLE
cachix -> garnix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - nocachix
   pull_request:
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,25 +4,22 @@ on:
   push:
     branches:
       - master
+      - nocachix
   pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v17
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      # TODO: Use garnix cache
-      - uses: cachix/cachix-action@v10
-        with:
-          name: srid
-          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
-          # Only needed for private caches
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+            trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.garnix.io https://cache.nixos.org/
       - name: Cache Nix dependencies
         run: |
+          nix --version
           nix develop -j 4 -c echo
       - name: Format check
         run: |
@@ -33,9 +30,6 @@ jobs:
       - name: Build Nix
         id: build-nix
         run: |
-          [[ -n $(git status -s) ]] && (echo 'modified and/or untracked'; exit 2)
-          ls -la
-          nix --version
           nix build -j auto
       - name: Build as docker img
         id: build

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -9,10 +9,8 @@ order: 1
 Emanote is supported on all popular operating systems through [Nix].
 
 1. Install [Nix] (for Windows, see [[wsl]] or [the Docker approach](https://github.com/srid/emanote/issues/230))
-2. Optional: Use build cache[^cache]: `nix profile install nixpkgs#cachix && cachix use srid`
+2. Optional: Use Nix cache provided [by garnix](https://garnix.io/docs/caching)
 3. Run `nix profile install github:srid/emanote` to install Emanote
-
-[^cache]: This cache works only on Linux. If you are on macOS, use the [garnix cache](https://garnix.io/docs/caching).
 
 To test your Emanote install,
 


### PR DESCRIPTION
Cachix has been slowing down the CI lot. Switch to [garnix cache](https://garnix.io/docs/caching), which also provides macOS M1 cache.

- Almost 7 minutes just to push to cachix: https://github.com/srid/emanote/runs/6759476285?check_suite_focus=true

