### PR TITLE
Set note `date` when the path begin with a timestamp

### DIFF
--- a/docs/guide/yaml-config.md
+++ b/docs/guide/yaml-config.md
@@ -21,6 +21,9 @@ Notice how this page's sidebar colorscheme has [changed to green]{.greenery}? Vi
 
 - `page.image`: The image to use for the page. This is used for the [[ogp]] meta tag `og:image` meta tag. If not specified, the first image in the page is used. Relative URLs are automatically rewritten to absolute URLs if `page.siteUrl` is non-empty.
 
+- `date`: The note timestamp. This is used to order note chronologically, such as for the timeline [[query|query]].
+  The value can be set from the filename if it begins with `YYYY-MM-DD`, which is useful for including the date in the note URL.
+  In case of conflict, the date from the YAML configuration takes priority.
 
 ## Examples
 

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -24,6 +24,7 @@
   - Lua filters: filter paths will now be looked up in all layers now.
   - Live server now uses Tailwind 3 ([\#503](https://github.com/srid/emanote/pull/503))
   - Enable auto identifier for org files ([\#502](https://github.com/srid/emanote/pull/502))
+  - Support date metadata from the filename when it begins with YYYY-MM-DD ([\#552](https://github.com/srid/emanote/pull/552)).
 - Bug fixes:
   - Emanote no longer crashes when run on an empty directory ([\#487](https://github.com/srid/emanote/issues/487))
   - Stork search fixes

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.3.17.1
+version:            1.3.18.0
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca


### PR DESCRIPTION
This change simplifies timeline creation by setting the date metadata from the filename when it begins with `YYYY-MM-DD-`.