### PR TITLE
orgmode: support `#+TITLE`

### DIFF
--- a/docs/demo/orgmode.org
+++ b/docs/demo/orgmode.org
@@ -1,4 +1,5 @@
-* Org Mode 
+#+TITLE: Org Mode
+
 Emanote provides first-class support for [[file:markdown.md][Markdown]]. But it also supports secondary formats (albeit not necessarily with the same level of support) beginning with [[https://orgmode.org/][Org Mode]]. See Pandoc's [[https://pandoc.org/org.html][Org section]] for information on controlling the parsing.
 
 **WARNING**: This is a =🧪 beta 🧪= feature.
@@ -34,4 +35,4 @@ If $a^2=b$ and \( b=2 \), then the solution must be
 either $$ a=+\sqrt{2} $$ or \[ a=-\sqrt{2} \]
 
 ** Limitations
-- =#+TITLE= and other metadata is not recognized (yet). Org Mode has no notion of a "frontmatter", therefore you must store file-associated metadata in a separate [[file:yaml-config.md][YAML file]].
+- While =#+TITLE= is recognized, other metadata are not recognized (yet). Org Mode has no notion of a "frontmatter", therefore you must store file-associated metadata in a separate [[file:yaml-config.md][YAML file]].

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.6.14.0
+version:            0.6.15.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/Pandoc/BuiltinFilters.hs
+++ b/src/Emanote/Pandoc/BuiltinFilters.hs
@@ -4,18 +4,23 @@ module Emanote.Pandoc.BuiltinFilters
   )
 where
 
+import Emanote.Model.Note qualified as N
 import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as HT
 import Emanote.Route (encodeRoute)
+import Emanote.Route.ModelRoute qualified as R
 import Emanote.Route.SiteRoute.Type (encodeTagIndexR)
+import Optics.Core ((^.))
 import Relude
 import Text.Pandoc.Definition qualified as B
 import Text.Pandoc.Walk qualified as W
 
 -- TODO: Run this in `parseNote`?
-prepareNoteDoc :: B.Pandoc -> B.Pandoc
-prepareNoteDoc =
-  preparePandoc
-    >>> withoutH1 -- Because, handling note title separately
+prepareNoteDoc :: N.Note -> B.Pandoc
+prepareNoteDoc note =
+  let doc' = preparePandoc $ note ^. N.noteDoc
+   in if R.isMdRoute (note ^. N.noteRoute)
+        then withoutH1 doc'
+        else doc'
 
 preparePandoc :: W.Walkable B.Inline b => b -> b
 preparePandoc =

--- a/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -68,7 +68,7 @@ embedResourceRoute model ctx note = do
     "ema:note:title" ## Tit.titleSplice ctx preparePandoc (MN._noteTitle note)
     "ema:note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute $ note ^. MN.noteRoute)
     "ema:note:pandoc"
-      ## pandocSplice ctx (prepareNoteDoc $ MN._noteDoc note)
+      ## pandocSplice ctx (prepareNoteDoc note)
 
 embedStaticFileRoute :: Model -> WL.WikiLink -> SF.StaticFile -> Maybe (HI.Splice Identity)
 embedStaticFileRoute model wl staticFile = do

--- a/src/Emanote/Route/ModelRoute.hs
+++ b/src/Emanote/Route/ModelRoute.hs
@@ -16,6 +16,7 @@ module Emanote.Route.ModelRoute
     withLmlRoute,
     mkLMLRouteFromFilePath,
     mkLMLRouteFromKnownFilePath,
+    isMdRoute,
     -- Static file routes
     StaticFileRoute,
   )
@@ -59,6 +60,11 @@ lmlRouteCase ::
 lmlRouteCase = \case
   LMLRoute_Md r -> Left r
   LMLRoute_Org r -> Right r
+
+isMdRoute :: LMLRoute -> Bool
+isMdRoute = \case
+  LMLRoute_Md _ -> True
+  _ -> False
 
 withLmlRoute :: (forall lmlType. HasExt ('LMLType lmlType) => R ('LMLType lmlType) -> r) -> LMLRoute -> r
 withLmlRoute f = either f f . lmlRouteCase

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -150,7 +150,7 @@ renderLmlHtml model note = do
     "ema:note:pandoc"
       ## C.withBlockCtx ctx
       $ \ctx' ->
-        Splices.pandocSplice ctx' (prepareNoteDoc $ MN._noteDoc note)
+        Splices.pandocSplice ctx' (prepareNoteDoc note)
 
 -- | If there is no 'current route', all sub-trees are marked as active/open.
 routeTreeSplice ::


### PR DESCRIPTION
Without this, it can be confusing to open foo.org and see 'RANDOM STUFF' in title.