### PR TITLE
Update the SVG of the link that redirects to index page

### DIFF
--- a/emanote/default/templates/components/footer.tpl
+++ b/emanote/default/templates/components/footer.tpl
@@ -11,11 +11,10 @@
   </div>
   <div>
     <a href="${ema:indexUrl}" title="View Index">
-      <svg class="${iconClass}" fill="none" stroke="currentColor" viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg">
+      <svg xmlns="http://www.w3.org/2000/svg" class="${iconClass}" fill="none" viewBox="0 0 24 24"
+        stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-          d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4">
-        </path>
+          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
       </svg>
     </a>
   </div>


### PR DESCRIPTION
Resolves #467 

The SVG has been updated from a logo that looks like "full-screen mode" to a logo that is used in https://srid.ca, which looks like "open book"
<img width="41" alt="Screenshot 2023-12-05 at 1 20 34 PM" src="https://github.com/srid/emanote/assets/23645788/8803058a-8f6b-4c7c-9d73-c373a90a006d">


⬇️⬇️⬇️


![image (4)](https://github.com/srid/emanote/assets/23645788/41e9de1a-1952-44b4-8cf2-23d81cbaf45a)
