### PR TITLE
Apply builtin Pandoc filters to backlink note excerpts

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -115,7 +115,7 @@ Ordered lists,
 
 ## Hash Tags
 
-Add Twitter-like hashtags anywhere in Markdown file. They can also be added to the YAML frontmatter. Hash tags can also be "hierarchical", for instance: #emanote/syntax/demo
+Add Twitter-like hashtags anywhere in Markdown file. They can also be added to the [[yaml-config|YAML frontmatter]]. Hash tags can also be "hierarchical", for instance: #emanote/syntax/demo
 
 ## Highlighting
 

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.7.13.0
+version:            0.7.14.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -16,7 +16,7 @@ import Emanote.Model.Meta qualified as Meta
 import Emanote.Model.Note qualified as MN
 import Emanote.Model.SData qualified as SData
 import Emanote.Model.Stork (renderStorkIndex)
-import Emanote.Pandoc.BuiltinFilters (prepareNoteDoc)
+import Emanote.Pandoc.BuiltinFilters (prepareNoteDoc, preparePandoc)
 import Emanote.Route qualified as R
 import Emanote.Route.SiteRoute (SiteRoute)
 import Emanote.Route.SiteRoute qualified as SR
@@ -146,7 +146,7 @@ renderLmlHtml model note = do
               "backlink:note:title" ## C.titleSplice bctx (M.modelLookupTitle source model)
               "backlink:note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute source)
               "backlink:note:contexts" ## Splices.listSplice (toList contexts) "context" $ \backlinkCtx -> do
-                let ctxDoc :: Pandoc = Pandoc mempty $ one $ B.Div B.nullAttr backlinkCtx
+                let ctxDoc :: Pandoc = preparePandoc $ Pandoc mempty $ one $ B.Div B.nullAttr backlinkCtx
                 "context:body" ## C.withInlineCtx bctx $ \ctx' ->
                   Splices.pandocSplice ctx' ctxDoc
     -- Sidebar navigation


### PR DESCRIPTION
This addresses the issue I noticed in another PR https://github.com/EmaApps/emanote/pull/189#issuecomment-1279490368:

> I've just found out that the builtin filters are not applied to the note excerpts in the backlinks ("Links to this page") section. [...] this also means that tags are not converted to links and that the emoji don't get their `font-family: emoji styling`. Is this behavior intended? It looks like a bug.

Perhaps the approach in the following TODO would be better: https://github.com/EmaApps/emanote/blob/65dd75053674aaf4fc36c0ad689938c8d6158e2e/src/Emanote/Pandoc/BuiltinFilters.hs#L16

but it needs more time, and it's a TODO with a question mark, so there probably are some doubts here that I'm not aware of.