### PR TITLE
Add `default.nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/12c64ca55c1014cdc1b16ed5a804aa8576601ff2.tar.gz";
+      sha256 = "0jm6nzb83wa6ai17ly9fzpqc40wg1viib8klq8lby54agpl213w5";
+    }
+  )
+  {
+    src = ./.;
+  }).defaultNix


### PR DESCRIPTION
This PR adds a default.nix so that one can still use this repo from a legacy nix system.

More info here: https://nixos.wiki/wiki/Flakes#Using_flakes_project_from_a_legacy_Nix