### PR TITLE
Display task checkboxes in backlinks and timeline (close #187)

### DIFF
--- a/default/templates/components/context.tpl
+++ b/default/templates/components/context.tpl
@@ -8,6 +8,16 @@
         </PandocLink>
         <OrderedList class="ml-4 space-y-1 list-decimal list-inside" />
         <BulletList class="ml-4 space-y-1 list-decimal list-inside" />
+        <Task:Checked>
+          <apply template="/templates/components/checkbox-checked">
+            <inlines />
+          </apply>
+        </Task:Checked>
+        <Task:Unchecked>
+          <apply template="/templates/components/checkbox-unchecked">
+            <inlines />
+          </apply>
+        </Task:Unchecked>
       </context:body>
     </div>
   </context>

--- a/docs/demo/markdown.md
+++ b/docs/demo/markdown.md
@@ -41,6 +41,7 @@ Demo: Checkout this note[^1] and this other note[^2] as both are footnotes. You 
 
 - [x] A task that was done
 - [ ] A task that is to be done.
+- [ ] Task with *Markdown* and links (eg: [[lua-filters]])
 - A list item with no task marker
 
 Tasks can also be written outside of list context, such as paragraphs:

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.6.18.0
+version:            0.6.19.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
Closes #187. It works. Unfortunately I duplicate the code from `pandoc.tpl`. I don't know if this can be avoided without too much effort.