### PR TITLE
Simplify route types by dropping `world-peace`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,3 +1,7 @@
+# Ours
+- ignore: {name: Use camelCase }
+
+# Relude's hlint.yaml
 - arguments:
   - "-XConstraintKinds"
   - "-XDeriveGeneric"

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.6.11.1
+version:            0.6.12.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca
@@ -143,7 +143,6 @@ common library-common
     , uuid
     , which
     , with-utf8
-    , world-peace
     , xmlhtml
     , yaml
 

--- a/src/Emanote/Model/Graph.hs
+++ b/src/Emanote/Model/Graph.hs
@@ -72,7 +72,7 @@ parentLmlRoute r = do
     -- Consider the index route as parent folder for all
     -- top-level notes.
     pure $ fromMaybe R.indexRoute $ R.routeParent lmlR
-  pure $ R.liftLMLRoute @('R.LMLType 'R.Md) . coerce $ pr
+  pure $ R.liftLMLRoute . coerce $ pr
 
 modelLookupBacklinks :: ModelRoute -> Model -> [(R.LMLRoute, NonEmpty [B.Block])]
 modelLookupBacklinks r model =

--- a/src/Emanote/Model/Graph.hs
+++ b/src/Emanote/Model/Graph.hs
@@ -38,7 +38,7 @@ modelFolgezettelAncestorTree r0 model =
               -- Folders are automatically made a folgezettel
               <> maybeToList (parentLmlRoute =<< leftToMaybe (R.modelRouteCase r))
       fmap catMaybes . forM folgezettelParents $ \parentR -> do
-        let parentModelR = R.liftModelRoute . R.lmlRouteCase $ parentR
+        let parentModelR = R.ModelRoute_LML parentR
         gets (parentModelR `Set.member`) >>= \case
           True -> pure Nothing
           False -> do

--- a/src/Emanote/Model/Link/Resolve.hs
+++ b/src/Emanote/Model/Link/Resolve.hs
@@ -1,6 +1,5 @@
 module Emanote.Model.Link.Resolve where
 
-import Data.WorldPeace.Union (openUnionLift)
 import Emanote.Model.Link.Rel qualified as Rel
 import Emanote.Model.Note qualified as MN
 import Emanote.Model.StaticFile qualified as SF
@@ -24,9 +23,8 @@ resolveUnresolvedRelTarget model = \case
       <&> resourceSiteRoute
   Rel.URTVirtual virtualRoute -> do
     Rel.RRTFound $
-      SR.SiteRoute
-        ( openUnionLift virtualRoute
-        )
+      SR.SiteRoute_VirtualRoute
+        virtualRoute
 
 resolveWikiLinkMustExist ::
   Model -> WL.WikiLink -> Rel.ResolvedRelTarget (Either MN.Note SF.StaticFile)

--- a/src/Emanote/Model/Type.hs
+++ b/src/Emanote/Model/Type.hs
@@ -99,7 +99,7 @@ modelInsertNote note =
 
 injectAncestor :: N.RAncestor -> IxNote -> IxNote
 injectAncestor ancestor ns =
-  let lmlR = R.liftLMLRoute @('R.LMLType 'R.Md) . coerce $ N.unRAncestor ancestor
+  let lmlR = R.liftLMLRoute . coerce $ N.unRAncestor ancestor
    in case N.lookupNotesByRoute lmlR ns of
         Just _ -> ns
         Nothing -> Ix.updateIx lmlR (N.ancestorPlaceholderNote lmlR) ns

--- a/src/Emanote/Pandoc/BuiltinFilters.hs
+++ b/src/Emanote/Pandoc/BuiltinFilters.hs
@@ -6,7 +6,7 @@ where
 
 import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as HT
 import Emanote.Route (encodeRoute)
-import Emanote.Route.SiteRoute.Type (TagIndexR (TagIndexR), encodeTagIndexR)
+import Emanote.Route.SiteRoute.Type (encodeTagIndexR)
 import Relude
 import Text.Pandoc.Definition qualified as B
 import Text.Pandoc.Walk qualified as W
@@ -37,7 +37,7 @@ linkifyInlineTags =
       x
   where
     tagUrl =
-      toText . encodeRoute . encodeTagIndexR . TagIndexR . toList . HT.deconstructTag
+      toText . encodeRoute . encodeTagIndexR . toList . HT.deconstructTag
 
 withoutH1 :: B.Pandoc -> B.Pandoc
 withoutH1 (B.Pandoc meta (B.Header 1 _ _ : rest)) =

--- a/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/src/Emanote/Pandoc/Renderer/Url.hs
@@ -6,7 +6,6 @@ module Emanote.Pandoc.Renderer.Url
 where
 
 import Data.Text qualified as T
-import Data.WorldPeace.Union (absurdUnion)
 import Ema.Route.Encoder qualified as Ema
 import Emanote.Model (Model)
 import Emanote.Model qualified as M
@@ -17,7 +16,6 @@ import Emanote.Model.Title qualified as Tit
 import Emanote.Pandoc.Link qualified as Link
 import Emanote.Pandoc.Markdown.Syntax.WikiLink qualified as WL
 import Emanote.Pandoc.Renderer (PandocInlineRenderer)
-import Emanote.Prelude (h)
 import Emanote.Route qualified as R
 import Emanote.Route.SiteRoute qualified as SR
 import Heist.Extra.Splices.Pandoc qualified as HP
@@ -159,11 +157,9 @@ siteRouteDefaultInnerText model url = \case
   SR.SiteRoute_AmbiguousR _ _ -> Nothing
   SR.SiteRoute_VirtualRoute _ -> Nothing
   SR.SiteRoute_ResourceRoute resR ->
-    resR & absurdUnion
-      `h` ( \(lmlR :: R.LMLRoute) ->
-              Tit.toInlines . MN._noteTitle <$> M.modelLookupNoteByRoute lmlR model
-          )
-      `h` ( \(_ :: R.StaticFileRoute, _ :: FilePath) ->
-              -- Just append a file: prefix, to existing wiki-link.
-              pure $ B.Str "File:" : [B.Str url]
-          )
+    case resR of
+      SR.ResourceRoute_LML lmlR ->
+        Tit.toInlines . MN._noteTitle <$> M.modelLookupNoteByRoute lmlR model
+      SR.ResourceRoute_StaticFile _ _ ->
+        -- Just append a file: prefix, to existing wiki-link.
+        pure $ B.Str "File:" : [B.Str url]

--- a/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/src/Emanote/Pandoc/Renderer/Url.hs
@@ -156,7 +156,7 @@ nonEmptyInlines x =
 siteRouteDefaultInnerText :: Model -> Text -> SR.SiteRoute -> Maybe [B.Inline]
 siteRouteDefaultInnerText model url = \case
   SR.SiteRoute_MissingR _ -> Nothing
-  SR.SiteRoute_AmbiguousR _ -> Nothing
+  SR.SiteRoute_AmbiguousR _ _ -> Nothing
   SR.SiteRoute_VirtualRoute _ -> Nothing
   SR.SiteRoute_ResourceRoute resR ->
     resR & absurdUnion

--- a/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/src/Emanote/Pandoc/Renderer/Url.hs
@@ -154,19 +154,16 @@ nonEmptyInlines x =
   fromMaybe (one $ B.Str x) . nonEmpty
 
 siteRouteDefaultInnerText :: Model -> Text -> SR.SiteRoute -> Maybe [B.Inline]
-siteRouteDefaultInnerText model url (SR.SiteRoute sr) =
-  sr
-    & absurdUnion
-    `h` (\(SR.MissingR _) -> Nothing)
-    `h` (\(SR.AmbiguousR _) -> Nothing)
-    `h` ( \(resR :: SR.ResourceRoute) ->
-            resR & absurdUnion
-              `h` ( \(lmlR :: R.LMLRoute) ->
-                      Tit.toInlines . MN._noteTitle <$> M.modelLookupNoteByRoute lmlR model
-                  )
-              `h` ( \(_ :: R.StaticFileRoute, _ :: FilePath) ->
-                      -- Just append a file: prefix, to existing wiki-link.
-                      pure $ B.Str "File:" : [B.Str url]
-                  )
-        )
-    `h` (\(_ :: SR.VirtualRoute) -> Nothing)
+siteRouteDefaultInnerText model url = \case
+  SR.SiteRoute_MissingR _ -> Nothing
+  SR.SiteRoute_AmbiguousR _ -> Nothing
+  SR.SiteRoute_VirtualRoute _ -> Nothing
+  SR.SiteRoute_ResourceRoute resR ->
+    resR & absurdUnion
+      `h` ( \(lmlR :: R.LMLRoute) ->
+              Tit.toInlines . MN._noteTitle <$> M.modelLookupNoteByRoute lmlR model
+          )
+      `h` ( \(_ :: R.StaticFileRoute, _ :: FilePath) ->
+              -- Just append a file: prefix, to existing wiki-link.
+              pure $ B.Str "File:" : [B.Str url]
+          )

--- a/src/Emanote/Prelude.hs
+++ b/src/Emanote/Prelude.hs
@@ -5,12 +5,6 @@
 module Emanote.Prelude where
 
 import Control.Monad.Logger (MonadLogger, logDebugNS, logErrorNS, logInfoNS, logWarnNS)
-import Data.WorldPeace.Union
-  ( ElemRemove,
-    OpenUnion,
-    Remove,
-    openUnionHandle,
-  )
 import Relude
 
 -- | Monadic version of `chain`
@@ -44,9 +38,3 @@ logE = logErrorNS "emanote"
 
 logW :: MonadLogger m => Text -> m ()
 logW = logWarnNS "emanote"
-
--- OpenUnion
-
--- Just an alias to avoid having to write this repeatedly.
-h :: forall a (as :: [Type]) b. ElemRemove a as => (OpenUnion (Remove a as) -> b) -> (a -> b) -> OpenUnion as -> b
-h = openUnionHandle

--- a/src/Emanote/Route/ModelRoute.hs
+++ b/src/Emanote/Route/ModelRoute.hs
@@ -33,7 +33,7 @@ data ModelRoute
   deriving anyclass (ToJSON)
 
 -- | R to a note file in LML (lightweight markup language) format
-data LMLRoute
+newtype LMLRoute
   = LMLRoute_Md (R ('LMLType 'Md))
   deriving stock (Eq, Show, Ord, Generic)
   deriving anyclass (ToJSON)

--- a/src/Emanote/Route/ModelRoute.hs
+++ b/src/Emanote/Route/ModelRoute.hs
@@ -18,21 +18,10 @@ module Emanote.Route.ModelRoute
 where
 
 import Data.Aeson.Types (ToJSON)
-import Data.WorldPeace.Union
-  ( IsMember,
-    OpenUnion,
-    absurdUnion,
-    openUnionHandle,
-    openUnionLift,
-  )
-import Emanote.Route.Ext (FileType (AnyExt, LMLType), LML (Md), SourceExt)
+import Emanote.Route.Ext (FileType (AnyExt, LMLType), LML (Md))
 import Emanote.Route.R (R)
 import Emanote.Route.R qualified as R
 import Relude
-
-type LMLRoutes' =
-  '[ R ('LMLType 'Md)
-   ]
 
 type StaticFileRoute = R 'AnyExt
 
@@ -44,22 +33,23 @@ data ModelRoute
   deriving anyclass (ToJSON)
 
 -- | R to a note file in LML (lightweight markup language) format
-type LMLRoute = OpenUnion LMLRoutes'
+data LMLRoute
+  = LMLRoute_Md (R ('LMLType 'Md))
+  deriving stock (Eq, Show, Ord, Generic)
+  deriving anyclass (ToJSON)
 
+-- TODO: Revamp this, and make it work with .org, etc.
 liftLMLRoute ::
-  forall ext.
-  IsMember (R ext) LMLRoutes' =>
-  R (ext :: FileType SourceExt) ->
+  R ('LMLType 'Md) ->
   LMLRoute
 liftLMLRoute =
-  openUnionLift
+  LMLRoute_Md
 
 lmlRouteCase ::
   LMLRoute ->
   R ('LMLType 'Md)
-lmlRouteCase =
-  absurdUnion
-    `openUnionHandle` id
+lmlRouteCase = \case
+  LMLRoute_Md r -> r
 
 modelRouteCase ::
   ModelRoute ->

--- a/src/Emanote/Route/SiteRoute.hs
+++ b/src/Emanote/Route/SiteRoute.hs
@@ -6,7 +6,7 @@ module Emanote.Route.SiteRoute
     TasksR (..),
     MissingR (..),
     AmbiguousR (..),
-    VirtualRoute,
+    VirtualRoute (..),
     ResourceRoute,
     decodeVirtualRoute,
     noteFileSiteRoute,

--- a/src/Emanote/Route/SiteRoute.hs
+++ b/src/Emanote/Route/SiteRoute.hs
@@ -1,7 +1,7 @@
 module Emanote.Route.SiteRoute
   ( SiteRoute (..),
     VirtualRoute (..),
-    ResourceRoute,
+    ResourceRoute (..),
     decodeVirtualRoute,
     noteFileSiteRoute,
     staticFileSiteRoute,

--- a/src/Emanote/Route/SiteRoute.hs
+++ b/src/Emanote/Route/SiteRoute.hs
@@ -1,11 +1,5 @@
 module Emanote.Route.SiteRoute
   ( SiteRoute (..),
-    IndexR (..),
-    ExportR (..),
-    TagIndexR (..),
-    TasksR (..),
-    MissingR (..),
-    AmbiguousR (..),
     VirtualRoute (..),
     ResourceRoute,
     decodeVirtualRoute,

--- a/src/Emanote/Route/SiteRoute/Class.hs
+++ b/src/Emanote/Route/SiteRoute/Class.hs
@@ -64,10 +64,10 @@ emanoteGeneratableRoutes model =
                   concat $
                     tags <&> \(HT.deconstructTag -> tagPath) ->
                       NE.filter (not . null) $ NE.inits tagPath
-         in openUnionLift IndexR :
-            openUnionLift ExportR :
-            openUnionLift TasksR :
-            (openUnionLift . TagIndexR <$> toList tagPaths)
+         in VirtualRoute_IndexR :
+            VirtualRoute_ExportR :
+            VirtualRoute_TasksR :
+            (VirtualRoute_TagIndexR <$> toList tagPaths)
    in htmlRoutes
         <> staticRoutes
         <> fmap SiteRoute_VirtualRoute virtualRoutes
@@ -204,15 +204,12 @@ indexLmlRoute =
 
 indexRoute :: SiteRoute
 indexRoute =
-  let virtR :: VirtualRoute = openUnionLift IndexR
-   in SiteRoute_VirtualRoute virtR
+  SiteRoute_VirtualRoute VirtualRoute_IndexR
 
 tagIndexRoute :: [HT.TagNode] -> SiteRoute
-tagIndexRoute (TagIndexR -> tagR) =
-  let virtR :: VirtualRoute = openUnionLift tagR
-   in SiteRoute_VirtualRoute virtR
+tagIndexRoute =
+  SiteRoute_VirtualRoute . VirtualRoute_TagIndexR
 
 taskIndexRoute :: SiteRoute
 taskIndexRoute =
-  let virtR :: VirtualRoute = openUnionLift TasksR
-   in SiteRoute_VirtualRoute virtR
+  SiteRoute_VirtualRoute VirtualRoute_TasksR

--- a/src/Emanote/Route/SiteRoute/Class.hs
+++ b/src/Emanote/Route/SiteRoute/Class.hs
@@ -59,10 +59,10 @@ emanoteGeneratableRoutes model =
                   concat $
                     tags <&> \(HT.deconstructTag -> tagPath) ->
                       NE.filter (not . null) $ NE.inits tagPath
-         in VirtualRoute_IndexR :
-            VirtualRoute_ExportR :
-            VirtualRoute_TasksR :
-            (VirtualRoute_TagIndexR <$> toList tagPaths)
+         in VirtualRoute_Index :
+            VirtualRoute_Export :
+            VirtualRoute_TaskIndex :
+            (VirtualRoute_TagIndex <$> toList tagPaths)
    in htmlRoutes
         <> staticRoutes
         <> fmap SiteRoute_VirtualRoute virtualRoutes
@@ -192,12 +192,12 @@ indexLmlRoute =
 
 indexRoute :: SiteRoute
 indexRoute =
-  SiteRoute_VirtualRoute VirtualRoute_IndexR
+  SiteRoute_VirtualRoute VirtualRoute_Index
 
 tagIndexRoute :: [HT.TagNode] -> SiteRoute
 tagIndexRoute =
-  SiteRoute_VirtualRoute . VirtualRoute_TagIndexR
+  SiteRoute_VirtualRoute . VirtualRoute_TagIndex
 
 taskIndexRoute :: SiteRoute
 taskIndexRoute =
-  SiteRoute_VirtualRoute VirtualRoute_TasksR
+  SiteRoute_VirtualRoute VirtualRoute_TaskIndex

--- a/src/Emanote/Route/SiteRoute/Class.hs
+++ b/src/Emanote/Route/SiteRoute/Class.hs
@@ -188,7 +188,7 @@ urlStrategy =
 
 indexLmlRoute :: LMLRoute
 indexLmlRoute =
-  R.liftLMLRoute @('R.LMLType 'R.Md) $ R.indexRoute
+  R.liftLMLRoute R.indexRoute
 
 indexRoute :: SiteRoute
 indexRoute =

--- a/src/Emanote/Route/SiteRoute/Type.hs
+++ b/src/Emanote/Route/SiteRoute/Type.hs
@@ -21,10 +21,10 @@ import Text.Show (show)
 
 -- | A route to a virtual resource (not in `Model`)
 data VirtualRoute
-  = VirtualRoute_IndexR
-  | VirtualRoute_TagIndexR [HT.TagNode]
-  | VirtualRoute_ExportR
-  | VirtualRoute_TasksR
+  = VirtualRoute_Index
+  | VirtualRoute_TagIndex [HT.TagNode]
+  | VirtualRoute_Export
+  | VirtualRoute_TaskIndex
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (ToJSON)
 
@@ -62,10 +62,10 @@ instance Show SiteRoute where
 
 decodeVirtualRoute :: FilePath -> Maybe VirtualRoute
 decodeVirtualRoute fp =
-  (VirtualRoute_IndexR <$ decodeIndexR fp)
-    <|> (VirtualRoute_TagIndexR <$> decodeTagIndexR fp)
-    <|> (VirtualRoute_ExportR <$ decodeExportR fp)
-    <|> (VirtualRoute_TasksR <$ decodeTasksR fp)
+  (VirtualRoute_Index <$ decodeIndexR fp)
+    <|> (VirtualRoute_TagIndex <$> decodeTagIndexR fp)
+    <|> (VirtualRoute_Export <$ decodeExportR fp)
+    <|> (VirtualRoute_TaskIndex <$ decodeTaskIndexR fp)
 
 decodeIndexR :: FilePath -> Maybe ()
 decodeIndexR fp = do
@@ -82,8 +82,8 @@ decodeTagIndexR fp = do
   "-" :| "tags" : tagPath <- pure $ R.unRoute $ R.decodeHtmlRoute fp
   pure $ fmap (HT.TagNode . Slug.unSlug) tagPath
 
-decodeTasksR :: FilePath -> Maybe ()
-decodeTasksR fp = do
+decodeTaskIndexR :: FilePath -> Maybe ()
+decodeTaskIndexR fp = do
   "-" :| ["tasks"] <- pure $ R.unRoute $ R.decodeHtmlRoute fp
   pass
 
@@ -91,13 +91,13 @@ decodeTasksR fp = do
 -- the decoders above.
 encodeVirtualRoute :: VirtualRoute -> FilePath
 encodeVirtualRoute = \case
-  VirtualRoute_TagIndexR tagNodes ->
+  VirtualRoute_TagIndex tagNodes ->
     R.encodeRoute $ encodeTagIndexR tagNodes
-  VirtualRoute_IndexR ->
+  VirtualRoute_Index ->
     R.encodeRoute $ R.R @() @'Ext.Html $ "-" :| ["all"]
-  VirtualRoute_ExportR ->
+  VirtualRoute_Export ->
     R.encodeRoute $ R.R @Ext.SourceExt @'Ext.AnyExt $ "-" :| ["export.json"]
-  VirtualRoute_TasksR ->
+  VirtualRoute_TaskIndex ->
     R.encodeRoute $ R.R @() @'Ext.Html $ "-" :| ["tasks"]
 
 encodeTagIndexR :: [HT.TagNode] -> R.R 'Ext.Html

--- a/src/Emanote/View/Common.hs
+++ b/src/Emanote/View/Common.hs
@@ -140,7 +140,7 @@ commonSplices withCtx model meta routeTitle = do
   -- get the full URL. The reason there is no slash in between is to account for
   -- the usual case of homeUrl being an empty string.
   "ema:homeUrl"
-    ## ( let homeR = SR.lmlSiteRoute $ R.liftLMLRoute @('R.LMLType 'R.Md) R.indexRoute
+    ## ( let homeR = SR.lmlSiteRoute $ R.liftLMLRoute R.indexRoute
              homeUrl' = SR.siteRouteUrl model homeR
              homeUrl = if homeUrl' /= "" then homeUrl' <> "/" else homeUrl'
           in HI.textSplice homeUrl

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -131,7 +131,7 @@ renderLmlHtml model note = do
     -- Note stuff
     "ema:note:title"
       ## C.titleSplice ctx (note ^. MN.noteTitle)
-    let modelRoute = R.liftModelRoute . R.lmlRouteCase $ r
+    let modelRoute = R.ModelRoute_LML r
     "ema:note:source-path"
       ## HI.textSplice (toText . R.encodeRoute . R.lmlRouteCase $ r)
     "ema:note:backlinks"

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -49,14 +49,14 @@ render m sr =
   let setErrorPageMeta =
         MN.noteMeta .~ SData.mergeAesons (withTemplateName "/templates/error" :| [withSiteTitle "Emanote Error"])
    in case sr of
-        SR.SiteRoute_MissingR (SR.MissingR urlPath) -> do
+        SR.SiteRoute_MissingR urlPath -> do
           let hereRoute = R.liftLMLRoute @('LMLType 'Md) . coerce $ R.decodeHtmlRoute urlPath
               note404 =
                 MN.missingNote hereRoute (toText urlPath)
                   & setErrorPageMeta
                   & MN.noteTitle .~ "! Missing link"
           Ema.AssetGenerated Ema.Html $ renderLmlHtml m note404
-        SR.SiteRoute_AmbiguousR (SR.AmbiguousR (urlPath, notes)) -> do
+        SR.SiteRoute_AmbiguousR urlPath notes -> do
           let noteAmb =
                 MN.ambiguousNoteURL urlPath notes
                   & setErrorPageMeta

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -46,7 +46,7 @@ render m sr =
         MN.noteMeta .~ SData.mergeAesons (withTemplateName "/templates/error" :| [withSiteTitle "Emanote Error"])
    in case sr of
         SR.SiteRoute_MissingR urlPath -> do
-          let hereRoute = R.liftLMLRoute @('LMLType 'Md) . coerce $ R.decodeHtmlRoute urlPath
+          let hereRoute = R.liftLMLRoute . coerce $ R.decodeHtmlRoute urlPath
               note404 =
                 MN.missingNote hereRoute (toText urlPath)
                   & setErrorPageMeta

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -75,13 +75,13 @@ renderResourceRoute m = \case
 
 renderVirtualRoute :: Model -> SR.VirtualRoute -> Ema.Asset LByteString
 renderVirtualRoute m = \case
-  SR.VirtualRoute_TagIndexR mtag ->
+  SR.VirtualRoute_TagIndex mtag ->
     Ema.AssetGenerated Ema.Html $ TagIndex.renderTagIndex m mtag
-  SR.VirtualRoute_IndexR ->
+  SR.VirtualRoute_Index ->
     Ema.AssetGenerated Ema.Html $ renderSRIndex m
-  SR.VirtualRoute_ExportR ->
+  SR.VirtualRoute_Export ->
     Ema.AssetGenerated Ema.Other $ renderGraphExport m
-  SR.VirtualRoute_TasksR ->
+  SR.VirtualRoute_TaskIndex ->
     Ema.AssetGenerated Ema.Html $ TaskIndex.renderTasks m
 
 renderSRIndex :: Model -> LByteString

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -81,20 +81,15 @@ renderResourceRoute m =
         )
 
 renderVirtualRoute :: Model -> SR.VirtualRoute -> Ema.Asset LByteString
-renderVirtualRoute m =
-  absurdUnion
-    `h` ( \(SR.TagIndexR mtag) ->
-            Ema.AssetGenerated Ema.Html $ TagIndex.renderTagIndex m mtag
-        )
-    `h` ( \SR.IndexR ->
-            Ema.AssetGenerated Ema.Html $ renderSRIndex m
-        )
-    `h` ( \SR.ExportR ->
-            Ema.AssetGenerated Ema.Other $ renderGraphExport m
-        )
-    `h` ( \SR.TasksR ->
-            Ema.AssetGenerated Ema.Html $ TaskIndex.renderTasks m
-        )
+renderVirtualRoute m = \case
+  SR.VirtualRoute_TagIndexR mtag ->
+    Ema.AssetGenerated Ema.Html $ TagIndex.renderTagIndex m mtag
+  SR.VirtualRoute_IndexR ->
+    Ema.AssetGenerated Ema.Html $ renderSRIndex m
+  SR.VirtualRoute_ExportR ->
+    Ema.AssetGenerated Ema.Other $ renderGraphExport m
+  SR.VirtualRoute_TasksR ->
+    Ema.AssetGenerated Ema.Html $ TaskIndex.renderTasks m
 
 renderSRIndex :: Model -> LByteString
 renderSRIndex model = do


### PR DESCRIPTION
In preparation for doing #18 (which also necessitates revamping `Ext.hs`, but that will happen in a different PR).

Open union types are unnecessary here. 