### PR TITLE
footnotes without javascript

### DIFF
--- a/default/templates/components/pandoc.tpl
+++ b/default/templates/components/pandoc.tpl
@@ -45,12 +45,11 @@
     </dl>
   </DefinitionList>
   <Note:Ref>
-    <!-- DoNotFormat -->
-    <!-- We use JavaScript because anchor links won't work if there is a <base> tag;
-         see https://stackoverflow.com/a/34765348 
-    -->
-    <sup class="px-0.5"><a class="text-${theme}-600 hover:underline" href="javascript:;" onclick="document.location.hash='#fn${footnote:idx}';"><footnote:idx /></a></sup>
-    <!-- DoNotFormat -->
+    <sup class="px-0.5">
+      <a class="text-${theme}-600 hover:underline" href="${ema:note:url}#fn${footnote:idx}">
+        <footnote:idx />
+      </a>
+    </sup>
   </Note:Ref>
   <Note:List>
     <div title="Footnotes"

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.7.12.3
+version:            0.7.13.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/View/Template.hs
+++ b/src/Emanote/View/Template.hs
@@ -159,6 +159,8 @@ renderLmlHtml model note = do
     let modelRoute = R.ModelRoute_LML r
     "ema:note:source-path"
       ## HI.textSplice (toText . R.withLmlRoute R.encodeRoute $ r)
+    "ema:note:url"
+      ## HI.textSplice (SR.siteRouteUrl model . SR.lmlSiteRoute $ r)
     "ema:note:backlinks"
       ## backlinksSplice (G.modelLookupBacklinks modelRoute model)
     let (backlinksDaily, backlinksNoDaily) = partition (Calendar.isDailyNote . fst) $ G.modelLookupBacklinks modelRoute model


### PR DESCRIPTION
This replaces the JS workaround of the `<base>` tag vs anchor links issue, and also prepares the ground for #137.

Be aware that this changes the behaviour of emanote when the user clicks a footnote link contained in an embedded note. However, footnotes in embedded notes are broken anyway #360 (and I think can be fixed in a reasonable way that is compatible with this PR), so maybe that's not a big issue.
