### PR TITLE
KaTeX support

### DIFF
--- a/docs/tips/js/math.md
+++ b/docs/tips/js/math.md
@@ -18,6 +18,16 @@ page:
     <snippet var="js.mathjax" />
 ```
 
+[KaTeX](https://katex.org/) can be used as an alternative to MathJax. Just like MathJax, it renders math specified between dollar signs.
+
+To enable it:
+
+```yaml
+page:
+  headHtml: |
+    <snippet var="js.katex" />
+```
+
 ## Demo
 
 When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are

--- a/docs/tips/js/math.md
+++ b/docs/tips/js/math.md
@@ -8,6 +8,8 @@ page:
 
 # Math
 
+## MathJax
+
 [MathJax](https://www.mathjax.org) can be used to render Math formulas.  For example, $a^2 + b ^ 2 = c$.
 
 To enable it, add the following to `page.headHtml` of [[yaml-config|YAML configuration]] or Markdown frontmatter.
@@ -17,6 +19,14 @@ page:
   headHtml: |
     <snippet var="js.mathjax" />
 ```
+
+### Demo
+
+When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+
+
+## KaTeX
 
 [KaTeX](https://katex.org/) can be used as an alternative to MathJax. Just like MathJax, it renders math specified between dollar signs.
 
@@ -28,7 +38,3 @@ page:
     <snippet var="js.katex" />
 ```
 
-## Demo
-
-When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
-$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -11,6 +11,7 @@
     - The semantics of `folder-folgezettel` is now applied in inverse (see docs)
   - Allow specifying custom page title in sidebar ([\#488](https://github.com/srid/emanote/pull/488))
   - Allow specifying `lang` attribute for HTML page in YAML config ([\#485](https://github.com/srid/emanote/pull/485))
+  - KaTeX support ([\#489](https://github.com/srid/emanote/pull/489))
 - Bug fixes:
   - Emanote no longer crashes when run on an empty directory ([\#487](https://github.com/srid/emanote/issues/487))
 

--- a/emanote/default/index.yaml
+++ b/emanote/default/index.yaml
@@ -138,6 +138,20 @@ js:
       };
     </script>
     <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  katex: |
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
+          integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV"
+          crossorigin="anonymous">
+    <script defer
+            src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
+            integrity="sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8"
+            crossorigin="anonymous"></script>
+    <script defer
+            src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
+            integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05"
+            crossorigin="anonymous"
+            onload="renderMathInElement(document.body);"></script>
 
 emanote:
   # Whether to automatically treat folder notes as a folgezettel parent of its contents

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.3.3.0
+version:            1.3.4.0
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
Hello, this pr adds support for [KaTeX](https://katex.org/) as an alternative to MathJax

> The **_fastest_** math typesetting library for the web.

Added snippet is stripped version provided in [katex installation instructions](https://katex.org/docs/browser#starter-template)

Tested on ungoogled-chromium 120 and firefox 120 on NixOS stable 23.11

Thanks for great work.