### PR TITLE
Add ignore on vim writebackup files

### DIFF
--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.6.17.1
+version:            0.6.18.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/Source/Pattern.hs
+++ b/src/Emanote/Source/Pattern.hs
@@ -35,6 +35,8 @@ ignorePatterns :: [FilePattern]
 ignorePatterns =
   [ -- Ignore all dotfile directories (eg: .git, .vscode)
     "**/.*/**",
+    -- Ignore vi/vim/neovim writebackup files (see ":help writebackup")
+    "**/*~",
     -- /Top-level ./-/ directory is reserved by Emanote
     "-/**"
   ]


### PR DESCRIPTION
Adds ignore pattern for Vi/Vim/Neovim writebackup files (`:help writebackup`)

However emanote seems to be too fast so it still notices that the file gets replaced and removes it before adding it back. The frontend doesn't seem to notice when I've manually tested it, but the logs suggest possible minor issues?

When editing via Vim (with this PR's changes included):

```log
[Info#emanote] [15:52:41] Re-registering file: ./docs/4913 R[/4913]
[Info#emanote] [15:52:41] Removing note: guide.md
[Info#emanote] [15:52:41] Reading file: ./docs/guide.md
[Info#emanote] [15:52:47] Re-registering file: ./docs/4913 R[/4913]
[Info#emanote] [15:52:47] Removing note: guide.md
[Info#emanote] [15:52:47] Reading file: ./docs/guide.md
[Info#emanote] [15:52:50] Re-registering file: ./docs/4913 R[/4913]
[Info#emanote] [15:52:50] Removing note: guide.md
[Info#emanote] [15:52:50] Reading file: ./docs/guide.md
```

When editing via Vim with writebackup disabled (`:set nowritebackup`) or via some other text editor such as the [Gnome Text Editor](https://gitlab.gnome.org/GNOME/gnome-text-editor):

```log
[Info#emanote] [15:54:39] Reading file: ./docs/guide.md
[Info#emanote] [15:54:41] Reading file: ./docs/guide.md
[Info#emanote] [15:54:43] Reading file: ./docs/guide.md
[Info#emanote] [15:54:44] Reading file: ./docs/guide.md
```

Maybe could help to add a short delay before emanote declares a file removed? Or is this an OK issue as there's no visible artifacts when actually editing a page?

Closes #316
