### PR TITLE
Include YAML frontmatter in the Stork index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - UI
   - Add source map for Stork [\#391](https://github.com/srid/emanote/pull/391)
   - Workaround for Prism.js and Tailwind CSS both using `table` class [\#320](https://github.com/srid/emanote/pull/396)
+  - Add option to include YAML frontmatter in the Stork index [\#398](https://github.com/srid/emanote/pull/398)
 - Features
   - Timeline backlinks recognize flexible daily notes suffixed with arbitrary string [\#395](https://github.com/srid/emanote/issues/395)
 - Misc

--- a/default/index.yaml
+++ b/default/index.yaml
@@ -131,3 +131,5 @@ js:
 emanote:
   # Whether to automatically treat folder notes as a folgezettel parent of its contents
   folder-folgezettel: true
+  stork:
+    frontmatter-handling: omit

--- a/default/index.yaml
+++ b/default/index.yaml
@@ -37,6 +37,7 @@ template:
     # (unless a route in it is active)
     collapsed: true
   stork:
+    # https://stork-search.net/docs/config-ref#frontmatter_handling
     frontmatter-handling: omit
 
 pandoc:

--- a/default/index.yaml
+++ b/default/index.yaml
@@ -36,6 +36,8 @@ template:
     # Whether this node in the sidebar tree should remain collapsed by default
     # (unless a route in it is active)
     collapsed: true
+  stork:
+    frontmatter-handling: omit
 
 pandoc:
   # Rewrite the class specified in Pandoc's Div and Span nodes. You can specify the class using
@@ -132,5 +134,3 @@ js:
 emanote:
   # Whether to automatically treat folder notes as a folgezettel parent of its contents
   folder-folgezettel: true
-  stork:
-    frontmatter-handling: omit

--- a/docs/guide/html-template/search.md
+++ b/docs/guide/html-template/search.md
@@ -10,11 +10,11 @@ You can trigger search input in one of the following ways:
 - Press `Ctrl+K` (or `⌘K` on macOS).
 - Click the lens icon on the sidebar (if using the 'book' [[html-template|template layout]]) or top-right corner (if using [[neuron-layout]]).
 
-## Including frontmatter content in the search
+## Including frontmatter in the search index
 
 By default, Stork doesn't include the text in the frontmatter as searchable.
 
-This can be changed by adding the following to `index.yaml`:
+This can be changed by adding the following to [[yaml-config|`index.yaml`]]:
 
 ```yaml
 template:
@@ -22,9 +22,10 @@ template:
     frontmatter-handling: ignore
 ```
 
-This allows you to search by the tags present in the frontmatter, but you will also get potentially undesired results when searching words like `order` or `date`.
-
 The possible values are `ignore`, `omit` and `parse`. Default `omit`. See the Stork [docs](https://stork-search.net/docs/config-ref#frontmatter_handling).
+
+This allows you to search by your frontmatter metadata (eg: tags) instead of just markdown body. Note that you may also get undesired results when searching words including non-relevant parts of the YAML frontmatter, like `order` or `date`; this is why the default is `omit`.
+
 
 ## Known issues
 

--- a/docs/guide/html-template/search.md
+++ b/docs/guide/html-template/search.md
@@ -7,11 +7,27 @@ Emanote provides client-side full-text search using [Stork](https://stork-search
 
 You can trigger search input in one of the following ways:
 
-- Press `Ctrl+K` (or `⌘K` on macOS). 
+- Press `Ctrl+K` (or `⌘K` on macOS).
 - Click the lens icon on the sidebar (if using the 'book' [[html-template|template layout]]) or top-right corner (if using [[neuron-layout]]).
+
+## Including frontmatter content in the search
+
+By default, Stork doesn't include the text in the frontmatter as searchable.
+
+This can be changed by adding the following to `index.yaml`:
+
+```yaml
+emanote:
+  stork:
+    frontmatter-handling: ignore
+```
+
+This allows you to search by the tags present in the frontmatter, but you will also get potentially undesired results when searching words like `order` or `date`.
+
+The possible values are `ignore`, `omit` and `parse`. Default `omit`. See the Stork [docs](https://stork-search.net/docs/config-ref#frontmatter_handling).
 
 ## Known issues
 
 - In live server mode, you may find that the browser will fetch remote assets (the wasm file) from files.stork-search.net. See details [here](https://github.com/jameslittle230/stork/issues/317#issuecomment-1258682222).
 
-[^1]: The Stork index file can be accessed at [`-/stork.st`](-/stork.st). 
+[^1]: The Stork index file can be accessed at [`-/stork.st`](-/stork.st).

--- a/docs/guide/html-template/search.md
+++ b/docs/guide/html-template/search.md
@@ -17,7 +17,7 @@ By default, Stork doesn't include the text in the frontmatter as searchable.
 This can be changed by adding the following to `index.yaml`:
 
 ```yaml
-emanote:
+template:
   stork:
     frontmatter-handling: ignore
 ```

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -104,6 +104,7 @@ common library-common
     , containers
     , data-default
     , dependent-sum
+    , deriving-aeson
     , directory
     , ema                    >=0.9
     , filepath

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.0.1.5
+version:            1.0.1.6
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Emanote/Model/Stork.hs
+++ b/src/Emanote/Model/Stork.hs
@@ -5,6 +5,7 @@ where
 
 import Control.Monad.Logger (MonadLoggerIO)
 import Data.IxSet.Typed qualified as Ix
+import Emanote.Model.Meta (lookupRouteMeta)
 import Emanote.Model.Note qualified as N
 import Emanote.Model.Stork.Index (File (File), Handling (Handling_Omit), Input (Input), readOrBuildStorkIndex)
 import Emanote.Model.Title qualified as Tit
@@ -19,7 +20,7 @@ import System.FilePath ((</>))
 
 renderStorkIndex :: (MonadIO m, MonadLoggerIO m) => Model -> m LByteString
 renderStorkIndex model = do
-  readOrBuildStorkIndex (model ^. M.modelStorkIndex) (Input (storkFiles model) Handling_Omit)
+  readOrBuildStorkIndex (model ^. M.modelStorkIndex) (Input (storkFiles model) (frontmatterHandling model))
 
 storkFiles :: Model -> [File]
 storkFiles model =
@@ -29,3 +30,8 @@ storkFiles model =
           ((baseDir </>) $ R.withLmlRoute R.encodeRoute $ note ^. N.noteRoute)
           (SR.siteRouteUrl model $ SR.lmlSiteRoute $ note ^. N.noteRoute)
           (Tit.toPlain $ note ^. N.noteTitle)
+
+frontmatterHandling :: Model -> Handling
+frontmatterHandling model =
+  let indexRoute = M.modelIndexRoute model
+   in lookupRouteMeta Handling_Omit ("emanote" :| ["stork", "frontmatter-handling"]) indexRoute model

--- a/src/Emanote/Model/Stork.hs
+++ b/src/Emanote/Model/Stork.hs
@@ -8,7 +8,13 @@ import Data.Default (Default (def))
 import Data.IxSet.Typed qualified as Ix
 import Emanote.Model.Meta (lookupRouteMeta)
 import Emanote.Model.Note qualified as N
-import Emanote.Model.Stork.Index (File (File), Handling, Input (Input), readOrBuildStorkIndex)
+import Emanote.Model.Stork.Index
+  ( Config (Config),
+    File (File),
+    Handling,
+    Input (Input),
+    readOrBuildStorkIndex,
+  )
 import Emanote.Model.Title qualified as Tit
 import Emanote.Model.Type (Model)
 import Emanote.Model.Type qualified as M
@@ -21,8 +27,8 @@ import System.FilePath ((</>))
 
 renderStorkIndex :: (MonadIO m, MonadLoggerIO m) => Model -> m LByteString
 renderStorkIndex model = do
-  let input = Input (storkFiles model) (frontmatterHandling model)
-  readOrBuildStorkIndex (model ^. M.modelStorkIndex) input
+  let config = Config $ Input (storkFiles model) (frontmatterHandling model)
+  readOrBuildStorkIndex (model ^. M.modelStorkIndex) config
 
 storkFiles :: Model -> [File]
 storkFiles model =

--- a/src/Emanote/Model/Stork.hs
+++ b/src/Emanote/Model/Stork.hs
@@ -6,7 +6,7 @@ where
 import Control.Monad.Logger (MonadLoggerIO)
 import Data.IxSet.Typed qualified as Ix
 import Emanote.Model.Note qualified as N
-import Emanote.Model.Stork.Index (File (File), Input (Input), readOrBuildStorkIndex)
+import Emanote.Model.Stork.Index (File (File), Handling (Handling_Omit), Input (Input), readOrBuildStorkIndex)
 import Emanote.Model.Title qualified as Tit
 import Emanote.Model.Type (Model)
 import Emanote.Model.Type qualified as M
@@ -19,7 +19,7 @@ import System.FilePath ((</>))
 
 renderStorkIndex :: (MonadIO m, MonadLoggerIO m) => Model -> m LByteString
 renderStorkIndex model = do
-  readOrBuildStorkIndex (model ^. M.modelStorkIndex) (Input $ storkFiles model)
+  readOrBuildStorkIndex (model ^. M.modelStorkIndex) (Input (storkFiles model) Handling_Omit)
 
 storkFiles :: Model -> [File]
 storkFiles model =

--- a/src/Emanote/Model/Stork.hs
+++ b/src/Emanote/Model/Stork.hs
@@ -20,7 +20,8 @@ import System.FilePath ((</>))
 
 renderStorkIndex :: (MonadIO m, MonadLoggerIO m) => Model -> m LByteString
 renderStorkIndex model = do
-  readOrBuildStorkIndex (model ^. M.modelStorkIndex) (Input (storkFiles model) (frontmatterHandling model))
+  let input = Input (storkFiles model) (frontmatterHandling model)
+  readOrBuildStorkIndex (model ^. M.modelStorkIndex) input
 
 storkFiles :: Model -> [File]
 storkFiles model =

--- a/src/Emanote/Model/Stork.hs
+++ b/src/Emanote/Model/Stork.hs
@@ -34,4 +34,4 @@ storkFiles model =
 frontmatterHandling :: Model -> Handling
 frontmatterHandling model =
   let indexRoute = M.modelIndexRoute model
-   in lookupRouteMeta Handling_Omit ("emanote" :| ["stork", "frontmatter-handling"]) indexRoute model
+   in lookupRouteMeta Handling_Omit ("template" :| ["stork", "frontmatter-handling"]) indexRoute model

--- a/src/Emanote/Model/Stork.hs
+++ b/src/Emanote/Model/Stork.hs
@@ -4,10 +4,11 @@ module Emanote.Model.Stork
 where
 
 import Control.Monad.Logger (MonadLoggerIO)
+import Data.Default (Default (def))
 import Data.IxSet.Typed qualified as Ix
 import Emanote.Model.Meta (lookupRouteMeta)
 import Emanote.Model.Note qualified as N
-import Emanote.Model.Stork.Index (File (File), Handling (Handling_Omit), Input (Input), readOrBuildStorkIndex)
+import Emanote.Model.Stork.Index (File (File), Handling, Input (Input), readOrBuildStorkIndex)
 import Emanote.Model.Title qualified as Tit
 import Emanote.Model.Type (Model)
 import Emanote.Model.Type qualified as M
@@ -35,4 +36,4 @@ storkFiles model =
 frontmatterHandling :: Model -> Handling
 frontmatterHandling model =
   let indexRoute = M.modelIndexRoute model
-   in lookupRouteMeta Handling_Omit ("template" :| ["stork", "frontmatter-handling"]) indexRoute model
+   in lookupRouteMeta def ("template" :| ["stork", "frontmatter-handling"]) indexRoute model

--- a/src/Emanote/Model/Stork/Index.hs
+++ b/src/Emanote/Model/Stork/Index.hs
@@ -13,6 +13,8 @@ module Emanote.Model.Stork.Index
 where
 
 import Control.Monad.Logger (MonadLoggerIO)
+import Data.Aeson (FromJSON (parseJSON))
+import Data.Aeson qualified as Aeson
 import Data.Text qualified as T
 import Data.Time (NominalDiffTime, diffUTCTime, getCurrentTime)
 import Emanote.Prelude (log, logD, logW)
@@ -122,7 +124,7 @@ parseHandling handling = case handling of
   "Ignore" -> Right Handling_Ignore
   "Omit" -> Right Handling_Omit
   "Parse" -> Right Handling_Parse
-  other -> Left $ "Unsupport value for frontmatter handling: " <> other
+  other -> Left $ "Unsupported value for frontmatter handling: " <> other
 
 handlingCodec :: Toml.Key -> TomlCodec Handling
 handlingCodec = textBy showHandling parseHandling
@@ -137,3 +139,10 @@ storkInputCodec :: TomlCodec StorkInput
 storkInputCodec =
   StorkInput
     <$> Toml.table inputCodec "input" .= globalInput
+
+instance FromJSON Handling where
+  parseJSON = Aeson.withText "FrontmatterHandling" $ \case
+    "ignore" -> pure Handling_Ignore
+    "omit" -> pure Handling_Omit
+    "parse" -> pure Handling_Parse
+    _ -> fail "Unsupported value for frontmatter-handling"

--- a/src/Emanote/Model/Stork/Index.hs
+++ b/src/Emanote/Model/Stork/Index.hs
@@ -16,6 +16,7 @@ where
 import Control.Monad.Logger (MonadLoggerIO)
 import Data.Aeson (FromJSON, genericParseJSON)
 import Data.Aeson qualified as Aeson
+import Data.Char (toLower)
 import Data.Default (Default (..))
 import Data.Text qualified as T
 import Data.Time (NominalDiffTime, diffUTCTime, getCurrentTime)
@@ -117,8 +118,12 @@ instance FromJSON Handling where
       handlingJSONOptions :: Aeson.Options
       handlingJSONOptions =
         Aeson.defaultOptions
-          { Aeson.constructorTagModifier = toString . T.toLower . T.replace "Handling_" "" . toText
+          { Aeson.constructorTagModifier = applyFirst toLower . drop 9
           }
+      applyFirst :: (Char -> Char) -> String -> String
+      applyFirst _f [] = []
+      applyFirst f (x:xs) = f x : xs
+
 
 configCodec :: TomlCodec Config
 configCodec =

--- a/src/Emanote/Model/Stork/Index.hs
+++ b/src/Emanote/Model/Stork/Index.hs
@@ -8,13 +8,14 @@ module Emanote.Model.Stork.Index
     readOrBuildStorkIndex,
     File (File),
     Input (Input),
-    Handling (Handling_Ignore, Handling_Omit, Handling_Parse),
+    Handling,
   )
 where
 
 import Control.Monad.Logger (MonadLoggerIO)
 import Data.Aeson (FromJSON, genericParseJSON)
 import Data.Aeson qualified as Aeson
+import Data.Default (Default (..))
 import Data.Text qualified as T
 import Data.Time (NominalDiffTime, diffUTCTime, getCurrentTime)
 import Emanote.Prelude (log, logD, logW)
@@ -93,6 +94,9 @@ data Handling
   | Handling_Omit
   | Handling_Parse
   deriving stock (Eq, Show, Generic)
+
+instance Default Handling where
+  def = Handling_Omit
 
 newtype Config = Config
   { configInput :: Input

--- a/src/Emanote/Model/Stork/Index.hs
+++ b/src/Emanote/Model/Stork/Index.hs
@@ -14,12 +14,10 @@ module Emanote.Model.Stork.Index
 where
 
 import Control.Monad.Logger (MonadLoggerIO)
-import Data.Aeson (FromJSON, genericParseJSON)
-import Data.Aeson qualified as Aeson
-import Data.Char (toLower)
 import Data.Default (Default (..))
 import Data.Text qualified as T
 import Data.Time (NominalDiffTime, diffUTCTime, getCurrentTime)
+import Deriving.Aeson
 import Emanote.Prelude (log, logD, logW)
 import Numeric (showGFloat)
 import Relude
@@ -108,22 +106,15 @@ data Handling
   | Handling_Omit
   | Handling_Parse
   deriving stock (Eq, Show, Generic)
+  deriving
+    (FromJSON)
+    via CustomJSON
+          '[ ConstructorTagModifier '[StripPrefix "Handling_", CamelToSnake]
+           ]
+          Handling
 
 instance Default Handling where
   def = Handling_Omit
-
-instance FromJSON Handling where
-  parseJSON = genericParseJSON handlingJSONOptions
-    where
-      handlingJSONOptions :: Aeson.Options
-      handlingJSONOptions =
-        Aeson.defaultOptions
-          { Aeson.constructorTagModifier = applyFirst toLower . drop 9
-          }
-      applyFirst :: (Char -> Char) -> String -> String
-      applyFirst _f [] = []
-      applyFirst f (x:xs) = f x : xs
-
 
 configCodec :: TomlCodec Config
 configCodec =

--- a/src/Emanote/Model/Stork/Index.hs
+++ b/src/Emanote/Model/Stork/Index.hs
@@ -62,7 +62,7 @@ storkBin = $(staticWhich "stork")
 
 runStork :: MonadIO m => Input -> m LByteString
 runStork input = do
-  let storkToml = handleTomlandBug $ Toml.encode storkInputCodec $ StorkInput input
+  let storkToml = handleTomlandBug $ Toml.encode configCodec $ Config input
   (_, !index, _) <-
     liftIO $
       readProcessWithExitCode
@@ -94,8 +94,8 @@ data Handling
   | Handling_Parse
   deriving stock (Eq, Show)
 
-newtype StorkInput = StorkInput
-  { globalInput :: Input
+newtype Config = Config
+  { configInput :: Input
   }
   deriving stock (Eq, Show)
 
@@ -135,10 +135,10 @@ inputCodec =
     <$> Toml.list fileCodec "files" .= inputFiles
     <*> Toml.diwrap (handlingCodec "frontmatter_handling") .= inputFrontmatterHandling
 
-storkInputCodec :: TomlCodec StorkInput
-storkInputCodec =
-  StorkInput
-    <$> Toml.table inputCodec "input" .= globalInput
+configCodec :: TomlCodec Config
+configCodec =
+  Config
+    <$> Toml.table inputCodec "input" .= configInput
 
 instance FromJSON Handling where
   parseJSON = Aeson.withText "FrontmatterHandling" $ \case


### PR DESCRIPTION
This PR sets the `frontmatter_handling` setting in Stork to `Ignore` so the frontmatter is included in the searchable text.

See #397 
