### PR TITLE
docs: minor fixes

### DIFF
--- a/docs/guide/markdown/embed.md
+++ b/docs/guide/markdown/embed.md
@@ -22,9 +22,9 @@ Embedding a note will simply inline it. For example, using `![[start]]` displays
 Embedding of [[file-links]], as indicated in the aforementioned Obsidian help page, will eventually be supported; for now, certain file types already work.
 
 See https://github.com/srid/emanote/issues/24 for progress.
-### Images 
+### Images
 
-Embedding image files as, say, `![[disaster-girl.jpg]]` is equivalent to `![](path/to/disaster-girl.jpg))` (this example links to [[disaster-girl.jpg|this image]]).  See also the tip: [[adding-images]].
+Embedding image files as, say, `![[disaster-girl.jpg]]` is equivalent to `![](path/to/disaster-girl.jpg)` (this example links to [[disaster-girl.jpg|this image]]).  See also the tip: [[adding-images]].
 
 [![[disaster-girl.jpg]]](https://knowyourmeme.com/memes/disaster-girl)
 

--- a/docs/guide/markdown/file-links.md
+++ b/docs/guide/markdown/file-links.md
@@ -2,10 +2,10 @@
 
 `[[..]]` style wikilinks can link to not only Markdown files, but also to any *other* files.
 
-For example, 
+For example,
 
 - Here is a link to some text file: [[Sample.txt]]
-- You can also specify the full, or subset of, the path: [[demo/Sample.txt]]
+- You can also specify the full, or subset of, the path: [[markdown/Sample.txt]]
 - Of course, a custom link text may also be specified: [[Sample.txt|Some text file]]
 - All of this is equivalent to [normal linking](./Sample.txt).
 


### PR DESCRIPTION
Remove extraneous right bracket in `docs/guide/markdown/embed.md`.

Fix link in `docs/guide/markdown/file-links.md` broken during reorganization.