### PR TITLE
run `preparePandoc` in `parseNoteOrg` and `parseNoteMarkdown`

### DIFF
--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.0.3.8
+version:            1.0.3.9
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/emanote/src/Emanote/Pandoc/BuiltinFilters.hs
+++ b/emanote/src/Emanote/Pandoc/BuiltinFilters.hs
@@ -1,22 +1,14 @@
 module Emanote.Pandoc.BuiltinFilters (
-  prepareNoteDoc,
   preparePandoc,
 ) where
 
-import Emanote.Model.Note qualified as N
 import Emanote.Pandoc.ExternalLink (setExternalLinkIcon)
 import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as HT
 import Emanote.Route (encodeRoute)
 import Emanote.Route.SiteRoute.Type (encodeTagIndexR)
-import Optics.Core ((^.))
 import Relude
 import Text.Pandoc.Definition qualified as B
 import Text.Pandoc.Walk qualified as W
-
--- TODO: Run this in `parseNote`?
-prepareNoteDoc :: N.Note -> B.Pandoc
-prepareNoteDoc note =
-  preparePandoc $ note ^. N.noteDoc
 
 preparePandoc :: W.Walkable B.Inline b => b -> b
 preparePandoc =

--- a/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -9,7 +9,6 @@ import Emanote.Model.Note qualified as MN
 import Emanote.Model.StaticFile (CodeLanguage (..), StaticFileInfo (..), staticFileInfoTemplateName)
 import Emanote.Model.StaticFile qualified as SF
 import Emanote.Model.Title qualified as Tit
-import Emanote.Pandoc.BuiltinFilters (prepareNoteDoc, preparePandoc)
 import Emanote.Pandoc.Link qualified as Link
 import Emanote.Pandoc.Renderer (PandocBlockRenderer, PandocInlineRenderer)
 import Emanote.Pandoc.Renderer.Url qualified as RenderedUrl
@@ -73,10 +72,10 @@ runEmbedTemplate name splices = do
 embedResourceRoute :: Model -> HP.RenderCtx -> MN.Note -> Maybe (HI.Splice Identity)
 embedResourceRoute model ctx note = do
   pure . runEmbedTemplate "note" $ do
-    "ema:note:title" ## Tit.titleSplice ctx preparePandoc (MN._noteTitle note)
+    "ema:note:title" ## Tit.titleSplice ctx id (MN._noteTitle note)
     "ema:note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute $ note ^. MN.noteRoute)
     "ema:note:pandoc" ##
-      pandocSplice ctx (prepareNoteDoc note)
+      pandocSplice ctx (note ^. MN.noteDoc)
 
 embedStaticFileRoute :: Model -> Text -> SF.StaticFile -> Maybe (HI.Splice Identity)
 embedStaticFileRoute model altText staticFile = do

--- a/emanote/src/Emanote/Pandoc/Renderer/Query.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Query.hs
@@ -10,7 +10,6 @@ import Emanote.Model (Model)
 import Emanote.Model.Note qualified as MN
 import Emanote.Model.Query qualified as Q
 import Emanote.Model.Title qualified as Tit
-import Emanote.Pandoc.BuiltinFilters (preparePandoc)
 import Emanote.Pandoc.Renderer (PandocBlockRenderer)
 import Emanote.Route (LMLRoute)
 import Emanote.Route.SiteRoute qualified as SR
@@ -38,7 +37,8 @@ queryResolvingSplice model _nr ctx noteRoute blk = do
       "query" ##
         HI.textSplice (show q)
       "result" ##
-        (HI.runChildrenWith . noteSpliceMap ($ ctx) model) `foldMapM` Q.runQuery noteRoute model q
+        (HI.runChildrenWith . noteSpliceMap ($ ctx) model)
+          `foldMapM` Q.runQuery noteRoute model q
 
 -- TODO: Reuse this elsewhere
 noteSpliceMap ::
@@ -47,6 +47,6 @@ noteSpliceMap ::
   MN.Note ->
   H.Splices (HI.Splice Identity)
 noteSpliceMap withCtx model note = do
-  "ema:note:title" ## withCtx $ \ctx -> Tit.titleSplice ctx preparePandoc (MN._noteTitle note)
+  "ema:note:title" ## withCtx $ \ctx -> Tit.titleSplice ctx id (MN._noteTitle note)
   "ema:note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute $ note ^. MN.noteRoute)
   "ema:note:metadata" ## HJ.bindJson (note ^. MN.noteMeta)

--- a/emanote/src/Emanote/View/Common.hs
+++ b/emanote/src/Emanote/View/Common.hs
@@ -22,7 +22,6 @@ import Emanote.Model.SData qualified as SData
 import Emanote.Model.Title qualified as Tit
 import Emanote.Model.Type (Model)
 import Emanote.Model.Type qualified as M
-import Emanote.Pandoc.BuiltinFilters (preparePandoc)
 import Emanote.Pandoc.Renderer (EmanotePandocRenderers (..), PandocRenderers (..))
 import Emanote.Pandoc.Renderer qualified as Renderer
 import Emanote.Route (LMLRoute)
@@ -75,7 +74,7 @@ mkTemplateRenderCtx model r meta =
       -- TODO: We should be using withInlineCtx, so as to make the wikilink
       -- render in note title.
       titleSplice titleDoc = withLinkInlineCtx $ \ctx ->
-        Tit.titleSplice ctx preparePandoc titleDoc
+        Tit.titleSplice ctx id titleDoc
    in TemplateRenderCtx {..}
   where
     withRenderCtx ::
@@ -140,7 +139,7 @@ commonSplices withCtx model meta routeTitle = do
   "ema:metadata" ##
     HJ.bindJson meta
   "ema:title" ## withCtx $ \ctx ->
-    Tit.titleSplice ctx preparePandoc routeTitle
+    Tit.titleSplice ctx id routeTitle
   -- <head>'s <title> cannot contain HTML
   "ema:titleFull" ##
     Tit.titleSpliceNoHtml routeTitleFull

--- a/emanote/src/Emanote/View/Template.hs
+++ b/emanote/src/Emanote/View/Template.hs
@@ -16,7 +16,6 @@ import Emanote.Model.Meta qualified as Meta
 import Emanote.Model.Note qualified as MN
 import Emanote.Model.SData qualified as SData
 import Emanote.Model.Stork (renderStorkIndex)
-import Emanote.Pandoc.BuiltinFilters (prepareNoteDoc, preparePandoc)
 import Emanote.Route qualified as R
 import Emanote.Route.SiteRoute (SiteRoute)
 import Emanote.Route.SiteRoute qualified as SR
@@ -146,7 +145,7 @@ renderLmlHtml model note = do
               "backlink:note:title" ## C.titleSplice bctx (M.modelLookupTitle source model)
               "backlink:note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute source)
               "backlink:note:contexts" ## Splices.listSplice (toList contexts) "context" $ \backlinkCtx -> do
-                let ctxDoc :: Pandoc = preparePandoc $ Pandoc mempty $ one $ B.Div B.nullAttr backlinkCtx
+                let ctxDoc = Pandoc mempty $ one $ B.Div B.nullAttr backlinkCtx
                 "context:body" ## C.withInlineCtx bctx $ \ctx' ->
                   Splices.pandocSplice ctx' ctxDoc
     -- Sidebar navigation
@@ -179,7 +178,7 @@ renderLmlHtml model note = do
     "ema:note:pandoc" ##
       C.withBlockCtx ctx $
         \ctx' ->
-          Splices.pandocSplice ctx' (prepareNoteDoc note)
+          Splices.pandocSplice ctx' (note ^. MN.noteDoc)
 
 -- | If there is no 'current route', all sub-trees are marked as active/open.
 routeTreeSplice ::


### PR DESCRIPTION
This implements the `TODO` from https://github.com/srid/emanote/blob/d165171ce46a967b0a72db138e06d16d86ef5dbb/emanote/src/Emanote/Pandoc/BuiltinFilters.hs#L16

I needed this for my failed approach at #167. I think this does not break anything and moreover it even fixes a bug:  the `font-family: emoji` style was not applied to the emoji in wikilink descriptions (this happened both in note body and in backlinks). See the screenshot of http://emanote.srid.ca/guide:

![obraz](https://github.com/srid/emanote/assets/53443372/d9f9351f-e5ad-4c38-b2aa-b6f91d9e3d5b)


