### PR TITLE
Footnotes restyled; backlinks get embed/mention split; tidy styles.tpl

### DIFF
--- a/emanote/default/templates/components/backlinks.tpl
+++ b/emanote/default/templates/components/backlinks.tpl
@@ -1,7 +1,7 @@
 <ema:note:backlinks:nodaily>
   <div id="backlinks" class="flex-1 mt-8">
     <header class="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Links to this page</header>
-    <ul class="backlink-grid grid grid-cols-1 md:grid-cols-2 gap-3">
+    <ul class="grid grid-cols-1 md:grid-cols-2 gap-3">
       <backlink>
         <li class="backlink-card bg-white dark:bg-gray-950 border-l-2 border-primary-400 dark:border-primary-500 rounded-r-md p-3 shadow-sm hover:shadow-md hover:border-primary-600 dark:hover:border-primary-300 transition-shadow">
           <a class="backlink-title text-primary-700 dark:text-primary-300 font-semibold no-underline hover:underline block mb-1"

--- a/emanote/default/templates/components/backlinks.tpl
+++ b/emanote/default/templates/components/backlinks.tpl
@@ -1,10 +1,10 @@
 <ema:note:backlinks:nodaily>
   <div id="backlinks" class="flex-1 mt-8">
     <header class="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Links to this page</header>
-    <ul class="grid grid-cols-1 md:grid-cols-2 gap-3">
+    <ul class="backlink-grid grid grid-cols-1 md:grid-cols-2 gap-3">
       <backlink>
-        <li class="bg-white dark:bg-gray-950 border-l-2 border-primary-400 dark:border-primary-500 rounded-r-md p-3 shadow-sm hover:shadow-md hover:border-primary-600 dark:hover:border-primary-300 transition-all">
-          <a class="text-primary-700 dark:text-primary-300 font-semibold no-underline hover:underline block mb-2"
+        <li class="backlink-card bg-white dark:bg-gray-950 border-l-2 border-primary-400 dark:border-primary-500 rounded-r-md p-3 shadow-sm hover:shadow-md hover:border-primary-600 dark:hover:border-primary-300 transition-shadow">
+          <a class="backlink-title text-primary-700 dark:text-primary-300 font-semibold no-underline hover:underline block mb-1"
             href="${backlink:note:url}">
             <backlink:note:title />
           </a>

--- a/emanote/default/templates/components/backlinks.tpl
+++ b/emanote/default/templates/components/backlinks.tpl
@@ -3,8 +3,8 @@
     <header class="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Links to this page</header>
     <ul class="grid grid-cols-1 md:grid-cols-2 gap-3">
       <backlink>
-        <li class="backlink-card bg-white dark:bg-gray-950 border-l-2 border-primary-400 dark:border-primary-500 rounded-r-md p-3 shadow-sm hover:shadow-md hover:border-primary-600 dark:hover:border-primary-300 transition-shadow">
-          <a class="backlink-title text-primary-700 dark:text-primary-300 font-semibold no-underline hover:underline block mb-1"
+        <li class="group bg-white dark:bg-gray-950 border-l-2 border-primary-400 dark:border-primary-500 rounded-r-md p-3 shadow-sm hover:shadow-md hover:border-primary-600 dark:hover:border-primary-300 transition-shadow has-[[data-wikilink-type=WikiLinkEmbed]]:border-l-4 has-[[data-wikilink-type=WikiLinkEmbed]]:border-primary-600 dark:has-[[data-wikilink-type=WikiLinkEmbed]]:border-primary-400">
+          <a class="text-primary-700 dark:text-primary-300 font-semibold no-underline hover:underline block mb-1 after:content-none group-has-[[data-wikilink-type=WikiLinkEmbed]]:after:content-['embeds'] after:ml-2 after:px-[0.45em] after:py-[0.05em] after:text-[0.65em] after:font-medium after:tracking-wider after:uppercase after:text-primary-700 after:bg-primary-50 after:rounded after:align-[0.15em] dark:after:text-primary-200 dark:after:bg-primary-900"
             href="${backlink:note:url}">
             <backlink:note:title />
           </a>

--- a/emanote/default/templates/components/context.tpl
+++ b/emanote/default/templates/components/context.tpl
@@ -1,4 +1,4 @@
-<div class="backlink-context overflow-x-auto text-sm text-gray-500 dark:text-gray-300">
+<div class="overflow-x-auto text-sm text-gray-500 dark:text-gray-300 [&_p]:m-0 [&_p+p]:mt-[0.35em]">
   <context>
     <div>
       <context:body>

--- a/emanote/default/templates/components/context.tpl
+++ b/emanote/default/templates/components/context.tpl
@@ -1,6 +1,6 @@
-<div class="mb-4 overflow-x-auto text-sm text-gray-500 dark:text-gray-300">
+<div class="backlink-context overflow-x-auto text-sm text-gray-500 dark:text-gray-300">
   <context>
-    <div class="mt-2">
+    <div>
       <context:body>
         <PandocLink class="text-primary-700 dark:text-primary-300">
           <Internal class="font-semibold no-underline hover:underline decoration-primary-500" />

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -69,7 +69,7 @@
   </DefinitionList>
   <Note:Ref>
     <sup id="fnref${footnote:idx}" class="footnote-ref">
-      <a href="${ema:note:url}#fn${footnote:idx}">[<footnote:idx />]</a>
+      <a href="${ema:note:url}#fn${footnote:idx}"><footnote:idx /></a>
     </sup>
   </Note:Ref>
   <Note:List>

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -80,7 +80,7 @@
         <footnote>
           <li id="fn${footnote:idx}" class="pl-2">
             <footnote:content />
-            <a href="#fnref${footnote:idx}" class="footnote-backref" aria-label="Back to content">↩</a>
+            <a href="${ema:note:url}#fnref${footnote:idx}" class="footnote-backref" aria-label="Back to content">↩</a>
           </li>
         </footnote>
       </ol>

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -67,16 +67,16 @@
       </DefinitionList:Items>
     </dl>
   </DefinitionList>
-  <Note:Ref><sup id="fnref${footnote:idx}" class="footnote-ref"><a href="${ema:note:url}#fn${footnote:idx}"><footnote:idx /></a></sup></Note:Ref>
+  <Note:Ref><sup id="fnref${footnote:idx}" class="footnote-ref text-[0.7em] leading-[0] align-super pr-[0.08em] font-medium [font-variant-numeric:lining-nums]"><a class="text-primary-600 dark:text-primary-400 no-underline hover:underline hover:underline-offset-2 hover:decoration-1" href="${ema:note:url}#fn${footnote:idx}"><footnote:idx /></a></sup></Note:Ref>
   <Note:List>
     <aside title="Footnotes"
-      class="text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+      class="relative mt-14 pt-7 max-w-[44rem] text-sm leading-relaxed text-gray-600 dark:text-gray-400 before:content-[''] before:absolute before:top-0 before:left-0 before:w-14 before:h-[2px] before:bg-primary-500 after:content-[''] after:absolute after:top-px after:left-14 after:right-0 after:h-px after:bg-gray-200 dark:after:bg-gray-800">
       <header class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Footnotes</header>
-      <ol class="footnote-list list-decimal pl-6 space-y-3 marker:text-gray-400 dark:marker:text-gray-500">
+      <ol class="footnote-list list-decimal pl-6 space-y-3 marker:text-primary-600 dark:marker:text-primary-400 marker:font-medium [font-variant-numeric:oldstyle-nums]">
         <footnote>
           <li id="fn${footnote:idx}" class="pl-2">
             <footnote:content />
-            <a href="${ema:note:url}#fnref${footnote:idx}" class="footnote-backref" aria-label="Back to content">↩</a>
+            <a href="${ema:note:url}#fnref${footnote:idx}" class="footnote-backref ml-2 inline-block no-underline text-gray-400 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 transition hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:translate-y-0" aria-label="Back to content">↩</a>
           </li>
         </footnote>
       </ol>

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -67,14 +67,10 @@
       </DefinitionList:Items>
     </dl>
   </DefinitionList>
-  <Note:Ref>
-    <sup id="fnref${footnote:idx}" class="footnote-ref">
-      <a href="${ema:note:url}#fn${footnote:idx}"><footnote:idx /></a>
-    </sup>
-  </Note:Ref>
+  <Note:Ref><sup id="fnref${footnote:idx}" class="footnote-ref"><a href="${ema:note:url}#fn${footnote:idx}"><footnote:idx /></a></sup></Note:Ref>
   <Note:List>
     <aside title="Footnotes"
-      class="mt-12 pt-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400 border-t-2 border-gray-200 dark:border-gray-800">
+      class="text-sm leading-relaxed text-gray-600 dark:text-gray-400">
       <header class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Footnotes</header>
       <ol class="footnote-list list-decimal pl-6 space-y-3 marker:text-gray-400 dark:marker:text-gray-500">
         <footnote>

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -68,20 +68,19 @@
     </dl>
   </DefinitionList>
   <Note:Ref>
-    <sup class="px-0.5">
-      <a class="text-primary-600 dark:text-primary-400 hover:underline" href="${ema:note:url}#fn${footnote:idx}">
-        <footnote:idx />
-      </a>
+    <sup id="fnref${footnote:idx}" class="footnote-ref">
+      <a href="${ema:note:url}#fn${footnote:idx}">[<footnote:idx />]</a>
     </sup>
   </Note:Ref>
   <Note:List>
     <aside title="Footnotes"
       class="mt-12 pt-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400 border-t-2 border-gray-200 dark:border-gray-800">
       <header class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Footnotes</header>
-      <ol class="list-decimal pl-6 space-y-3 marker:font-mono marker:text-xs marker:text-gray-400 dark:marker:text-gray-500">
+      <ol class="footnote-list list-decimal pl-6 space-y-3 marker:text-gray-400 dark:marker:text-gray-500">
         <footnote>
           <li id="fn${footnote:idx}" class="pl-2">
             <footnote:content />
+            <a href="#fnref${footnote:idx}" class="footnote-backref" aria-label="Back to content">↩</a>
           </li>
         </footnote>
       </ol>

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -71,6 +71,109 @@
   }
 </style>
 
+<style data-category="footnotes">
+  /* Body-side ref: show as [N] with subtle background so it reads as a
+     footnote marker and is easier to click. */
+  sup.footnote-ref {
+    font-size: 0.75em;
+    padding: 0 0.15em;
+  }
+  sup.footnote-ref a {
+    color: var(--color-primary-700);
+    text-decoration: none;
+    padding: 0.05em 0.25em;
+    border-radius: 3px;
+    background-color: var(--color-primary-50);
+    transition: background-color 0.15s;
+  }
+  sup.footnote-ref a:hover {
+    background-color: var(--color-primary-100);
+    text-decoration: underline;
+  }
+  .dark sup.footnote-ref a {
+    color: var(--color-primary-300);
+    background-color: var(--color-primary-950);
+  }
+  .dark sup.footnote-ref a:hover {
+    background-color: var(--color-primary-900);
+  }
+
+  /* Back-reference arrow at end of footnote item. */
+  a.footnote-backref {
+    margin-left: 0.35em;
+    color: var(--color-gray-400);
+    text-decoration: none;
+  }
+  a.footnote-backref:hover {
+    color: var(--color-primary-600);
+  }
+  .dark a.footnote-backref {
+    color: var(--color-gray-600);
+  }
+  .dark a.footnote-backref:hover {
+    color: var(--color-primary-400);
+  }
+
+  /* :target highlight — flash the landed footnote (and the ref, when
+     jumped back to) so the destination is obvious. */
+  ol.footnote-list li:target,
+  sup.footnote-ref:target a {
+    animation: footnote-flash 1.2s ease-out;
+  }
+  @keyframes footnote-flash {
+    0%   { background-color: var(--color-primary-100); }
+    100% { background-color: transparent; }
+  }
+  .dark ol.footnote-list li:target,
+  .dark sup.footnote-ref:target a {
+    animation: footnote-flash-dark 1.2s ease-out;
+  }
+  @keyframes footnote-flash-dark {
+    0%   { background-color: var(--color-primary-900); }
+    100% { background-color: transparent; }
+  }
+</style>
+
+<style data-category="backlinks">
+  /* Tighten context spacing — the default block margins from the global
+     prose rules make each card feel sparse. */
+  .backlink-context p,
+  .backlink-context div {
+    margin: 0;
+  }
+  .backlink-context p + p {
+    margin-top: 0.35em;
+  }
+
+  /* Embed vs mention: if the card's context contains a WikiLinkEmbed, the
+     source page *transcludes* this one — a stronger relationship. Surface
+     it with a thicker, more saturated left rail and a small badge. */
+  li.backlink-card:has([data-wikilink-type="WikiLinkEmbed"]) {
+    border-left-width: 4px;
+    border-left-color: var(--color-primary-600);
+  }
+  .dark li.backlink-card:has([data-wikilink-type="WikiLinkEmbed"]) {
+    border-left-color: var(--color-primary-400);
+  }
+  li.backlink-card:has([data-wikilink-type="WikiLinkEmbed"]) .backlink-title::after {
+    content: "embeds";
+    margin-left: 0.5em;
+    padding: 0.05em 0.45em;
+    font-size: 0.65em;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--color-primary-700);
+    background-color: var(--color-primary-50);
+    border-radius: 3px;
+    vertical-align: 0.15em;
+  }
+  .dark li.backlink-card:has([data-wikilink-type="WikiLinkEmbed"]) .backlink-title::after {
+    color: var(--color-primary-200);
+    background-color: var(--color-primary-900);
+  }
+</style>
+
 <style data-category="callout">
   /* To prevent overemphasis of link styles in callout titles */
   .callout .callout-title a {

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -76,6 +76,8 @@
      footnote marker and is easier to click. */
   sup.footnote-ref {
     font-size: 0.75em;
+    line-height: 0;
+    vertical-align: super;
     padding: 0 0.15em;
   }
   sup.footnote-ref a {

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -106,46 +106,6 @@
   }
 </style>
 
-<style data-category="backlinks">
-  /* Tighten context spacing — the default block margins from the global
-     prose rules make each card feel sparse. Scoped to <p> only so nested
-     content (blockquotes, callouts, embed wrappers) keeps its own layout. */
-  .backlink-context p {
-    margin: 0;
-  }
-  .backlink-context p + p {
-    margin-top: 0.35em;
-  }
-
-  /* Embed vs mention: if the card's context contains a WikiLinkEmbed, the
-     source page *transcludes* this one — a stronger relationship. Surface
-     it with a thicker, more saturated left rail and a small badge. */
-  li.backlink-card:has([data-wikilink-type="WikiLinkEmbed"]) {
-    border-left-width: 4px;
-    border-left-color: var(--color-primary-600);
-  }
-  .dark li.backlink-card:has([data-wikilink-type="WikiLinkEmbed"]) {
-    border-left-color: var(--color-primary-400);
-  }
-  li.backlink-card:has([data-wikilink-type="WikiLinkEmbed"]) .backlink-title::after {
-    content: "embeds";
-    margin-left: 0.5em;
-    padding: 0.05em 0.45em;
-    font-size: 0.65em;
-    font-weight: 500;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    color: var(--color-primary-700);
-    background-color: var(--color-primary-50);
-    border-radius: 3px;
-    vertical-align: 0.15em;
-  }
-  .dark li.backlink-card:has([data-wikilink-type="WikiLinkEmbed"]) .backlink-title::after {
-    color: var(--color-primary-200);
-    background-color: var(--color-primary-900);
-  }
-</style>
-
 <style data-category="callout">
   /* To prevent overemphasis of link styles in callout titles */
   .callout .callout-title a {

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -98,7 +98,6 @@
     background-color: var(--color-primary-900);
   }
 
-  /* Back-reference arrow at end of footnote item. */
   a.footnote-backref {
     margin-left: 0.35em;
     color: var(--color-gray-400);

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -1,3 +1,17 @@
+<!-- styles.tpl is the escape hatch for CSS that inline Tailwind can't
+     express: @keyframes, :target, ::marker bodies that need multiple
+     properties, decorative ::before/::after stacks, @media queries,
+     font-feature-settings, and cross-cutting rules that apply to
+     Pandoc-rendered HTML we don't author class-by-class.
+
+     Prefer inline Tailwind in the templates (components/*.tpl) for
+     anything expressible as utility classes — colors, spacing,
+     typography, hover/dark/motion-reduce variants, before:content-[''],
+     marker:*, align-super, etc. Use arbitrary values (e.g.
+     [font-variant-numeric:oldstyle-nums]) before reaching for a new
+     rule here. Only land in this file when the alternative would be a
+     pile of [...] utilities so ugly that a CSS block reads cleaner. -->
+
 <link rel="stylesheet" href="${ema:emanoteStaticLayerUrl}/skylighting.css" />
 
 <!-- Fonts are self-hosted under _emanote-static/fonts to keep the
@@ -72,101 +86,10 @@
 </style>
 
 <style data-category="footnotes">
-  /* Footnotes as editorial apparatus — the scholarly gutter of a book,
-     not a second column of body prose. A short primary tick over a
-     full-width hairline marks the section break; old-style figures and
-     primary-tinted markers keep the numerals quiet but considered. */
-
-  /* Body-side ref — hugs the preceding word with lining figures and a
-     true superscript baseline. No padding-left so it reads as part of
-     the same word, not a separate token. */
-  sup.footnote-ref {
-    font-size: 0.7em;
-    line-height: 0;
-    vertical-align: super;
-    padding: 0 0.08em 0 0;
-    font-variant-numeric: lining-nums;
-    font-weight: 500;
-  }
-  sup.footnote-ref a {
-    color: var(--color-primary-600);
-    text-decoration: none;
-  }
-  sup.footnote-ref a:hover {
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
-    text-decoration-thickness: 1px;
-  }
-  .dark sup.footnote-ref a {
-    color: var(--color-primary-400);
-  }
-
-  /* The <aside> itself — replace the flat border-t-2 with a dual rule:
-     a short primary accent over a thin gray hairline, magazine-style. */
-  aside[title="Footnotes"] {
-    border-top: none !important;
-    margin-top: 3.5rem;
-    padding-top: 1.75rem;
-    position: relative;
-    max-width: 44rem;
-  }
-  aside[title="Footnotes"]::before {
-    /* Short primary tick, left-aligned */
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 3.5rem;
-    height: 2px;
-    background-color: var(--color-primary-500);
-  }
-  aside[title="Footnotes"]::after {
-    /* Thin gray hairline extending beneath the tick */
-    content: "";
-    position: absolute;
-    top: 1px;
-    left: 3.5rem;
-    right: 0;
-    height: 1px;
-    background-color: var(--color-gray-200);
-  }
-  .dark aside[title="Footnotes"]::after {
-    background-color: var(--color-gray-800);
-  }
-
-  /* List markers — old-style figures in primary, feel cited not listy */
-  ol.footnote-list {
-    font-variant-numeric: oldstyle-nums;
-  }
-  ol.footnote-list > li::marker {
-    color: var(--color-primary-600);
-    font-weight: 500;
-  }
-  .dark ol.footnote-list > li::marker {
-    color: var(--color-primary-400);
-  }
-
-  /* Back-reference — thin, muted; lifts and tints on hover */
-  a.footnote-backref {
-    margin-left: 0.5em;
-    color: var(--color-gray-400);
-    text-decoration: none;
-    display: inline-block;
-    transition: transform 0.15s ease, color 0.15s ease;
-  }
-  a.footnote-backref:hover {
-    color: var(--color-primary-600);
-    transform: translateY(-1px);
-  }
-  .dark a.footnote-backref {
-    color: var(--color-gray-600);
-  }
-  .dark a.footnote-backref:hover {
-    color: var(--color-primary-400);
-  }
-
-  /* :target flash — brief highlight on landing; theme-scoped start
-     color lets one keyframe serve both modes. */
+  /* Only the :target flash and its keyframes live here — Tailwind can't
+     express @keyframes or a theme-scoped start color for one animation.
+     Everything else (aside rules, markers, sup, backref) is inline
+     utilities in components/pandoc.tpl. */
   :root { --footnote-flash-start: var(--color-primary-100); }
   .dark { --footnote-flash-start: var(--color-primary-900); }
   ol.footnote-list li:target,
@@ -177,19 +100,9 @@
     0%   { background-color: var(--footnote-flash-start); }
     100% { background-color: transparent; }
   }
-
-  /* Respect users who asked for less motion */
   @media (prefers-reduced-motion: reduce) {
     ol.footnote-list li:target,
-    sup.footnote-ref:target a {
-      animation: none;
-    }
-    a.footnote-backref {
-      transition: none;
-    }
-    a.footnote-backref:hover {
-      transform: none;
-    }
+    sup.footnote-ref:target a { animation: none; }
   }
 </style>
 

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -72,32 +72,91 @@
 </style>
 
 <style data-category="footnotes">
-  /* Body-side ref: show as [N] with subtle background so it reads as a
-     footnote marker and is easier to click. */
+  /* Footnotes as editorial apparatus — the scholarly gutter of a book,
+     not a second column of body prose. A short primary tick over a
+     full-width hairline marks the section break; old-style figures and
+     primary-tinted markers keep the numerals quiet but considered. */
+
+  /* Body-side ref — hugs the preceding word with lining figures and a
+     true superscript baseline. No padding-left so it reads as part of
+     the same word, not a separate token. */
   sup.footnote-ref {
-    font-size: 0.75em;
+    font-size: 0.7em;
     line-height: 0;
     vertical-align: super;
-    padding: 0 0.15em;
+    padding: 0 0.08em 0 0;
+    font-variant-numeric: lining-nums;
+    font-weight: 500;
   }
   sup.footnote-ref a {
-    color: var(--color-primary-700);
+    color: var(--color-primary-600);
     text-decoration: none;
   }
   sup.footnote-ref a:hover {
     text-decoration: underline;
+    text-underline-offset: 0.2em;
+    text-decoration-thickness: 1px;
   }
   .dark sup.footnote-ref a {
-    color: var(--color-primary-300);
+    color: var(--color-primary-400);
   }
 
+  /* The <aside> itself — replace the flat border-t-2 with a dual rule:
+     a short primary accent over a thin gray hairline, magazine-style. */
+  aside[title="Footnotes"] {
+    border-top: none !important;
+    margin-top: 3.5rem;
+    padding-top: 1.75rem;
+    position: relative;
+    max-width: 44rem;
+  }
+  aside[title="Footnotes"]::before {
+    /* Short primary tick, left-aligned */
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 3.5rem;
+    height: 2px;
+    background-color: var(--color-primary-500);
+  }
+  aside[title="Footnotes"]::after {
+    /* Thin gray hairline extending beneath the tick */
+    content: "";
+    position: absolute;
+    top: 1px;
+    left: 3.5rem;
+    right: 0;
+    height: 1px;
+    background-color: var(--color-gray-200);
+  }
+  .dark aside[title="Footnotes"]::after {
+    background-color: var(--color-gray-800);
+  }
+
+  /* List markers — old-style figures in primary, feel cited not listy */
+  ol.footnote-list {
+    font-variant-numeric: oldstyle-nums;
+  }
+  ol.footnote-list > li::marker {
+    color: var(--color-primary-600);
+    font-weight: 500;
+  }
+  .dark ol.footnote-list > li::marker {
+    color: var(--color-primary-400);
+  }
+
+  /* Back-reference — thin, muted; lifts and tints on hover */
   a.footnote-backref {
-    margin-left: 0.35em;
+    margin-left: 0.5em;
     color: var(--color-gray-400);
     text-decoration: none;
+    display: inline-block;
+    transition: transform 0.15s ease, color 0.15s ease;
   }
   a.footnote-backref:hover {
     color: var(--color-primary-600);
+    transform: translateY(-1px);
   }
   .dark a.footnote-backref {
     color: var(--color-gray-600);
@@ -106,9 +165,8 @@
     color: var(--color-primary-400);
   }
 
-  /* :target highlight — flash the landed footnote (and the ref, when
-     jumped back to) so the destination is obvious. Theme-scoped start
-     color lets the single keyframe serve both light and dark. */
+  /* :target flash — brief highlight on landing; theme-scoped start
+     color lets one keyframe serve both modes. */
   :root { --footnote-flash-start: var(--color-primary-100); }
   .dark { --footnote-flash-start: var(--color-primary-900); }
   ol.footnote-list li:target,
@@ -118,6 +176,20 @@
   @keyframes footnote-flash {
     0%   { background-color: var(--footnote-flash-start); }
     100% { background-color: transparent; }
+  }
+
+  /* Respect users who asked for less motion */
+  @media (prefers-reduced-motion: reduce) {
+    ol.footnote-list li:target,
+    sup.footnote-ref:target a {
+      animation: none;
+    }
+    a.footnote-backref {
+      transition: none;
+    }
+    a.footnote-backref:hover {
+      transform: none;
+    }
   }
 </style>
 

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -113,7 +113,7 @@
   .dark { --footnote-flash-start: var(--color-primary-900); }
   ol.footnote-list li:target,
   sup.footnote-ref:target a {
-    animation: footnote-flash 1.2s ease-out;
+    animation: footnote-flash 0.5s ease-out;
   }
   @keyframes footnote-flash {
     0%   { background-color: var(--footnote-flash-start); }

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -81,21 +81,12 @@
   sup.footnote-ref a {
     color: var(--color-primary-700);
     text-decoration: none;
-    padding: 0.05em 0.25em;
-    border-radius: 3px;
-    background-color: var(--color-primary-50);
-    transition: background-color 0.15s;
   }
   sup.footnote-ref a:hover {
-    background-color: var(--color-primary-100);
     text-decoration: underline;
   }
   .dark sup.footnote-ref a {
     color: var(--color-primary-300);
-    background-color: var(--color-primary-950);
-  }
-  .dark sup.footnote-ref a:hover {
-    background-color: var(--color-primary-900);
   }
 
   a.footnote-backref {

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -115,21 +115,16 @@
   }
 
   /* :target highlight — flash the landed footnote (and the ref, when
-     jumped back to) so the destination is obvious. */
+     jumped back to) so the destination is obvious. Theme-scoped start
+     color lets the single keyframe serve both light and dark. */
+  :root { --footnote-flash-start: var(--color-primary-100); }
+  .dark { --footnote-flash-start: var(--color-primary-900); }
   ol.footnote-list li:target,
   sup.footnote-ref:target a {
     animation: footnote-flash 1.2s ease-out;
   }
   @keyframes footnote-flash {
-    0%   { background-color: var(--color-primary-100); }
-    100% { background-color: transparent; }
-  }
-  .dark ol.footnote-list li:target,
-  .dark sup.footnote-ref:target a {
-    animation: footnote-flash-dark 1.2s ease-out;
-  }
-  @keyframes footnote-flash-dark {
-    0%   { background-color: var(--color-primary-900); }
+    0%   { background-color: var(--footnote-flash-start); }
     100% { background-color: transparent; }
   }
 </style>

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -131,9 +131,9 @@
 
 <style data-category="backlinks">
   /* Tighten context spacing — the default block margins from the global
-     prose rules make each card feel sparse. */
-  .backlink-context p,
-  .backlink-context div {
+     prose rules make each card feel sparse. Scoped to <p> only so nested
+     content (blockquotes, callouts, embed wrappers) keeps its own layout. */
+  .backlink-context p {
     margin: 0;
   }
   .backlink-context p + p {


### PR DESCRIPTION
Two small UI sections got in the way of skimming. **Footnotes had no way back** and read as stray digits rather than cited references. **Backlinks all looked the same** whether the source merely mentioned this page or fully transcluded it — a strictly stronger relationship hidden behind identical cards.

Footnotes are now an editorial apparatus: a short primary tick over a thin gray hairline marks the section break, Lora old-style figures and primary-tinted markers keep the numerals quiet but considered, and the body-side ref is a true superscript with lining figures that hugs the preceding word. Each item ends with a `↩` backref; jumping in either direction triggers a 0.5s `:target` flash so the destination is obvious. _One `@keyframes` serves both light and dark via a theme-scoped CSS variable._

Backlink cards now declare embeds visually — a thicker, more saturated left rail plus a small `EMBEDS` badge after the title. The distinction is read from the `data-wikilink-type` attribute the Pandoc renderer already emits, via `has-[...]:` and `group-has-[...]:after:*` Tailwind variants. Card context spacing collapses paragraph margins so each card reads as one compact block.

> A styling-discipline pass came out of this: `styles.tpl` now carries a file-level comment saying it's an escape hatch for CSS that inline Tailwind can't express (`@keyframes`, `:target`, decorative `::before/::after` stacks, cross-cutting rules over Pandoc-rendered HTML). The footnote and backlink styling moved into utility chains in `components/pandoc.tpl`, `backlinks.tpl`, and `context.tpl`; the file-level comment keeps future agents from drifting that boundary.

### Try it locally

```sh
cd /path/to/your/notebook
nix run github:srid/emanote/ui-footnotes-backlinks
```