### PR TITLE
templates: prevent the external link icon from wrapping

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -29,6 +29,8 @@
   - Stork search fixes
     - Fix empty stork index generation when using more than 1 layer ([\#493](https://github.com/srid/emanote/issues/493))
     - Stork search index is now uses note path from their associated layer ([\#495](https://github.com/srid/emanote/pull/495))
+- UI
+  - prevent the external link icon from wrapping ([\#528](https://github.com/srid/emanote/pull/528))
 - Update ema, new use newer morphdom (2.7.2)
 
 ## 1.2.0.0 (2023-08-24)

--- a/emanote/default/templates/base.tpl
+++ b/emanote/default/templates/base.tpl
@@ -100,7 +100,12 @@
       content: ""
     }
 
+    a[data-linkicon="external"] {
+      padding-right: 24px;
+    }
+
     a[data-linkicon="external"]::after {
+      margin-right: -24px;
       content: url('data:image/svg+xml,\
       <svg xmlns="http://www.w3.org/2000/svg" height="0.7em" viewBox="0 0 20 20"> \
         <g style="stroke:gray;stroke-width:1"> \

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.3.15.1
+version:            1.3.16.0
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
See: https://stackoverflow.com/questions/16100956/prevent-after-element-from-wrapping-to-next-line