### PR TITLE
Allow uptree nodes to be configured

### DIFF
--- a/default/index.yaml
+++ b/default/index.yaml
@@ -116,4 +116,7 @@ js:
     </script>
     <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
+emanote:
+  # Whether to automatically treat folder notes as a folgezettel parent of its contents
+  folder-folgezettel: true
 

--- a/docs/demo/neuron-layout.md
+++ b/docs/demo/neuron-layout.md
@@ -12,4 +12,4 @@ template:
   name: /templates/layouts/note
 ```
 
-The "note" layout includes the [uplink tree of Neuron](https://neuron.zettel.page/uplink-tree) based on folgezettel links as well as directory layout. Note that all top-level notes are automatically made a folgezettel branch of the root note (index), such that the "home" link appears on top in the uplink tree of all notes. As a demo, the page you are viewing is rendered using the "note" layout (whilst leaving the rest of the site to use the default "book" layout.)
+The "note" layout includes the [[uptree]] of Neuron based on folgezettel links as well as directory layout. Note that all top-level notes are automatically made a folgezettel branch of the root note (index), such that the "home" link appears on top in the uplink tree of all notes. As a demo, the page you are viewing is rendered using the "note" layout (whilst leaving the rest of the site to use the default "book" layout.)

--- a/docs/guide/uptree.md
+++ b/docs/guide/uptree.md
@@ -1,18 +1,21 @@
 # Uplink tree
 
-The _uplink tree_ or "uptree" is a feature available in the `note` template, which visualizes hierarchical relationships between notes as a graph at the top of the page.
+The _uplink tree_ or "uptree"[^neuron] is a feature available in #[[neuron-layout|the `note` template]], which visualizes hierarchical relationships between notes as a graph at the top of the page.
+
+[^neuron]: This feature was inspired by an equivalent feature [from Neuron](https://neuron.zettel.page/uplink-tree).
 
 These relationships are called by _folgezettel links_ and created with a special variation of emanote link syntax.
 
-Conceptually, a folgezettel link can be thought of as an arrow from a parent note to a descendent note.
+Conceptually, a [folgezettel](https://neuron.zettel.page/folgezettel-heterarchy) link can be thought of as an arrow from a parent note to a descendent note.
 
 ## Syntax
-```yaml
-A folgezettel link from another page to this one:
+
+```markdown
+## A folgezettel link from another page to this one:
 
 Here is the #[[source-note]]
 
-A folgezettel link from this page to another one:
+## A folgezettel link from this page to another one:
 
 Here is the [[target-note]]#
 ```
@@ -21,7 +24,7 @@ Here is the [[target-note]]#
 
 By default, Emanote also includes any directories in your note's path as vertices in the uptree graph.
 
-This behavior can be configured. To turn off the folder nodes, set to `false` the corresponding flag in your configuration as shown here:
+This behavior can be configured. To turn off the implicit folder nodes, set to `false` the corresponding flag in [[yaml-config|your configuration]] as shown here:
 
 ```yaml
 emanote:

--- a/docs/guide/uptree.md
+++ b/docs/guide/uptree.md
@@ -1,0 +1,31 @@
+# Uplink tree
+
+The _uplink tree_ or "uptree" is a feature available in the `note` template, which visualizes hierarchical relationships between notes as a graph at the top of the page.
+
+These relationships are called by _folgezettel links_ and created with a special variation of emanote link syntax.
+
+Conceptually, a folgezettel link can be thought of as an arrow from a parent note to a descendent note.
+
+## Syntax
+```yaml
+A folgezettel link from another page to this one:
+
+Here is the #[[source-note]]
+
+A folgezettel link from this page to another one:
+
+Here is the [[target-note]]#
+```
+
+## Folder nodes
+
+By default, Emanote also includes any directories in your note's path as vertices in the uptree graph.
+
+This behavior can be configured. To turn off the folder nodes, set to `false` the corresponding flag in your configuration as shown here:
+
+```yaml
+emanote:
+  # Whether to automatically treat folder notes as a folgezettel parent of its contents
+  folder-folgezettel: false
+```
+

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.6.12.0
+version:            0.6.13.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/Model/Graph.hs
+++ b/src/Emanote/Model/Graph.hs
@@ -8,6 +8,7 @@ import Data.Tree (Forest, Tree (Node))
 import Emanote.Model.Calendar qualified as Calendar
 import Emanote.Model.Link.Rel qualified as Rel
 import Emanote.Model.Link.Resolve qualified as Resolve
+import Emanote.Model.Meta (lookupRouteMeta)
 import Emanote.Model.Note qualified as MN
 import Emanote.Model.Type (Model, modelRels)
 import Emanote.Pandoc.Markdown.Syntax.WikiLink qualified as WL
@@ -36,7 +37,12 @@ modelFolgezettelAncestorTree r0 model =
             folgezettelBacklinks
               <> folgezettelFrontlinks
               -- Folders are automatically made a folgezettel
-              <> maybeToList (parentLmlRoute =<< leftToMaybe (R.modelRouteCase r))
+              <> maybeToList
+                ( do
+                    lmlR <- leftToMaybe (R.modelRouteCase r)
+                    guard $ lookupRouteMeta True ("emanote" :| ["folder-folgezettel"]) lmlR model
+                    parentLmlRoute lmlR
+                )
       fmap catMaybes . forM folgezettelParents $ \parentR -> do
         let parentModelR = R.ModelRoute_LML parentR
         gets (parentModelR `Set.member`) >>= \case


### PR DESCRIPTION
Hey there. We talked about this on Matrix a while back. 

Ive been happily using Emanote with a fork that only disabled this implicit node. So to get back on the main release, the presence needs to be configurable. This patch seems to accomplish that as intended.

This does raise the question about whether the special case for the root node is needed. If I were designing around only my preferred usage I would probably set the default value to False instead of True, and remove the special treatment of the root. But since the current behavior corresponds to your preference, I preserved that here. But it's worth noting that it's a possibility in the design space to skip that special treatment.

Feel free to make any branding suggestions. And I'd be happy to add something to documentation, if you have any thoughts on where I should put it (`guide.md`? `tips.md`?)