### PR TITLE
ci: Deploy docs using nix (not docker)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,33 +28,12 @@ jobs:
         id: docs
         if: matrix.system == 'aarch64-linux'
         run: |
-          nix build .#docs -o docs-web
-          export DOCSWEB=$(readlink ./docs-web)
-          echo "::set-output name=docs-web::${DOCSWEB}"
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
-        if: github.ref == 'refs/heads/ci-docs-nix'
-        with:
-          name: docs-website
-          retention-days: 1
-          path: |
-            ${{ steps.docs.outputs.docs-web }}
-
-  website:
-    needs: nix
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/ci-docs-nix'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download built docs
-        uses: actions/download-artifact@v4
-        with:
-          name: docs-website
-      - name: Deploy to website to gh-pages 🚀
+          nix build .#docs -o docs-static
+      - name: Deploy docs to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs-web
+          publish_dir: ./docs-static
           cname: emanote.srid.ca
 
   docker-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build Nix
-        if: matrix.system /= 'x86_64-linux'
+        if: matrix.system != 'x86_64-linux'
         run: |
           nixci --build-systems "github:nix-systems/${{ matrix.system }}"
       - name: Check closure size
-        if: matrix.system /= 'x86_64-linux'
+        if: matrix.system != 'x86_64-linux'
         run: |
           nix run .#check-closure-size
       - name: Docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,25 +14,30 @@ jobs:
       matrix:
         # TODO: Disabling x86_64-linux for now, as it is causing qemu segfault.
         # Fix treefmt check causing qemu segfault: https://nixos.zulipchat.com/#narrow/stream/413948-nixos/topic/QEMU.20internal.20SIGSEGV
-        system: [x86_64-linux, aarch64-linux, aarch64-darwin]
+        system: [aarch64-linux, aarch64-darwin]
     steps:
       - uses: actions/checkout@v4
       - name: Build Nix
-        if: matrix.system != 'x86_64-linux'
         run: |
           nixci --build-systems "github:nix-systems/${{ matrix.system }}"
       - name: Check closure size
-        if: matrix.system != 'x86_64-linux'
         run: |
           nix run .#check-closure-size
+
+  website:
+    runs-on: ubuntu-latest
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.garnix.io?priority=41 https://cache.nixos.org/
       - name: Docs
         id: docs
-        if: matrix.system == 'x86_64-linux'
         run: |
           nix build .#docs -o docs-static
       - name: Deploy docs to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3
-        if: matrix.system == 'x86_64-linux'
         # if: github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
 
   website:
     runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,26 +12,27 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        # TODO: Disablig x86_64-linux for now, as it is causing qemu segfault.
+        # TODO: Disabling x86_64-linux for now, as it is causing qemu segfault.
         # Fix treefmt check causing qemu segfault: https://nixos.zulipchat.com/#narrow/stream/413948-nixos/topic/QEMU.20internal.20SIGSEGV
-        system: [aarch64-linux, aarch64-darwin]
+        system: [x86_64-linux, aarch64-linux, aarch64-darwin]
     steps:
       - uses: actions/checkout@v4
       - name: Build Nix
+        if: matrix.system /= 'x86_64-linux'
         run: |
           nixci --build-systems "github:nix-systems/${{ matrix.system }}"
       - name: Check closure size
+        if: matrix.system /= 'x86_64-linux'
         run: |
-          # TODO: Check on all platforms?
           nix run .#check-closure-size
       - name: Docs
         id: docs
-        if: matrix.system == 'aarch64-linux'
+        if: matrix.system == 'x86_64-linux'
         run: |
           nix build .#docs -o docs-static
       - name: Deploy docs to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3
-        if: matrix.system == 'aarch64-linux'
+        if: matrix.system == 'x86_64-linux'
         # if: github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - ci-docs-nix
   pull_request:
 
 jobs:
@@ -79,7 +80,7 @@ jobs:
           docker push sridca/emanote:latest
 
   website:
-    needs: docker-build
+    needs: nix
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/ci-docs-nix'
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,9 @@ jobs:
         run: |
           nix run .#check-closure-size
 
+  # TODO: Use self-hosted runner
   website:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,13 +35,16 @@ jobs:
           extra-conf: |
             trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.garnix.io?priority=41 https://cache.nixos.org/
-      - name: Docs
+      - name: Docs static site
         id: docs
         run: |
           nix build .#docs -o docs-static
+          if ! [ -f ./docs-static/index.html ]; then
+            echo "ERROR: There is no index.html"
+            exit 2
+          fi
       - name: Deploy docs to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3
-        # if: github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs-static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         if: matrix.system == 'aarch64-linux'
         run: |
           nix build .#docs -o docs-web
-          export DOCSWEB=./docs-web
+          export DOCSWEB=$(readlink ./docs-web)
           echo "::set-output name=docs-web::${DOCSWEB}"
       - name: Upload docs artifact
         uses: actions/upload-artifact@v4
@@ -39,6 +39,23 @@ jobs:
           retention-days: 1
           path: |
             ${{ steps.docs.outputs.docs-web }}
+
+  website:
+    needs: nix
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/ci-docs-nix'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download built docs
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-website
+      - name: Deploy to website to gh-pages 🚀
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs-web
+          cname: emanote.srid.ca
 
   docker-build:
     runs-on: self-hosted
@@ -79,20 +96,3 @@ jobs:
           echo ${{ secrets.DOCKER_PASS }} | docker login -u sridca --password-stdin
           set -x
           docker push sridca/emanote:latest
-
-  website:
-    needs: nix
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/ci-docs-nix'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download built docs
-        uses: actions/download-artifact@v4
-        with:
-          name: docs-website
-      - name: Deploy to website to gh-pages 🚀
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs-web
-          cname: emanote.srid.ca

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
           nix build .#docs -o docs-static
       - name: Deploy docs to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3
+        if: matrix.system == 'aarch64-linux'
+        # if: github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs-static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,20 @@ jobs:
         run: |
           # TODO: Check on all platforms?
           nix run .#check-closure-size
+      - name: Docs
+        id: docs
+        run: |
+          nix build .#docs -o docs-web
+          export DOCSWEB=./docs-web
+          echo "::set-output name=docs-web::${DOCSWEB}"
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        if: github.ref == 'refs/heads/ci-docs-nix'
+        with:
+          name: docs-website
+          retention-days: 1
+          path: |
+            ${{ steps.docs.outputs.docs-web }}
 
   docker-build:
     runs-on: self-hosted
@@ -67,29 +81,16 @@ jobs:
   website:
     needs: docker-build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/ci-docs-nix'
     steps:
       - uses: actions/checkout@v4
-      - name: Download docker image
+      - name: Download built docs
         uses: actions/download-artifact@v4
         with:
-          name: docker-img
-      - name: Load Docker image
-        run: |
-          docker load -i *docker-image-emanote.tar.gz
-      - name: Generate website HTML 🔧
-        run: |
-          mkdir -p ./docs/.ci/output
-          # demo.md has broken links for demo
-          docker run \
-            -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 \
-            -v $PWD/docs:/data \
-            --tmpfs /tmp \
-            sridca/emanote emanote --layers /data --allow-broken-links gen /data/.ci/output
-          cp -r ./docs/.ci .
+          name: docs-website
       - name: Deploy to website to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .ci/output
+          publish_dir: ./docs-web
           cname: emanote.srid.ca

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
           nix run .#check-closure-size
       - name: Docs
         id: docs
+        if: matrix.system == 'aarch64-linux'
         run: |
           nix build .#docs -o docs-web
           export DOCSWEB=./docs-web

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - ci-docs-nix
   pull_request:
 
 jobs:


### PR DESCRIPTION
Docker's 💩 and it is currently broken on Github Actions for some reason.