### PR TITLE
Add links to tailwindcss and heroicons licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ To discuss the emanote project, [join Matrix][matrix] or post in [GitHub Discuss
 [^licenses]: Emanote uses software and resources that are licensed differently, viz.:
     - [Logo](https://www.svgrepo.com/svg/267765/paper-plane)
     - [Stork search](https://github.com/jameslittle230/stork/blob/master/license.txt)
-    - Various SVG icons are from [Heroicons](https://heroicons.com/)
+    - [Tailwind CSS](https://github.com/tailwindlabs/tailwindcss/blob/master/LICENSE)
+    - Various SVG icons are from [Heroicons](https://github.com/tailwindlabs/heroicons/blob/master/LICENSE)


### PR DESCRIPTION
Tailwind CSS was missing in the list. I also changed the Heroicons link to point directly to the license.