### PR TITLE
Fixed yaml example link to point to emanote template

### DIFF
--- a/docs/guide/yaml-config.md
+++ b/docs/guide/yaml-config.md
@@ -16,4 +16,4 @@ Notice how this page's sidebar colorscheme has [changed to green]{.greenery}? Vi
 
 ## Examples
 
-- https://github.com/srid/srid/blob/master/content/index.yaml
+- https://github.com/srid/emanote-template/blob/master/index.yaml

--- a/docs/guide/yaml-config.md
+++ b/docs/guide/yaml-config.md
@@ -16,4 +16,5 @@ Notice how this page's sidebar colorscheme has [changed to green]{.greenery}? Vi
 
 ## Examples
 
+- https://github.com/srid/srid/blob/master/index.yaml
 - https://github.com/srid/emanote-template/blob/master/index.yaml


### PR DESCRIPTION
This pull request just fixes the broken link in the yaml docs. Resolves #405 