### PR TITLE
Fix H2 styling & Add documentation

### DIFF
--- a/docs/guide/markdown/custom-style.md
+++ b/docs/guide/markdown/custom-style.md
@@ -45,6 +45,35 @@ Using [fenced_divs](https://github.com/jgm/commonmark-hs/blob/master/commonmark-
 ![[file-links]]
 :::
 
+## Customizing Default Styling and Templates
+
+Emanote allows you to customize the appearance of HTML components without the need for
+manual styling each time. This can be accomplished by overriding default templates in your
+notebook.
+
+To start customizing, create a templates directory in your notebook. From there, you can
+override any templates you wish by copying them from Emanote's default templates into your
+notebook's templates directory. For example, if you want to customize the default pandoc
+styling, you can copy the [pandoc.tpl](https://github.com/srid/emanote/blob/master/emanote/default/templates/components/pandoc.tpl)
+file from Emanote's GitHub repository into your templates/components directory and edit it
+accordingly.
+
+This customization process works through a "union" of the default layer (provided by
+Emanote) and your notebook's layer. Essentially, it's similar to the `unionfs` concept -
+both the default layer and your notebook are union-mounted in Haskell using
+[srid/unionmount](https://github.com/srid/unionmount). This way, you only need to copy and
+modify the specific files you want to override, without affecting the rest of the default templates.
+
+Several users have successfully implemented this customization approach in their projects.
+Refer to the following examples for inspiration:
+
+- [srid/srid](https://github.com/srid/srid/tree/master/templates)
+- [TheNeikos/hemera.systems](https://github.com/TheNeikos/hemera.systems/tree/master/content/templates)
+- [gil0mendes](https://gitlab.com/gil0mendes/website/-/tree/live/content/templates)
+- [ChenghaoMou/chenghaomou](https://github.com/ChenghaoMou/chenghaomou.github.io/tree/master/templates)
+
+For additional information and discussion on this topic, check out
+[this discussion on GitHub](https://github.com/srid/emanote/discussions/438).
 
 [^mob]: If you are viewing this page on mobile or smaller screens, the embedded notes will be stacked on top of one another because we use Tailwind's [responsive classes](https://tailwindcss.com/docs/responsive-design). Incidentally, we use the `{class=".."}` syntax, rather than the `{.someClass}` syntax, only because the former is [more lenient](https://github.com/jgm/commonmark-hs/issues/76) in accepting non-standard class names, such as the Tailwind responsive classes (eg. `lg:grid-cols-2`).
 

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Make Stork recognize orgmode notes ([\#413](https://github.com/srid/emanote/issues/413))
 - Features
   - Audio embedding ([\#418](https://github.com/srid/emanote/pull/418))
+- UI
+  - Remove inline styling of H2 elements
 - Misc
   - Update Ema to simplify the live server websocket observation logic
 

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -98,7 +98,7 @@
   <Code class="py-0.5 px-0.5 bg-gray-100" />
   <Header>
     <h1 class="pb-2 mb-2 text-5xl font-bold text-center" />
-    <h2 class="inline-block mt-6 mb-4 text-4xl font-bold text-gray-700 border-b-2" />
+    <h2 class="mt-6 mb-4 text-4xl font-bold text-gray-700 border-b-2" />
     <h3 class="mt-6 mb-2 text-3xl font-bold text-gray-700" />
     <h4 class="mt-6 mb-2 text-2xl font-bold text-gray-700" />
     <h5 class="mt-6 mb-2 text-xl font-bold text-gray-700" />

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.0.3.5
+version:            1.0.3.6
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
See https://github.com/srid/emanote/discussions/438

I fix the styling on H2 heading component and attempt to add a section about how to override default styling.