### PR TITLE
Add macOS launchd support to home-manager module

### DIFF
--- a/docs/start/install/nix.md
+++ b/docs/start/install/nix.md
@@ -44,9 +44,10 @@ in {
 
 Re-apply your home-manager configuration the usual way (e.g. `home-manager switch`).
 
-You will then have an `emanote` command in your profile, and a systemd
-user service running a live-preview of your notes.
+You will then have an `emanote` command in your profile, and a background
+service running a live-preview of your notes (systemd on Linux, launchd on macOS).
 
+On Linux:
 ```sh
 $ home-manager switch
 ...
@@ -60,6 +61,15 @@ $ systemctl --user status emanote.service
         CPU: 2.884s
      CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/emanote.service
              └─1705303 /nix/store/9hj2cwk1jakfws0d1hpwa221kcni3j45-emanote-0.3.12.1/bin/emanote --layers /nix/store/hr7wp1xvqn48b8gy16sdq6k2csrvr8c1-emanote-config;/home/user/notes
+```
+
+On macOS:
+```sh
+$ home-manager switch
+...
+$ launchctl list | grep emanote
+-	0	org.nix-community.home.emanote
+$ tail ~/Library/Logs/emanote.log
 ```
 
 [home-manager]: https://nixos.asia/en/home-manager

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -7,6 +7,7 @@
 - UI revamp (#622)
   - Dark mode (#605, #617)
 - Mermaid: add `elk` layout (#618)
+- Home Manager module: macOS support via launchd (#623)
 
 ## 1.4.0.0 (2025-08-18)
 


### PR DESCRIPTION
The home-manager module now works on macOS via launchd. Previously only systemd (Linux) was supported. Logs go to ~/Library/Logs/emanote.log on macOS.