### PR TITLE
Bootstrap APM with srid/agency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,13 @@ result
 result-*
 .direnv
 
-/.claude/*.local.*
+# We use apm
+/.claude/
 
 /.pre-commit-config.yaml
 
 /ghcid.log
+
+
+# APM dependencies
+apm_modules/

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,0 +1,18 @@
+lockfile_version: '1'
+generated_at: '2026-04-07T00:00:00.681514+00:00'
+apm_version: 0.8.10
+dependencies:
+- repo_url: srid/agency
+  host: github.com
+  resolved_commit: fdcd6901c9c1c476a9dee9d3afc95b533286942b
+  resolved_ref: master
+  package_type: apm_package
+  deployed_files:
+  - .claude/commands/do.md
+  - .claude/commands/talk.md
+  - .claude/hooks/agency/scripts/do-stop-guard.sh
+  - .claude/rules/apm-sources.md
+  - .claude/skills/code-police
+  - .claude/skills/github-pr
+  - .claude/skills/hickey
+  content_hash: sha256:ea3ea7a0c80263561a765dff41e46f5bab4a2f80be42f6e37ebce104082adc77

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,9 @@
+name: early-flower
+version: 1.0.0
+description: APM project for early-flower
+author: Sridhar Ratnakumar
+dependencies:
+  apm:
+  - srid/agency#master
+  mcp: []
+scripts: {}


### PR DESCRIPTION
**APM package management** added to the project, pulling in `srid/agency` as a dependency. This brings in shared Claude commands, skills, and hooks (do, talk, code-police, github-pr, hickey).

The `.claude/` directory is now fully APM-managed and gitignored — _local overrides still work, they just won't be tracked_.