### PR TITLE
Unexpose test sources; add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Revision history for emanote
+
+## Unreleased
+
+- Dev
+  - Move test sources to Cabal's `other-modules` so they are not exposed.
+
+## 0.8.0.0 (2022-11-03)
+
+Initial release.

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -201,11 +201,11 @@ library
     Emanote.View.TagIndex
     Emanote.View.TaskIndex
     Emanote.View.Template
-    Paths_emanote
 
   other-modules:
     Emanote.Model.Link.RelSpec
     Emanote.Model.QuerySpec
+    Paths_emanote
     Spec
 
   autogen-modules: Paths_emanote

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -160,13 +160,11 @@ library
     Emanote.Model.Calendar
     Emanote.Model.Graph
     Emanote.Model.Link.Rel
-    Emanote.Model.Link.RelSpec
     Emanote.Model.Link.Resolve
     Emanote.Model.Meta
     Emanote.Model.Note
     Emanote.Model.Note.Filter
     Emanote.Model.Query
-    Emanote.Model.QuerySpec
     Emanote.Model.SData
     Emanote.Model.StaticFile
     Emanote.Model.Stork
@@ -204,6 +202,10 @@ library
     Emanote.View.TaskIndex
     Emanote.View.Template
     Paths_emanote
+
+  exposed-modules:
+    Emanote.Model.Link.RelSpec
+    Emanote.Model.QuerySpec
     Spec
 
   autogen-modules: Paths_emanote

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            0.8.0.0
+version:            0.8.1.0
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -203,7 +203,7 @@ library
     Emanote.View.Template
     Paths_emanote
 
-  exposed-modules:
+  other-modules:
     Emanote.Model.Link.RelSpec
     Emanote.Model.QuerySpec
     Spec

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -13,6 +13,7 @@ description:
 -- A URL where users can report bugs.
 bug-reports:        https://github.com/EmaApps/emanote/issues
 extra-source-files:
+  CHANGELOG.md
   LICENSE
   README.md
 


### PR DESCRIPTION
Don't want Spec.hs and friends exposed in https://hackage.haskell.org/package/emanote