### PR TITLE
commonmark-extensions >=0.2.3.4

### DIFF
--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.0.3.9
+version:            1.0.3.10
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -97,7 +97,7 @@ common library-common
     , blaze-html
     , bytestring
     , commonmark
-    , commonmark-extensions  <0.2.3.3
+    , commonmark-extensions  >=0.2.3.4
     , commonmark-pandoc
     , commonmark-simple
     , commonmark-wikilink
@@ -223,7 +223,7 @@ executable emanote
     build-depends: emanote
 
 test-suite test
-  import:         library-common 
+  import:         library-common
   type:           exitcode-stdio-1.0
   hs-source-dirs: test
   main-is:        Spec.hs

--- a/flake.nix
+++ b/flake.nix
@@ -58,9 +58,6 @@
             treefmt = config.treefmt.build.wrapper;
           } // config.treefmt.build.programs;
 
-          packages = {
-            commonmark-extensions.source = "0.2.3.2";
-          };
           settings = {
             emanote = { name, pkgs, self, super, ... }: {
               imports = [


### PR DESCRIPTION
Closes #372. Fixed by https://github.com/jgm/commonmark-hs/commit/10f7b0c840e2f84b83cb215a9e889012b622bd0d.