### PR TITLE
callout: Avoid hardcoding callout type

### DIFF
--- a/docs/guide/markdown/callout.md
+++ b/docs/guide/markdown/callout.md
@@ -43,6 +43,6 @@ Emanote supports [Obsidian-style callouts](https://help.obsidian.md/Editing+and+
 
 Callouts also work with [[orgmode]] syntax.
 
-## Customizing callouts {#custom}
+## Custom callouts {#custom}
 
-To customize their structure and styling, change `callout.tpl` (and `base.tpl`) in [[html-template|HTML templates]]. Want to add additional callout types to Emanote? See [this PR](https://github.com/srid/emanote/pull/571) as example.
+To add a new custom callout named `foo` (viz.: `[!foo] ...`), create a `/templates/filters/callout/foo.tpl` file in your [[html-template|templates]] folder. You can also change the layout and styling of existing callout types in [`/templates/filters/callout/*.tpl`](https://github.com/srid/emanote/tree/master/emanote/default/templates/filters/callout).

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               emanote
-version:            1.3.24.2
+version:            1.3.25.0
 license:            AGPL-3.0-only
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca
@@ -97,6 +97,7 @@ common library-common
     , base                   >=4.14    && <5
     , blaze-html
     , bytestring
+    , casing
     , commonmark
     , commonmark-extensions  >=0.2.3.4
     , commonmark-pandoc


### PR DESCRIPTION
Building atop #572 - we make it so that callout types are no longer hardcoded in Haskell.

The user can easily add custom callouts by creating the associated `.tpl` file (see #572)

@nramirezuy 

https://github.com/srid/emanote/issues/465