### PR TITLE
Update ema for `idiomorph` (Possibly improved live server performance)

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -31,6 +31,8 @@
   - Stork search fixes
     - Fix empty stork index generation when using more than 1 layer ([\#493](https://github.com/srid/emanote/issues/493))
     - Stork search index is now uses note path from their associated layer ([\#495](https://github.com/srid/emanote/pull/495))
+- Performance
+  - Browser-side performance improvement using `idiomorph` ([\#567](https://github.com/srid/emanote/pull/567))
 - UI
   - prevent the external link icon from wrapping ([\#528](https://github.com/srid/emanote/pull/528))
 - Update ema, new use newer morphdom (2.7.2)

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.3.19.0
+version:            1.3.20.0
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/flake.lock
+++ b/flake.lock
@@ -35,15 +35,16 @@
     "ema": {
       "flake": false,
       "locked": {
-        "lastModified": 1724260267,
-        "narHash": "sha256-pxTlvpK0l7pek43FIz6KYAazK0BWbnuBJSFrcShVoWE=",
+        "lastModified": 1737321961,
+        "narHash": "sha256-+iLtdzwVv0wyTdFfk4XFJAZPmA9Of7stYbo2sTBzN7M=",
         "owner": "srid",
         "repo": "ema",
-        "rev": "16e2752267cd49027e281409daa25b6ecba68fd3",
+        "rev": "74b619f9865748a690fc7cf1b865fec801daaa97",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "idiomorph",
         "repo": "ema",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     flake-root.url = "github:srid/flake-root";
     nixos-unified.url = "github:srid/nixos-unified";
 
-    ema.url = "github:srid/ema";
+    ema.url = "github:srid/ema/idiomorph";
     ema.flake = false;
 
     heist-extra.url = "github:srid/heist-extra";


### PR DESCRIPTION
https://github.com/srid/ema/pull/168

To use this PR on your notebook,

```sh
nix run github:srid/emanote/idiomorph -- -L /path/to/your/notes
```