### PR TITLE
Added missing <with> to highlightjs example

### DIFF
--- a/docs/tips/js/syntax-highlighting.md
+++ b/docs/tips/js/syntax-highlighting.md
@@ -23,7 +23,9 @@ Bear in mind that when using highlight.js you must manually add language support
 page:
   headHtml: |
     <snippet var="js.highlightjs" />
+    <with var="js">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/${value:highlightjs-ver}/languages/haskell.min.js"></script>
+    </with>
 ```
 
 (The `highlightjs-ver` variable also comes from the default `index.yaml`)


### PR DESCRIPTION
The highlightjs docs doesn't work out of the box. Need the `<with var="js">` node to get the version variable to resolve.
