### PR TITLE
Workaround for Prism.js and Tailwind CSS both using `table` class (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Reduce Emanote's Nix runtime closure size
 - UI
   - Add source map for Stork [\#391](https://github.com/srid/emanote/pull/391)
+  - Workaround for Prism.js and Tailwind CSS both using `table` class [\#320](https://github.com/srid/emanote/pull/396)
 - Features
   - Timeline backlinks recognize flexible daily notes suffixed with arbitrary string [\#395](https://github.com/srid/emanote/issues/395)
 - Misc

--- a/default/index.yaml
+++ b/default/index.yaml
@@ -95,6 +95,7 @@ js:
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/prism.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <style>code span.token.table{display:inline;}</style> <!-- Tailwind and Prism both use the .table class. This resets the display:table property set by Tailwind. https://github.com/EmaApps/emanote/issues/320 -->
   # Syntax highlighting using highlight.js
   highlightjs: |
     <!-- highlight.js -->

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.0.1.4
+version:            1.0.1.5
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
This is a hack, but it looks like it works. If `table` turns out to be the only name clash, this workaround may be sufficient to close #320. But I won't mind if you prefer some more elegant solution and close this PR.