### PR TITLE
`nix build` of a Emanote website failing with unicode related errors

### DIFF
--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.6.23.0
+version:            0.6.23.1
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/nix/emanote.nix
+++ b/nix/emanote.nix
@@ -86,7 +86,6 @@ in
                   text = ''
                     set -xe
                     cd ${cfg.pathString} 
-                    export LANG=C.UTF-8 LC_ALL=C.UTF-8  # https://github.com/EmaApps/emanote/issues/125
                     ${config.emanote.package}/bin/emanote run ${if cfg.port == 0 then "" else "--port ${toString cfg.port}"}
                   '';
                 }) + /bin/emanoteRun.sh;
@@ -108,10 +107,11 @@ in
                 pkgs.runCommand "emanote-static-website" { }
                   ''
                     mkdir $out
+                    export LANG=C.UTF-8 LC_ALL=C.UTF-8  # https://github.com/EmaApps/emanote/issues/125
                     ${pkgs.lib.getExe config.emanote.package} \
-                    --layers "${configDir};${cfg.path}" \
-                    ${if cfg.allowBrokenLinks then "--allow-broken-links" else ""} \
-                      gen $out
+                      --layers "${configDir};${cfg.path}" \
+                      ${if cfg.allowBrokenLinks then "--allow-broken-links" else ""} \
+                        gen $out
                   '';
             })
             config.emanote.sites;

--- a/nix/emanote.nix
+++ b/nix/emanote.nix
@@ -86,6 +86,7 @@ in
                   text = ''
                     set -xe
                     cd ${cfg.pathString} 
+                    export LANG=C.UTF-8 LC_ALL=C.UTF-8  # https://github.com/EmaApps/emanote/issues/125
                     ${config.emanote.package}/bin/emanote run ${if cfg.port == 0 then "" else "--port ${toString cfg.port}"}
                   '';
                 }) + /bin/emanoteRun.sh;


### PR DESCRIPTION
Trying to fix

https://github.com/srid/srid/runs/7814003596?check_suite_focus=true

<img width="715" alt="image" src="https://user-images.githubusercontent.com/3998/184448018-5b148b52-b31e-4ffc-99a7-e4d986bdace2.png">

cf. https://github.com/EmaApps/emanote/issues/125