### PR TITLE
Mitigate stork memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Add option to include YAML frontmatter in the Stork index [\#398](https://github.com/srid/emanote/pull/398)
 - Features
   - Timeline backlinks recognize flexible daily notes suffixed with arbitrary string [\#395](https://github.com/srid/emanote/issues/395)
+- Performance
+  - Address client-side memory leak due to Stork search in live server [\#411](https://github.com/srid/emanote/issues/411#issuecomment-1402056235)
 - Misc
   - Ignore toplevel `flake.{nix,lock}` by default.
   - Remove deprecated `_emanote-bin/compile-css` script

--- a/default/templates/components/stork/stork-search-head.tpl
+++ b/default/templates/components/stork/stork-search-head.tpl
@@ -15,11 +15,13 @@
 <script src="${ema:emanoteStaticLayerUrl}/stork/stork.js"></script>
 <ema:metadata>
   <with var="template">
-    <script data-emanote-base-url="${value:baseUrl}">
+    <script id="emanote-stork" data-emanote-base-url="${value:baseUrl}">
       window.emanote = {};
       window.emanote.stork = {
         searchShown: false,
+        indexIsStale: false,
         toggleSearch: function () {
+          window.emanote.stork.refreshIndex();
           document.getElementById('stork-search-container').classList.toggle('hidden');
           window.emanote.stork.searchShown = document.body.classList.toggle('stork-overflow-hidden-important');
           if (window.emanote.stork.searchShown) {
@@ -32,14 +34,26 @@
           window.emanote.stork.searchShown = false;
         },
 
-        init: function () {
+        getBaseUrl: function () {
+          const baseUrl = document.getElementById("emanote-stork").getAttribute('data-emanote-base-url') || '/';
+          return baseUrl;
+        },
+
+        registerIndex: function (options) {
           const indexName = 'emanote-search'; // used to match input[data-stork] attribute value
-          const baseUrl = document.currentScript.getAttribute('data-emanote-base-url') || '/';
-          const indexUrl = baseUrl + '-/stork.st';
+          const indexUrl = window.emanote.stork.getBaseUrl() + '-/stork.st';
+          stork.register(
+            indexName,
+            indexUrl,
+            options);
+        },
+
+        init: function () {
           if (document.readyState !== 'complete') {
+            console.log("stork: normal register");
             window.addEventListener('load', function () {
-              stork.initialize(baseUrl + '_emanote-static/stork/stork.wasm');
-              stork.register(indexName, indexUrl);
+              stork.initialize(window.emanote.stork.getBaseUrl() + '_emanote-static/stork/stork.wasm');
+              window.emanote.stork.registerIndex();
             });
 
             document.addEventListener('keydown', event => {
@@ -52,10 +66,30 @@
               }
             });
           } else {
-            // Override existing on Ema's hot-reload
-            stork.register(indexName, indexUrl, { forceOverwrite: true });
+            // Mark the current index as stale, and refresh it *only when* the
+            // user actually invokes search.
+            // 
+            // We do not refresh the index *right away*, as that will cause
+            // memory leaks in the browser. See
+            // https://github.com/srid/emanote/issues/411#issuecomment-1402056235
+            console.log("stork: Marking index as stale");
+            window.emanote.stork.markIndexAsStale();
+          }
+        },
+
+        markIndexAsStale: function () {
+          window.emanote.stork.indexIsStale = true;
+        },
+
+        refreshIndex: function () {
+          if (window.emanote.stork.indexIsStale) {
+            console.log("stork: Reloading index");
+            window.emanote.stork.indexIsStale = false;
+            // NOTE: This will leak memory. See the comment above.
+            window.emanote.stork.registerIndex({ forceOverwrite: true });
           }
         }
+
       };
 
       window.emanote.stork.init();

--- a/default/templates/components/stork/stork-search-head.tpl
+++ b/default/templates/components/stork/stork-search-head.tpl
@@ -50,7 +50,6 @@
 
         init: function () {
           if (document.readyState !== 'complete') {
-            console.log("stork: normal register");
             window.addEventListener('load', function () {
               stork.initialize(window.emanote.stork.getBaseUrl() + '_emanote-static/stork/stork.wasm');
               window.emanote.stork.registerIndex();
@@ -66,6 +65,8 @@
               }
             });
           } else {
+            // This section is called during Ema's hot reload.
+            // 
             // Mark the current index as stale, and refresh it *only when* the
             // user actually invokes search.
             // 

--- a/emanote.cabal
+++ b/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.0.1.7
+version:            1.0.1.8
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
This is not a complete fix. Instead of leaking `O(update_or_linkswitch)` this will leak `O(search_invocation)` (excluding those cases where the user actually clicks on a search result; because that causes full-page refresh). Since the latter happens rarely and much less frequently, this should definitely be a significant improvement and acceptable fix.

#411