### PR TITLE
Fix broken links; including Work_Sans font preload URL

### DIFF
--- a/default/templates/hooks/more-head.tpl
+++ b/default/templates/hooks/more-head.tpl
@@ -1,12 +1,12 @@
 <!-- What goes in this file will appear on near the end of <head>-->
 <link rel="preload"
-  href="${ema:emanoteStaticLayerUrl}/fonts/Maven_Pro/WorkSans-VariableFont_wght.ttf" as="font"
+  href="${ema:emanoteStaticLayerUrl}/fonts/Work_Sans/WorkSans-VariableFont_wght.ttf" as="font"
   type="font/ttf" crossorigin>
 
 <style>
   @font-face {
     font-family: 'WorkSans';
-    /* FIXME: This ought to be: ${ema:emanoteStaticLayerUrl}/fonts/Maven_Pro/WorkSans-VariableFont_wght.ttf */
+    /* FIXME: This ought to be: ${ema:emanoteStaticLayerUrl}/fonts/Work_Sans/WorkSans-VariableFont_wght.ttf */
     src: url(_emanote-static/fonts/Work_Sans/WorkSans-VariableFont_wght.ttf) format("truetype");
     font-display: swap;
   }

--- a/docs/guide/yaml-config.md
+++ b/docs/guide/yaml-config.md
@@ -12,7 +12,7 @@ tags: [emanote/yaml/demo]
 
 Configure your site metadata, rendering configuration and such using YAML configuration. Create a `foo.yaml` alongside `foo.md` or `foo/` folder, and those settings apply only to that route. The YAML structure is the same as your Markdown frontmatter, and vice-versa. Settings in the YAML frontmatter apply onto that Markdown route only; whereas settings in an individual .yaml file apply to that entire sub-route tree. Emanote does a deep-merge of the parent YAML configurations, so you can have children override only what's necessary. This is sometimes known as ["data cascade"](https://www.11ty.dev/docs/data-cascade/). The final merged YAML structure is passed to the HTML templates, of which you have full rendering control over.
 
-Notice how this page's sidebar colorscheme has [changed to green]{.greenery}? View [the source of this page](https://github.com/srid/emanote/blob/master/docs/demo/yaml-config.md) to see the magic involved. That CSS greenery you just saw too comes from YAML.
+Notice how this page's sidebar colorscheme has [changed to green]{.greenery}? View [the source of this page](https://github.com/EmaApps/emanote/blob/master/docs/guide/yaml-config.md) to see the magic involved. That CSS greenery you just saw too comes from YAML.
 
 ## Examples
 

--- a/docs/start/install/nix.md
+++ b/docs/start/install/nix.md
@@ -63,4 +63,4 @@ $ systemctl --user status emanote.service
 ```
 
 [home-manager]: https://github.com/nix-community/home-manager
-[module]: https://github.com/srid/emanote/blob/master/home-manager-module.nix
+[module]: https://github.com/EmaApps/emanote/blob/master/nix/home-manager-module.nix

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.7.14.0
+version:            0.7.15.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
I fixed broken links found using https://www.deadlinkchecker.com/.

Perhaps the font thing may be related to #357?

Sorry for dividing the docs fixes into 2 commits. I'm not at home and have to use the github web editor to edit the files; I don't know if I can edit 2 files in one commit using this tool, or if I can squash the commits somehow.