### PR TITLE
Update `nixpkgs`

### DIFF
--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -43,8 +43,6 @@ common haskell-common
     -fprint-explicit-foralls -fprint-explicit-kinds
 
   default-extensions:
-    NoImplicitPrelude
-    NoStarIsType
     BangPatterns
     ConstraintKinds
     DataKinds
@@ -70,6 +68,8 @@ common haskell-common
     LambdaCase
     MultiParamTypeClasses
     MultiWayIf
+    NoImplicitPrelude
+    NoStarIsType
     NumericUnderscores
     OverloadedStrings
     PolyKinds

--- a/emanote/src/Emanote.hs
+++ b/emanote/src/Emanote.hs
@@ -67,8 +67,8 @@ run cfg@EmanoteConfig {..} = do
         >>= postRun cfg
     CLI.Cmd_Export -> do
       Dynamic (unModelEma -> model0, _) <-
-        flip runLoggerLoggingT oneOffLogger $
-          siteInput @SiteRoute (Ema.CLI.action def) cfg
+        flip runLoggerLoggingT oneOffLogger
+          $ siteInput @SiteRoute (Ema.CLI.action def) cfg
       putLBSLn $ Export.renderJSONExport model0
   where
     -- A logger suited for running one-off commands.
@@ -84,8 +84,8 @@ run cfg@EmanoteConfig {..} = do
 
 postRun :: EmanoteConfig -> (Model.ModelEma, (FilePath, [FilePath])) -> IO ()
 postRun EmanoteConfig {..} (unModelEma -> model0, (outPath, genPaths)) = do
-  when (model0 ^. modelCompileTailwind) $
-    compileTailwindCss (outPath </> generatedCssFile) genPaths
+  when (model0 ^. modelCompileTailwind)
+    $ compileTailwindCss (outPath </> generatedCssFile) genPaths
   checkBrokenLinks _emanoteConfigCli $ Export.modelRels model0
   checkBadMarkdownFiles $ Model.modelNoteErrors model0
 
@@ -104,8 +104,9 @@ checkBadMarkdownFiles noteErrs = runStderrLoggingT $ do
 
 checkBrokenLinks :: CLI.Cli -> Map LMLRoute [Export.Link] -> IO ()
 checkBrokenLinks cli modelRels = runStderrLoggingT $ do
-  ((), res :: Sum Int) <- runWriterT $
-    forM_ (Map.toList modelRels) $ \(noteRoute, rels) ->
+  ((), res :: Sum Int) <- runWriterT
+    $ forM_ (Map.toList modelRels)
+    $ \(noteRoute, rels) ->
       forM_ (sortNub rels) $ \(Export.Link urt rrt) ->
         case rrt of
           RRTFound _ -> pass
@@ -127,11 +128,15 @@ compileTailwindCss :: (MonadUnliftIO m) => FilePath -> [FilePath] -> m ()
 compileTailwindCss cssPath genPaths = do
   runStdoutLoggingT $ do
     log $ "Running Tailwind CSS v3 compiler to generate: " <> toText cssPath
-    Tailwind.runTailwind $
-      def
-        & Tailwind.tailwindConfig % Tailwind.tailwindConfigContent .~ genPaths
-        & Tailwind.tailwindOutput .~ cssPath
-        & Tailwind.tailwindMode .~ Tailwind.Production
+    Tailwind.runTailwind
+      $ def
+      & Tailwind.tailwindConfig
+      % Tailwind.tailwindConfigContent
+      .~ genPaths
+      & Tailwind.tailwindOutput
+      .~ cssPath
+      & Tailwind.tailwindMode
+      .~ Tailwind.Production
 
 defaultEmanotePandocRenderers :: EmanotePandocRenderers Model.Model LMLRoute
 defaultEmanotePandocRenderers =

--- a/emanote/src/Emanote/CLI.hs
+++ b/emanote/src/Emanote/CLI.hs
@@ -36,8 +36,8 @@ cliParser cwd = do
   pure Cli {..}
   where
     pathList defaultPath = do
-      option pathListReader $
-        mconcat
+      option pathListReader
+        $ mconcat
           [ long "layers"
           , short 'L'
           , metavar "LAYERS"

--- a/emanote/src/Emanote/Model/Calendar.hs
+++ b/emanote/src/Emanote/Model/Calendar.hs
@@ -44,9 +44,10 @@ parseRouteDay =
       -- Day
       day <- asInt =<< replicateM 2 M.digitChar
       -- Optional suffix (ignored)
-      void $
-        optional $ do
+      void
+        $ optional
+        $ do
           void $ M.oneOf ['-', '_', ' ']
           void M.takeRest
-      maybe (fail "Not a date") pure $
-        fromGregorianValid year (fromInteger month) (fromInteger day)
+      maybe (fail "Not a date") pure
+        $ fromGregorianValid year (fromInteger month) (fromInteger day)

--- a/emanote/src/Emanote/Model/Graph.hs
+++ b/emanote/src/Emanote/Model/Graph.hs
@@ -115,10 +115,11 @@ lookupNoteByWikiLink model wl = do
 
 modelLookupBacklinks :: R.LMLRoute -> Model -> [(R.LMLRoute, NonEmpty [B.Block])]
 modelLookupBacklinks r model =
-  sortOn (Calendar.backlinkSortKey model . fst) $
-    groupNE $
-      backlinkRels r model <&> \rel ->
-        (rel ^. Rel.relFrom, rel ^. Rel.relCtx)
+  sortOn (Calendar.backlinkSortKey model . fst)
+    $ groupNE
+    $ backlinkRels r model
+    <&> \rel ->
+      (rel ^. Rel.relFrom, rel ^. Rel.relCtx)
   where
     groupNE :: forall a b. (Ord a) => [(a, b)] -> [(a, NonEmpty b)]
     groupNE =

--- a/emanote/src/Emanote/Model/Link/Rel.hs
+++ b/emanote/src/Emanote/Model/Link/Rel.hs
@@ -67,8 +67,9 @@ noteRels note =
   where
     extractLinks :: Map Text (NonEmpty ([(Text, Text)], [B.Block])) -> IxRel
     extractLinks m =
-      Ix.fromList $
-        flip concatMap (Map.toList m) $ \(url, instances) -> do
+      Ix.fromList
+        $ flip concatMap (Map.toList m)
+        $ \(url, instances) -> do
           flip mapMaybe (toList instances) $ \(attrs, ctx) -> do
             let parentR = R.withLmlRoute R.routeParent $ note ^. noteRoute
             (target, _manchor) <- parseUnresolvedRelTarget parentR attrs url
@@ -103,8 +104,8 @@ parseUnresolvedRelTarget baseDir attrs url = do
 
 relocateRelUrlUnder :: Maybe FilePath -> FilePath -> FilePath
 relocateRelUrlUnder mbase fp =
-  normalizeIgnoringSymlinks $
-    case mbase of
+  normalizeIgnoringSymlinks
+    $ case mbase of
       Nothing -> fp
       Just x -> x </> fp
 

--- a/emanote/src/Emanote/Model/Link/Resolve.hs
+++ b/emanote/src/Emanote/Model/Link/Resolve.hs
@@ -22,8 +22,8 @@ resolveUnresolvedRelTarget model = \case
     resolveModelRoute model r
       <&> resourceSiteRoute
   Rel.URTVirtual virtualRoute -> do
-    Rel.RRTFound $
-      SR.SiteRoute_VirtualRoute
+    Rel.RRTFound
+      $ SR.SiteRoute_VirtualRoute
         virtualRoute
 
 resolveWikiLinkMustExist ::

--- a/emanote/src/Emanote/Model/Query.hs
+++ b/emanote/src/Emanote/Model/Query.hs
@@ -61,12 +61,12 @@ queryParser = do
   where
     fromUserPath s =
       if
-          | "*" `T.isInfixOf` s ->
-              QueryByPathPattern (toString s)
-          | "/" `T.isPrefixOf` s ->
-              QueryByPath (toString $ T.drop 1 s)
-          | otherwise ->
-              QueryByPathPattern (toString $ "**/" <> s <> "/**")
+        | "*" `T.isInfixOf` s ->
+            QueryByPathPattern (toString s)
+        | "/" `T.isPrefixOf` s ->
+            QueryByPath (toString $ T.drop 1 s)
+        | otherwise ->
+            QueryByPathPattern (toString $ "**/" <> s <> "/**")
 
 runQuery :: R.LMLRoute -> Model -> Query -> [Note]
 runQuery currentRoute model =

--- a/emanote/src/Emanote/Model/StaticFile.hs
+++ b/emanote/src/Emanote/Model/StaticFile.hs
@@ -76,18 +76,18 @@ readStaticFileInfo ::
 readStaticFileInfo fp readFilePath = do
   let extension = toText (takeExtension fp)
   if
-      | extension `elem` imageExts ->
-          pure $ Just StaticFileInfoImage
-      | extension `elem` videoExts ->
-          pure $ Just StaticFileInfoVideo
-      | extension `elem` audioExts ->
-          pure $ Just StaticFileInfoAudio
-      | extension == ".pdf" ->
-          pure $ Just StaticFileInfoPDF
-      | Just lang <- Map.lookup extension codeExts -> do
-          code <- readFilePath fp
-          pure $ Just $ StaticFileInfoCode lang code
-      | otherwise -> return Nothing
+    | extension `elem` imageExts ->
+        pure $ Just StaticFileInfoImage
+    | extension `elem` videoExts ->
+        pure $ Just StaticFileInfoVideo
+    | extension `elem` audioExts ->
+        pure $ Just StaticFileInfoAudio
+    | extension == ".pdf" ->
+        pure $ Just StaticFileInfoPDF
+    | Just lang <- Map.lookup extension codeExts -> do
+        code <- readFilePath fp
+        pure $ Just $ StaticFileInfoCode lang code
+    | otherwise -> return Nothing
   where
     imageExts = [".jpg", ".jpeg", ".png", ".svg", ".gif", ".bmp", ".webp"]
     videoExts = [".mp4", ".webm", ".ogv"]

--- a/emanote/src/Emanote/Model/Stork/Index.hs
+++ b/emanote/src/Emanote/Model/Stork/Index.hs
@@ -65,8 +65,8 @@ runStork :: (MonadIO m) => Config -> m LByteString
 runStork config = do
   let storkToml = handleTomlandBug $ Toml.encode configCodec config
   (_, !index, _) <-
-    liftIO $
-      readProcessWithExitCode
+    liftIO
+      $ readProcessWithExitCode
         storkBin
         -- NOTE: Cannot use "--output -" due to bug in Rust or Stork:
         -- https://github.com/jameslittle230/stork/issues/262
@@ -132,26 +132,26 @@ configCodec :: TomlCodec Config
 configCodec =
   Config
     <$> Toml.table inputCodec "input"
-      .= configInput
+    .= configInput
   where
     inputCodec :: TomlCodec Input
     inputCodec =
       Input
         <$> Toml.list fileCodec "files"
-          .= inputFiles
+        .= inputFiles
         <*> Toml.diwrap (handlingCodec "frontmatter_handling")
-          .= inputFrontmatterHandling
+        .= inputFrontmatterHandling
     fileCodec :: TomlCodec File
     fileCodec =
       File
         <$> Toml.string "path"
-          .= filePath
+        .= filePath
         <*> Toml.text "url"
-          .= fileUrl
+        .= fileUrl
         <*> Toml.text "title"
-          .= fileTitle
+        .= fileTitle
         <*> Toml.diwrap (filetypeCodec "filetype")
-          .= fileFiletype
+        .= fileFiletype
     handlingCodec :: Toml.Key -> TomlCodec Handling
     handlingCodec = textBy showHandling parseHandling
       where

--- a/emanote/src/Emanote/Model/Task.hs
+++ b/emanote/src/Emanote/Model/Task.hs
@@ -44,8 +44,9 @@ instance Indexable TaskIxs Task where
 noteTasks :: Note -> IxTask
 noteTasks note =
   let taskListItems = TaskList.queryTasks $ note ^. N.noteDoc
-   in Ix.fromList $
-        zip [1 ..] taskListItems <&> \(idx, (checked, doc)) ->
+   in Ix.fromList
+        $ zip [1 ..] taskListItems
+        <&> \(idx, (checked, doc)) ->
           Task (note ^. N.noteRoute) idx doc checked
 
 makeLenses ''Task

--- a/emanote/src/Emanote/Model/Type.hs
+++ b/emanote/src/Emanote/Model/Type.hs
@@ -115,12 +115,12 @@ modelInsertNote note =
           >>> injectAncestors (N.noteAncestors note)
           >>> dropRedundantAncestor r
        )
-    >>> modelRels
-      %~ updateIxMulti r (Rel.noteRels note)
-    >>> modelTasks
-      %~ updateIxMulti r (Task.noteTasks note)
-    >>> modelNav
-      %~ PathTree.treeInsertPath (R.withLmlRoute R.unRoute r)
+      >>> modelRels
+    %~ updateIxMulti r (Rel.noteRels note)
+      >>> modelTasks
+    %~ updateIxMulti r (Task.noteTasks note)
+      >>> modelNav
+    %~ PathTree.treeInsertPath (R.withLmlRoute R.unRoute r)
   where
     r = note ^. N.noteRoute
 
@@ -172,15 +172,15 @@ modelDeleteNote :: LMLRoute -> ModelT f -> ModelT f
 modelDeleteNote k model =
   model
     & modelNotes
-      %~ ( Ix.deleteIx k
-            >>> restoreAncestor (N.RAncestor <$> mFolderR)
-         )
-    & modelRels
-      %~ deleteIxMulti k
-    & modelTasks
-      %~ deleteIxMulti k
-    & modelNav
-      %~ maybe (PathTree.treeDeletePath (R.withLmlRoute R.unRoute k)) (const id) mFolderR
+    %~ ( Ix.deleteIx k
+          >>> restoreAncestor (N.RAncestor <$> mFolderR)
+       )
+      & modelRels
+    %~ deleteIxMulti k
+      & modelTasks
+    %~ deleteIxMulti k
+      & modelNav
+    %~ maybe (PathTree.treeDeletePath (R.withLmlRoute R.unRoute k)) (const id) mFolderR
   where
     -- If the note being deleted is $folder.md *and* folder/ has .md files, this
     -- will be `Just folderRoute`.
@@ -261,9 +261,9 @@ modelLookupFeedNoteByHtmlRoute r model = case resolvedTarget of
   _ -> Nothing
   where
     resolvedTarget =
-      Rel.resolvedRelTargetFromCandidates $
-        N.lookupNotesByXmlRoute r $
-          _modelNotes model
+      Rel.resolvedRelTargetFromCandidates
+        $ N.lookupNotesByXmlRoute r
+        $ _modelNotes model
 
 modelLookupTitle :: LMLRoute -> ModelT f -> Tit.Title
 modelLookupTitle r =
@@ -273,11 +273,13 @@ modelLookupTitle r =
 modelWikiLinkTargets :: WL.WikiLink -> Model -> [Either (R.LMLView, Note) StaticFile]
 modelWikiLinkTargets wl model =
   let notes =
-        Ix.toList $
-          (model ^. modelNotes) @= wl
+        Ix.toList
+          $ (model ^. modelNotes)
+          @= wl
       staticFiles =
-        Ix.toList $
-          (model ^. modelStaticFiles) @= wl
+        Ix.toList
+          $ (model ^. modelStaticFiles)
+          @= wl
    in fmap Right staticFiles <> fmap Left ((R.LMLView_Html,) <$> notes)
 
 modelLookupStaticFileByRoute :: R 'AnyExt -> ModelT f -> Maybe StaticFile
@@ -294,14 +296,16 @@ modelNoteRels =
 
 modelNoteMetas :: Model -> Map LMLRoute (Tit.Title, LMLRoute, Aeson.Value)
 modelNoteMetas model =
-  Map.fromList $
-    Ix.toList (_modelNotes model) <&> \note ->
+  Map.fromList
+    $ Ix.toList (_modelNotes model)
+    <&> \note ->
       (note ^. N.noteRoute, (note ^. N.noteTitle, note ^. N.noteRoute, note ^. N.noteMeta))
 
 modelNoteErrors :: Model -> Map LMLRoute [Text]
 modelNoteErrors model =
-  Map.fromList $
-    flip mapMaybe (Ix.toList (_modelNotes model)) $ \note -> do
+  Map.fromList
+    $ flip mapMaybe (Ix.toList (_modelNotes model))
+    $ \note -> do
       let errs = note ^. N.noteErrors
       guard $ not $ null errs
       pure (note ^. N.noteRoute, errs)

--- a/emanote/src/Emanote/Pandoc/BuiltinFilters.hs
+++ b/emanote/src/Emanote/Pandoc/BuiltinFilters.hs
@@ -23,10 +23,10 @@ linkifyInlineTags =
   W.walk $ \case
     inline@(B.Span attr is) ->
       if
-          | Just inlineTag <- HT.getTagFromInline inline ->
-              B.Span attr [B.Link mempty is (tagUrl inlineTag, "Tag")]
-          | otherwise ->
-              inline
+        | Just inlineTag <- HT.getTagFromInline inline ->
+            B.Span attr [B.Link mempty is (tagUrl inlineTag, "Tag")]
+        | otherwise ->
+            inline
     x ->
       x
   where

--- a/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
+++ b/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
@@ -14,19 +14,20 @@ import Text.Pandoc.Definition (Pandoc)
 
 parseMarkdown :: FilePath -> Text -> Either Text (Maybe Aeson.Value, Pandoc)
 parseMarkdown =
-  parseMarkdownWithFrontMatter @Aeson.Value $
+  parseMarkdownWithFrontMatter @Aeson.Value
+    $
     -- As the commonmark documentation states, pipeTableSpec should be placed after
     -- fancyListSpec and defaultSyntaxSpec to avoid bad results when parsing
     -- non-table lines.
     -- see https://github.com/jgm/commonmark-hs/issues/52
     baseExtsSansPipeTable
-      <> gfmExtensionsSansPipeTable
-      <> CE.pipeTableSpec
-      <> WL.wikilinkSpec
-      -- ASK: Can we conditionally disable this?
-      -- cf. https://github.com/srid/emanote/issues/167
-      <> IT.hashTagSpec
-      <> IH.highlightSpec
+    <> gfmExtensionsSansPipeTable
+    <> CE.pipeTableSpec
+    <> WL.wikilinkSpec
+    -- ASK: Can we conditionally disable this?
+    -- cf. https://github.com/srid/emanote/issues/167
+    <> IT.hashTagSpec
+    <> IH.highlightSpec
   where
     baseExtsSansPipeTable =
       mconcat

--- a/emanote/src/Emanote/Pandoc/Renderer.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer.hs
@@ -55,13 +55,15 @@ mkRenderCtxWithPandocRenderers nr@PandocRenderers {..} classRules model x =
   Splices.mkRenderCtx
     classRules
     ( \ctx blk ->
-        asum $
-          pandocBlockRenderers <&> \f ->
+        asum
+          $ pandocBlockRenderers
+          <&> \f ->
             f model nr ctx x blk
     )
     ( \ctx blk ->
-        asum $
-          pandocInlineRenderers <&> \f ->
+        asum
+          $ pandocInlineRenderers
+          <&> \f ->
             f model nr ctx x blk
     )
 

--- a/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -51,8 +51,8 @@ embedBlockRegularLinkResolvingSplice model _nf ctx noteRoute node = do
   (Rel.URTResource mr, _mAnchor) <-
     Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveModelRoute model mr
-  RenderedUrl.renderSomeInlineRefWith Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl $
-    either (const Nothing) (embedStaticFileRoute model $ WL.plainify is)
+  RenderedUrl.renderSomeInlineRefWith Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl
+    $ either (const Nothing) (embedStaticFileRoute model $ WL.plainify is)
 
 embedInlineWikiLinkResolvingSplice :: PandocInlineRenderer Model R.LMLRoute
 embedInlineWikiLinkResolvingSplice model _nf ctx noteRoute inl = do
@@ -61,8 +61,8 @@ embedInlineWikiLinkResolvingSplice model _nf ctx noteRoute inl = do
   let parentR = R.withLmlRoute R.routeParent noteRoute
   (Rel.URTWikiLink (WL.WikiLinkEmbed, wl), _mAnchor) <- Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveWikiLinkMustExist model wl
-  RenderedUrl.renderSomeInlineRefWith Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl $
-    either (const Nothing) (embedStaticFileRoute model $ show wl)
+  RenderedUrl.renderSomeInlineRefWith Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl
+    $ either (const Nothing) (embedStaticFileRoute model $ show wl)
 
 runEmbedTemplate :: ByteString -> H.Splices (HI.Splice Identity) -> HI.Splice Identity
 runEmbedTemplate name splices = do

--- a/emanote/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Url.hs
@@ -76,14 +76,15 @@ renderSomeInlineRefWith getSr (is, (url, tit)) rRel model (ctxSansCustomSplicing
                 ]
             )
         details <-
-          HP.rpInline ctx $
+          HP.rpInline ctx
+            $
             -- FIXME: This aside is meaningless for non-wikilink links (regular
             -- Markdown links)
-            B.Span ("", ["emanote:error:aside"], []) $
-              one $
-                tooltip "Find notes containing this broken link" $
-                  one $
-                    B.Link B.nullAttr (one $ B.Emph $ one $ B.Str "backlinks") (url, "")
+            B.Span ("", ["emanote:error:aside"], [])
+            $ one
+            $ tooltip "Find notes containing this broken link"
+            $ one
+            $ B.Link B.nullAttr (one $ B.Emph $ one $ B.Str "backlinks") (url, "")
         if M.inLiveServer model
           then pure $ raw <> details
           else pure raw
@@ -144,10 +145,11 @@ replaceLinkNodeWithRoute model r (inner, url) =
     nonEmptyLinkInlines :: Model -> Text -> Maybe SR.SiteRoute -> [B.Inline] -> [B.Inline]
     nonEmptyLinkInlines model' url' mr = \case
       [] ->
-        toList $
-          nonEmptyInlines url $
-            fromMaybe [] $
-              siteRouteDefaultInnerText model' url' =<< mr
+        toList
+          $ nonEmptyInlines url
+          $ fromMaybe []
+          $ siteRouteDefaultInnerText model' url'
+          =<< mr
       x -> x
 
 -- | Ensure that inlines list is non-empty, using the provided singleton value if necessary.

--- a/emanote/src/Emanote/Route/R.hs
+++ b/emanote/src/Emanote/Route/R.hs
@@ -52,7 +52,7 @@ routeSlugWithPrefix prefix r = do
 -- | The base name of the route without its parent path.
 routeBaseName :: R ext -> Text
 routeBaseName =
-  Slug.unSlug . head . NE.reverse . unRoute
+  Slug.unSlug . last . unRoute
 
 routeParent :: R ext -> Maybe (R 'Folder)
 routeParent =

--- a/emanote/src/Emanote/Route/R.hs
+++ b/emanote/src/Emanote/Route/R.hs
@@ -22,8 +22,10 @@ instance (HasExt ext) => ToJSON (R ext) where
 
 instance (HasExt ext) => Show (R ext) where
   show r =
-    toString $
-      "R[/" <> encodeRoute r <> "]"
+    toString
+      $ "R[/"
+      <> encodeRoute r
+      <> "]"
 
 -- | Convert foo/bar.<ext> to a @R@
 mkRouteFromFilePath :: forall a (ext :: FileType a). (HasExt ext) => FilePath -> Maybe (R ext)

--- a/emanote/src/Emanote/Route/SiteRoute/Class.hs
+++ b/emanote/src/Emanote/Route/SiteRoute/Class.hs
@@ -59,11 +59,13 @@ emanoteGeneratableRoutes model =
       virtualRoutes :: [VirtualRoute] =
         let tags = fst <$> M.modelTags model
             tagPaths =
-              Set.fromList $
-                ([] :) $ -- [] Triggers generation of main tag index.
-                  concat $
-                    tags <&> \(HT.deconstructTag -> tagPath) ->
+              Set.fromList
+                $ ([] :)
+                $ concatMap -- [] Triggers generation of main tag index.
+                  ( \(HT.deconstructTag -> tagPath) ->
                       NE.filter (not . null) $ NE.inits tagPath
+                  )
+                  tags
          in VirtualRoute_Index
               : VirtualRoute_Export
               : VirtualRoute_StorkIndex

--- a/emanote/src/Emanote/Route/SiteRoute/Class.hs
+++ b/emanote/src/Emanote/Route/SiteRoute/Class.hs
@@ -40,22 +40,25 @@ import Relude
 emanoteGeneratableRoutes :: ModelEma -> [SiteRoute]
 emanoteGeneratableRoutes model =
   let htmlRoutes =
-        model ^. M.modelNotes
-          & Ix.toList
-          <&> noteFileSiteRoute'
+        model
+          ^. M.modelNotes
+            & Ix.toList
+            <&> noteFileSiteRoute'
       feedRoutes =
-        model ^. M.modelNotes
-          & Ix.toList
-          & filter N.noteHasFeed
-          <&> noteFeedSiteRoute
+        model
+          ^. M.modelNotes
+            & Ix.toList
+            & filter N.noteHasFeed
+            <&> noteFeedSiteRoute
       staticRoutes =
         let includeFile f =
               not (LiveServerFile.isLiveServerFile f)
                 || (f == LiveServerFile.tailwindFullCssPath && not (model ^. M.modelCompileTailwind))
-         in model ^. M.modelStaticFiles
-              & Ix.toList
-              & filter (includeFile . R.encodeRoute . SF._staticFileRoute)
-              <&> staticFileSiteRoute
+         in model
+              ^. M.modelStaticFiles
+                & Ix.toList
+                & filter (includeFile . R.encodeRoute . SF._staticFileRoute)
+                <&> staticFileSiteRoute
       virtualRoutes :: [VirtualRoute] =
         let tags = fst <$> M.modelTags model
             tagPaths =

--- a/emanote/src/Emanote/Source/Loc.hs
+++ b/emanote/src/Emanote/Source/Loc.hs
@@ -50,8 +50,9 @@ defaultLayer = LocDefault
 
 userLayers :: NonEmpty FilePath -> Set Loc
 userLayers paths =
-  fromList $
-    zip [1 ..] (toList paths) <&> uncurry LocUser
+  fromList
+    $ zip [1 ..] (toList paths)
+    <&> uncurry LocUser
 
 -- | Return the effective path of a file.
 locResolve :: (Loc, FilePath) -> FilePath

--- a/emanote/src/Emanote/Source/Patch.hs
+++ b/emanote/src/Emanote/Source/Patch.hs
@@ -111,9 +111,9 @@ patchModel' layers noteF storkIndexTVar scriptingEngine fpType fp action = do
               let fpAbs = locResolve overlay
               traverseToSnd (readRefreshedFile refreshAction) fpAbs
             sData <-
-              liftIO $
-                either (throwIO . BadInput) pure $
-                  SD.parseSDataCascading r yamlContents
+              liftIO
+                $ either (throwIO . BadInput) pure
+                $ SD.parseSDataCascading r yamlContents
             pure $ M.modelInsertData sData
           UM.Delete -> do
             log $ "Removing data: " <> toText fp

--- a/emanote/src/Emanote/Source/Pattern.hs
+++ b/emanote/src/Emanote/Source/Pattern.hs
@@ -7,16 +7,16 @@ import System.FilePattern (FilePattern)
 filePattern :: (HasCallStack) => R.FileType R.SourceExt -> FilePath
 filePattern = \case
   R.LMLType R.Md ->
-    R.withExt @_ @('R.LMLType 'R.Md) $
-      "**/*"
+    R.withExt @_ @('R.LMLType 'R.Md)
+      $ "**/*"
   R.LMLType R.Org ->
-    R.withExt @_ @('R.LMLType 'R.Org) $
-      "**/*"
+    R.withExt @_ @('R.LMLType 'R.Org)
+      $ "**/*"
   R.Yaml ->
     R.withExt @_ @'R.Yaml "**/*"
   R.HeistTpl ->
-    R.withExt @_ @'R.HeistTpl $
-      "**/*"
+    R.withExt @_ @'R.HeistTpl
+      $ "**/*"
   R.AnyExt ->
     "**"
 

--- a/emanote/src/Emanote/View/Common.hs
+++ b/emanote/src/Emanote/View/Common.hs
@@ -121,8 +121,9 @@ commonSplices withCtx model meta routeTitle = do
   -- Add tailwind css shim
   "tailwindCssShim" ##
     do
-      pure . RX.renderHtmlNodes $
-        if M.inLiveServer model || not (model ^. M.modelCompileTailwind)
+      pure
+        . RX.renderHtmlNodes
+        $ if M.inLiveServer model || not (model ^. M.modelCompileTailwind)
           then do
             -- Twind shim doesn't reliably work in dev server mode. Let's just use the
             -- tailwind CDN.
@@ -138,8 +139,9 @@ commonSplices withCtx model meta routeTitle = do
     HI.textSplice (toText $ showVersion Paths_emanote.version)
   "ema:metadata" ##
     HJ.bindJson meta
-  "ema:title" ## withCtx $ \ctx ->
-    Tit.titleSplice ctx id routeTitle
+  "ema:title" ##
+    withCtx $ \ctx ->
+      Tit.titleSplice ctx id routeTitle
   -- <head>'s <title> cannot contain HTML
   "ema:titleFull" ##
     Tit.titleSpliceNoHtml routeTitleFull
@@ -166,10 +168,10 @@ commonSplices withCtx model meta routeTitle = do
         -- Also: more-head.tpl is the one place where this is hardcoded.
         let staticFolder = "_emanote-static"
             itUrl =
-              SR.siteRouteUrl model $
-                SR.staticFileSiteRoute $
-                  fromMaybe (error "no _emanote-static?") $
-                    M.modelLookupStaticFile (staticFolder </> "inverted-tree.css") model
+              SR.siteRouteUrl model
+                $ SR.staticFileSiteRoute
+                $ fromMaybe (error "no _emanote-static?")
+                $ M.modelLookupStaticFile (staticFolder </> "inverted-tree.css") model
             staticFolderUrl = fst $ T.breakOn "/inverted-tree.css" itUrl
             -- Deal with a silly Firefox bug https://github.com/srid/emanote/issues/340
             --
@@ -192,9 +194,9 @@ commonSplices withCtx model meta routeTitle = do
     cannotBeCached url = url <> "?instanceId=" <> show (model ^. M.modelInstanceID)
     cachedTailwindCdn = do
       let localCdnUrl =
-            SR.siteRouteUrl model $
-              SR.staticFileSiteRoute $
-                LiveServerFiles.tailwindCssFile model
+            SR.siteRouteUrl model
+              $ SR.staticFileSiteRoute
+              $ LiveServerFiles.tailwindCssFile model
       H.link
         ! A.href (H.toValue localCdnUrl)
         ! A.rel "stylesheet"

--- a/emanote/src/Emanote/View/Export.hs
+++ b/emanote/src/Emanote/View/Export.hs
@@ -72,8 +72,9 @@ renderJSONExport model =
 
 modelRels :: Model -> Map LMLRoute [Link]
 modelRels model =
-  Map.fromListWith (<>) $
-    M.modelNoteRels model <&> \rel ->
+  Map.fromListWith (<>)
+    $ M.modelNoteRels model
+    <&> \rel ->
       let from_ = rel ^. Rel.relFrom
           to_ = rel ^. Rel.relTo
           toTarget =

--- a/emanote/src/Emanote/View/TagIndex.hs
+++ b/emanote/src/Emanote/View/TagIndex.hs
@@ -87,23 +87,23 @@ renderTagIndex model tagPath = do
     "ema:tag:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.tagIndexRoute tagPath)
     let parents = maybe [] (inits . init) $ nonEmpty (tagIndexPath tagIdx)
     "ema:tagcrumbs" ##
-      Splices.listSplice parents "ema:each-crumb" $
-        \crumb -> do
+      Splices.listSplice parents "ema:each-crumb"
+        $ \crumb -> do
           let crumbTitle = maybe "/" (HT.unTagNode . last) . nonEmpty $ crumb
               crumbUrl = SR.siteRouteUrl model $ SR.tagIndexRoute crumb
           "ema:tagcrumb:title" ## HI.textSplice crumbTitle
           "ema:tagcrumb:url" ## HI.textSplice crumbUrl
     "ema:childTags" ##
-      Splices.listSplice (tagIndexChildren tagIdx) "ema:each-childTag" $
-        \childTag -> do
+      Splices.listSplice (tagIndexChildren tagIdx) "ema:each-childTag"
+        $ \childTag -> do
           let childIndex = mkTagIndex model (toList . fst $ childTag)
           "ema:childTag:title" ## HI.textSplice (tagNodesText $ fst childTag)
           "ema:childTag:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.tagIndexRoute (toList $ fst childTag))
           "ema:childTag:count-note" ## HI.textSplice (show (length $ snd childTag))
           "ema:childTag:count-tag" ## HI.textSplice (show (length $ tagIndexChildren childIndex))
     "ema:notes" ##
-      Splices.listSplice (tagIndexNotes tagIdx) "ema:each-note" $
-        \note ->
+      Splices.listSplice (tagIndexNotes tagIdx) "ema:each-note"
+        $ \note ->
           PF.noteSpliceMap (withInlineCtx tCtx) model note
 
 tagNodesText :: NonEmpty HT.TagNode -> Text

--- a/emanote/src/Emanote/View/TaskIndex.hs
+++ b/emanote/src/Emanote/View/TaskIndex.hs
@@ -23,10 +23,12 @@ newtype TaskIndex = TaskIndex {unTaskIndex :: Map R.LMLRoute (NonEmpty Task)}
 
 mkTaskIndex :: Model -> TaskIndex
 mkTaskIndex model =
-  TaskIndex . Map.map NE.sort $
-    Map.fromListWith (<>) $
-      filter (not . Task._taskChecked) (Ix.toList $ model ^. M.modelTasks) <&> \task ->
-        (task ^. Task.taskRoute, one task)
+  TaskIndex
+    . Map.map NE.sort
+    $ Map.fromListWith (<>)
+    $ filter (not . Task._taskChecked) (Ix.toList $ model ^. M.modelTasks)
+    <&> \task ->
+      (task ^. Task.taskRoute, one task)
 
 renderTasks :: Model -> LByteString
 renderTasks model = do
@@ -42,8 +44,9 @@ renderTasks model = do
       taskSplice task = do
         let r = task ^. Task.taskRoute
         -- TODO: reuse note splice
-        "task:description" ## Common.withInlineCtx tCtx $ \ctx ->
-          Splices.pandocSplice ctx $ B.Pandoc mempty $ one $ B.Plain $ task ^. Task.taskDescription
+        "task:description" ##
+          Common.withInlineCtx tCtx $ \ctx ->
+            Splices.pandocSplice ctx $ B.Pandoc mempty $ one $ B.Plain $ task ^. Task.taskDescription
         "note:title" ## Common.titleSplice tCtx (M.modelLookupTitle r model)
         "note:url" ## HI.textSplice (SR.siteRouteUrl model $ SR.lmlSiteRoute (R.LMLView_Html, r))
 

--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693626178,
-        "narHash": "sha256-Rpiy6lIOu4zny8tfGuIeN1ji9eSz9nPmm9yBhh/4IOM=",
+        "lastModified": 1702900294,
+        "narHash": "sha256-pt7sSoJYNw3n8YtXw0Z/Nnr6/PfY2YrjDvqboErXnRM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfb7dfec93f3b5d7274db109f2990bc889861caf",
+        "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
           settings = {
             # TODO: Eliminate these after new emanote gets upstreamed to nixpkgs
             fsnotify.check = false;
+            heist.broken = false;
             ixset-typed.broken = false;
             ixset-typed.jailbreak = true;
             ema.jailbreak = true;
@@ -90,7 +91,7 @@
               justStaticExecutables = true;
               removeReferencesTo = [
                 self.pandoc
-                self.pandoc_3_1_6
+                self.pandoc_3_1_9
                 self.pandoc-types
                 self.warp
               ];


### PR DESCRIPTION
Couple of other things the PR is required to do as a result of updating `nixpkgs`:
- Mark `heist` as unbroken and use `pandoc_3_1_9` as `pandoc_3_1_6` is no longer in the package set.
- Fix `hlint` warnings
- Run `treefmt`