### PR TITLE
Static math on by default: LaTeX → MathML at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ apm_modules/
 
 /.worktrees
 /.do-results.json
+/.claude/scheduled_tasks.lock

--- a/docs/guide/html-template/external-links.md
+++ b/docs/guide/html-template/external-links.md
@@ -1,8 +1,5 @@
 ---
 slug: external-links
-page:
-  headHtml: |
-    <snippet var="js.mathjax" />
 ---
 
 # External links

--- a/docs/guide/orgmode.org
+++ b/docs/guide/orgmode.org
@@ -15,7 +15,7 @@ Here is a handpicked selection of syntatic features of Org Mode as particularly 
 
 *** Code blocks 
 
-See [[file:../tips/js/syntax-highlighting.md][Syntax Highlighting]] for general information.
+See [[file:../tips/syntax-highlighting.md][Syntax Highlighting]] for general information.
 
 #+NAME: factorial
 #+BEGIN_SRC haskell :results silent :exports code :var n=0

--- a/docs/guide/orgmode.yaml
+++ b/docs/guide/orgmode.yaml
@@ -1,3 +1,2 @@
-page:
-  headHtml: |
-    <snippet var="js.mathjax" />
+slug: orgmode
+

--- a/docs/tips/js/math.md
+++ b/docs/tips/js/math.md
@@ -9,7 +9,7 @@ Emanote renders `$...$` and `$$...$$` to **MathML at build time** by default via
 ### Demo
 
 When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
-$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}.$$
 
 ## Opting out
 
@@ -39,8 +39,15 @@ Paste the KaTeX loader directly into `page.headHtml` — Emanote's default confi
 ```yaml
 page:
   headHtml: |
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous">
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
+          crossorigin="anonymous">
+    <script defer
+            src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
+            crossorigin="anonymous"></script>
+    <script defer
+            src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
+            crossorigin="anonymous"
+            onload="renderMathInElement(document.body);"></script>
 ```
 

--- a/docs/tips/js/math.md
+++ b/docs/tips/js/math.md
@@ -6,7 +6,7 @@ slug: math
 
 Emanote renders `$...$` and `$$...$$` to **MathML at build time** by default via [`texmath`](https://hackage.haskell.org/package/texmath). Modern browsers (Firefox, Safari, Chrome ≥109) render MathML natively, so the page ships no math JS bundle.
 
-### Demo
+## Demo
 
 When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
 $$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}.$$

--- a/docs/tips/js/math.md
+++ b/docs/tips/js/math.md
@@ -1,17 +1,28 @@
 ---
 slug: math
-page:
-  headHtml: |
-    <snippet var="js.mathjax" />
 ---
 
 # Math
 
-## MathJax
+Emanote renders `$...$` and `$$...$$` to **MathML at build time** by default via [`texmath`](https://hackage.haskell.org/package/texmath). Modern browsers (Firefox, Safari, Chrome ≥109) render MathML natively, so the page ships no math JS bundle.
 
-[MathJax](https://www.mathjax.org) can be used to render Math formulas.  For example, $a^2 + b ^ 2 = c$.
+### Demo
 
-To enable it, add the following to `page.headHtml` of [[yaml-config|YAML configuration]] or Markdown frontmatter.
+When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+
+## Opting out
+
+If you prefer KaTeX's typography or need to support a very old browser, disable static rendering in your site's `index.yaml`:
+
+```yaml
+emanote:
+  staticMath: false
+```
+
+Then enable a client-side renderer per page (or globally via `page.headHtml` in your root `index.yaml`).
+
+### MathJax
 
 ```yaml
 page:
@@ -19,21 +30,17 @@ page:
     <snippet var="js.mathjax" />
 ```
 
-### Demo
+The `js.mathjax` snippet is shipped in the default config.
 
-When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
-$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+### KaTeX
 
-
-## KaTeX
-
-[KaTeX](https://katex.org/) can be used as an alternative to MathJax. Just like MathJax, it renders math specified between dollar signs.
-
-To enable it:
+Paste the KaTeX loader directly into `page.headHtml` — Emanote's default config no longer defines a `js.katex` snippet:
 
 ```yaml
 page:
   headHtml: |
-    <snippet var="js.katex" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
 ```
 

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 - **Tailwind v3 → v4 migration** with CSS-variable design tokens ([#633](https://github.com/srid/emanote/pull/633))
 - Built-in static syntax highlighting using skylighting, replacing client-side JS highlighters ([#624](https://github.com/srid/emanote/pull/624))
-- Built-in static math rendering (LaTeX → MathML at build time via `texmath`), closes [#626](https://github.com/srid/emanote/issues/626). KaTeX snippet removed from default config; MathJax snippet retained.
+- **Built-in static math rendering**: `$...$` / `$$...$$` are now converted to MathML at build time via `texmath`, so no runtime math JS is needed on a default site ([#639](https://github.com/srid/emanote/pull/639), closes [#626](https://github.com/srid/emanote/issues/626)).
+  - Controlled by `emanote.staticMath` (default: `true`). Set to `false` to fall back to client-side JS renderers.
+  - **Breaking**: the `js.katex` snippet has been removed from the default config. Existing sites referencing `<snippet var="js.katex" />` must inline the KaTeX loader into `page.headHtml` — see `docs/tips/js/math` for the exact lines. The `js.mathjax` snippet is retained.
+  - **API change** (only affects consumers of the `heist-extra` library directly): `mkRenderCtxWithPandocRenderers` now takes a `RenderFeatures` record instead of a lone `Bool`; `CodeBackend` / `MathBackend` sum types replace per-feature booleans.
 - UI revamp (#622, [#636](https://github.com/srid/emanote/pull/636))
   - New self-hosted typography: Lora + Space Grotesk + Space Mono.
   - Manual dark/light theme toggle (#605, #617) with `localStorage` persistence.

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Tailwind v3 → v4 migration** with CSS-variable design tokens ([#633](https://github.com/srid/emanote/pull/633))
 - Built-in static syntax highlighting using skylighting, replacing client-side JS highlighters ([#624](https://github.com/srid/emanote/pull/624))
+- Built-in static math rendering (LaTeX → MathML at build time via `texmath`), closes [#626](https://github.com/srid/emanote/issues/626). KaTeX snippet removed from default config; MathJax snippet retained.
 - UI revamp (#622, [#636](https://github.com/srid/emanote/pull/636))
   - New self-hosted typography: Lora + Space Grotesk + Space Mono.
   - Manual dark/light theme toggle (#605, #617) with `localStorage` persistence.

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - **Tailwind v3 → v4 migration** with CSS-variable design tokens ([#633](https://github.com/srid/emanote/pull/633))
 - Built-in static syntax highlighting using skylighting, replacing client-side JS highlighters ([#624](https://github.com/srid/emanote/pull/624))
-- Built-in static math rendering (LaTeX → MathML at build time via `texmath`) ([#639](https://github.com/srid/emanote/pull/639), closes [#626](https://github.com/srid/emanote/issues/626))
+- Built-in static math rendering (LaTeX → MathML at build time via `texmath`) ([#639](https://github.com/srid/emanote/pull/639))
 - UI revamp (#622, [#636](https://github.com/srid/emanote/pull/636))
   - New self-hosted typography: Lora + Space Grotesk + Space Mono.
   - Manual dark/light theme toggle (#605, #617) with `localStorage` persistence.

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -6,10 +6,7 @@
 
 - **Tailwind v3 → v4 migration** with CSS-variable design tokens ([#633](https://github.com/srid/emanote/pull/633))
 - Built-in static syntax highlighting using skylighting, replacing client-side JS highlighters ([#624](https://github.com/srid/emanote/pull/624))
-- **Built-in static math rendering**: `$...$` / `$$...$$` are now converted to MathML at build time via `texmath`, so no runtime math JS is needed on a default site ([#639](https://github.com/srid/emanote/pull/639), closes [#626](https://github.com/srid/emanote/issues/626)).
-  - Controlled by `emanote.staticMath` (default: `true`). Set to `false` to fall back to client-side JS renderers.
-  - **Breaking**: the `js.katex` snippet has been removed from the default config. Existing sites referencing `<snippet var="js.katex" />` must inline the KaTeX loader into `page.headHtml` — see `docs/tips/js/math` for the exact lines. The `js.mathjax` snippet is retained.
-  - **API change** (only affects consumers of the `heist-extra` library directly): `mkRenderCtxWithPandocRenderers` now takes a `RenderFeatures` record instead of a lone `Bool`; `CodeBackend` / `MathBackend` sum types replace per-feature booleans.
+- Built-in static math rendering (LaTeX → MathML at build time via `texmath`) ([#639](https://github.com/srid/emanote/pull/639), closes [#626](https://github.com/srid/emanote/issues/626))
 - UI revamp (#622, [#636](https://github.com/srid/emanote/pull/636))
   - New self-hosted typography: Lora + Space Grotesk + Space Mono.
   - Manual dark/light theme toggle (#605, #617) with `localStorage` persistence.

--- a/emanote/default/index.yaml
+++ b/emanote/default/index.yaml
@@ -137,20 +137,6 @@ js:
       };
     </script>
     <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-  katex: |
-    <link rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
-          integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV"
-          crossorigin="anonymous">
-    <script defer
-            src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
-            integrity="sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8"
-            crossorigin="anonymous"></script>
-    <script defer
-            src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
-            integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05"
-            crossorigin="anonymous"
-            onload="renderMathInElement(document.body);"></script>
 
 emanote:
   # Whether to automatically treat folder notes as a folgezettel parent of its contents
@@ -160,3 +146,9 @@ emanote:
   # Enable server-side syntax highlighting using skylighting (default: true)
   # Set to false to use client-side highlighters like highlight.js instead
   syntaxHighlighting: true
+
+  # Render `$...$` / `$$...$$` to MathML at build time via texmath (default: true).
+  # Modern browsers render MathML natively (Firefox, Safari, Chrome >=109), so
+  # no runtime JS is needed. Set to false to fall back to client-side JS
+  # (MathJax snippet, or a custom KaTeX snippet — see docs/tips/js/math).
+  staticMath: true

--- a/emanote/src/Emanote/Pandoc/Renderer.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer.hs
@@ -50,8 +50,8 @@ mkRenderCtxWithPandocRenderers ::
   Map Text Text ->
   model ->
   route ->
-  -- | Enable syntax highlighting for code blocks
-  Bool ->
+  -- | Rendering feature selection (code highlighting, static math, …)
+  Splices.RenderFeatures ->
   HeistT Identity m Splices.RenderCtx
 mkRenderCtxWithPandocRenderers nr@PandocRenderers {..} classRules model x =
   Splices.mkRenderCtx

--- a/emanote/src/Emanote/View/Common.hs
+++ b/emanote/src/Emanote/View/Common.hs
@@ -98,13 +98,11 @@ mkTemplateRenderCtx model r meta =
     renderFeatures =
       RenderFeatures
         { codeHighlighting =
-            if SData.lookupAeson True ("emanote" :| ["syntaxHighlighting"]) meta
-              then Skylighting
-              else NoHighlighting
+            bool NoHighlighting Skylighting
+              $ SData.lookupAeson True ("emanote" :| ["syntaxHighlighting"]) meta
         , mathRendering =
-            if SData.lookupAeson True ("emanote" :| ["staticMath"]) meta
-              then StaticMathML
-              else NoStaticMath
+            bool NoStaticMath StaticMathML
+              $ SData.lookupAeson True ("emanote" :| ["staticMath"]) meta
         }
 
 defaultRouteMeta :: Model -> (LMLRoute, Aeson.Value)

--- a/emanote/src/Emanote/View/Common.hs
+++ b/emanote/src/Emanote/View/Common.hs
@@ -31,7 +31,7 @@ import Emanote.View.LiveServerFiles qualified as LiveServerFiles
 import Emanote.View.Tailwind (generatedCssFile, tailwindBrowserConfig, themeRemapStyle)
 import Heist qualified as H
 import Heist.Extra.Splices.List qualified as Splices
-import Heist.Extra.Splices.Pandoc.Ctx (RenderCtx)
+import Heist.Extra.Splices.Pandoc.Ctx (CodeBackend (..), MathBackend (..), RenderCtx, RenderFeatures (..))
 import Heist.Extra.TemplateState qualified as Tmpl
 import Heist.Interpreted qualified as HI
 import Heist.Splices.Apply qualified as HA
@@ -90,13 +90,22 @@ mkTemplateRenderCtx model r meta =
           classRules
           model
           r
-          enableSyntaxHighlighting
+          renderFeatures
     classRules :: Map Text Text
     classRules =
       SData.lookupAeson mempty ("pandoc" :| ["rewriteClass"]) meta
-    enableSyntaxHighlighting :: Bool
-    enableSyntaxHighlighting =
-      SData.lookupAeson True ("emanote" :| ["syntaxHighlighting"]) meta
+    renderFeatures :: RenderFeatures
+    renderFeatures =
+      RenderFeatures
+        { codeHighlighting =
+            if SData.lookupAeson True ("emanote" :| ["syntaxHighlighting"]) meta
+              then Skylighting
+              else NoHighlighting
+        , mathRendering =
+            if SData.lookupAeson True ("emanote" :| ["staticMath"]) meta
+              then StaticMathML
+              else NoStaticMath
+        }
 
 defaultRouteMeta :: Model -> (LMLRoute, Aeson.Value)
 defaultRouteMeta model =

--- a/flake.lock
+++ b/flake.lock
@@ -136,16 +136,15 @@
     "heist-extra": {
       "flake": false,
       "locked": {
-        "lastModified": 1776809601,
-        "narHash": "sha256-GYuo4mAlxB3wq5l8dFbhRRJEJei6vHkdIHOoKGp35FM=",
+        "lastModified": 1776811520,
+        "narHash": "sha256-FCWJVrXjIu/du69h/rfkqXYcjA2+1CpJcxNVyDR6eyA=",
         "owner": "srid",
         "repo": "heist-extra",
-        "rev": "9e00d21a84bf146ff3ec784f69f3a776f89573aa",
+        "rev": "13c70e98621740fda1d93f4a5bd766b357535377",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "static-math",
         "repo": "heist-extra",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -136,15 +136,16 @@
     "heist-extra": {
       "flake": false,
       "locked": {
-        "lastModified": 1766109391,
-        "narHash": "sha256-ytHgIoRlkI5K0SDq33znlY0wjlqcwoQCe1z9JfHT/Fw=",
+        "lastModified": 1776809601,
+        "narHash": "sha256-GYuo4mAlxB3wq5l8dFbhRRJEJei6vHkdIHOoKGp35FM=",
         "owner": "srid",
         "repo": "heist-extra",
-        "rev": "81f1ea0cf1226215430171dbe613a2988c6cc46a",
+        "rev": "9e00d21a84bf146ff3ec784f69f3a776f89573aa",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "static-math",
         "repo": "heist-extra",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
     ema.flake = false;
     lvar.url = "github:srid/lvar/0.2.0.0";
     lvar.flake = false;
+    # TODO: replace with tagged release once srid/heist-extra#11 merges.
     heist-extra.url = "github:srid/heist-extra/static-math";
     heist-extra.flake = false;
     unionmount.url = "github:srid/unionmount/0.3.0.0";

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     ema.flake = false;
     lvar.url = "github:srid/lvar/0.2.0.0";
     lvar.flake = false;
-    heist-extra.url = "github:srid/heist-extra";
+    heist-extra.url = "github:srid/heist-extra/static-math";
     heist-extra.flake = false;
     unionmount.url = "github:srid/unionmount/0.3.0.0";
     unionmount.flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,7 @@
     ema.flake = false;
     lvar.url = "github:srid/lvar/0.2.0.0";
     lvar.flake = false;
-    # TODO: replace with tagged release once srid/heist-extra#11 merges.
-    heist-extra.url = "github:srid/heist-extra/static-math";
+    heist-extra.url = "github:srid/heist-extra";
     heist-extra.flake = false;
     unionmount.url = "github:srid/unionmount/0.3.0.0";
     unionmount.flake = false;

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -11,3 +11,7 @@ Feature: Smoke
     Given I note the resolved primary palette at "/"
     When I open "/themed.html"
     Then the resolved primary palette differs from the noted value
+
+  Scenario: Static math renders to a MathML element
+    When I open "/math.html"
+    Then the page contains a MathML element

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -12,6 +12,14 @@ Feature: Smoke
     When I open "/themed.html"
     Then the resolved primary palette differs from the noted value
 
-  Scenario: Static math renders to a MathML element
+  Scenario: Inline math renders to MathML at build time
     When I open "/math.html"
-    Then the page contains a MathML element
+    Then the page contains an inline <math> element in the MathML namespace
+
+  Scenario: Display math renders to block MathML at build time
+    When I open "/math.html"
+    Then the page contains a block <math> element in the MathML namespace
+
+  Scenario: KaTeX is not loaded by default
+    When I open "/math.html"
+    Then no KaTeX stylesheet is referenced

--- a/tests/fixtures/notebook/math.md
+++ b/tests/fixtures/notebook/math.md
@@ -5,5 +5,10 @@ page:
 
 # Math
 
-Static-math probe: the equation $x^2 + y^2 = z^2$ should serialize as a
-`<math>` element because `emanote.staticMath` defaults to `true`.
+Inline math probe: $x^2 + y^2 = z^2$ should become a `<math>` element
+with `display="inline"` (texmath's default for InlineMath).
+
+Display math probe: the quadratic formula below should become a `<math>`
+element with `display="block"`.
+
+$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$

--- a/tests/fixtures/notebook/math.md
+++ b/tests/fixtures/notebook/math.md
@@ -1,0 +1,9 @@
+---
+page:
+  siteTitle: Math Fixture
+---
+
+# Math
+
+Static-math probe: the equation $x^2 + y^2 = z^2$ should serialize as a
+`<math>` element because `emanote.staticMath` defaults to `true`.

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -27,21 +27,38 @@ Then(
   },
 );
 
-// texmath emits `<math xmlns="http://www.w3.org/1998/Math/MathML" display="...">`
-// for every expression. Assert on the namespace *and* display attribute so a
-// regression to raw `\(…\)` delimiters (for client-side MathJax/KaTeX) — which
-// would produce 0 math elements — fails loudly.
+// texmath emits `<math xmlns="…" display="…">` for every expression. The HTML
+// parser places `<math>` in the MathML namespace automatically, so
+// `element.namespaceURI` is the reliable check — the `xmlns=` attribute is a
+// namespace declaration that CSS `[xmlns=…]` selectors don't see. We assert
+// the `display` attribute via a CSS selector and the namespace via JS.
 const MATHML_NS = "http://www.w3.org/1998/Math/MathML";
+
+async function assertMathMLCount(
+  page: EmanoteWorld["page"],
+  display: "inline" | "block",
+  msgSuffix: string,
+) {
+  const count = await page.evaluate(
+    ({ display, ns }) =>
+      [...document.querySelectorAll(`math[display="${display}"]`)].filter(
+        (el) => el.namespaceURI === ns,
+      ).length,
+    { display, ns: MATHML_NS },
+  );
+  assert.ok(
+    count > 0,
+    `Expected at least one ${display} MathML element; found ${count}. ${msgSuffix}`,
+  );
+}
 
 Then(
   "the page contains an inline <math> element in the MathML namespace",
   async function (this: EmanoteWorld) {
-    const count = await this.page
-      .locator(`math[xmlns="${MATHML_NS}"][display="inline"]`)
-      .count();
-    assert.ok(
-      count > 0,
-      `Expected at least one inline MathML element; found ${count}. emanote.staticMath default may have regressed, or texmath's InlineMath → display="inline" mapping changed.`,
+    await assertMathMLCount(
+      this.page,
+      "inline",
+      "emanote.staticMath default may have regressed, or texmath's InlineMath → display=\"inline\" mapping changed.",
     );
   },
 );
@@ -49,12 +66,10 @@ Then(
 Then(
   "the page contains a block <math> element in the MathML namespace",
   async function (this: EmanoteWorld) {
-    const count = await this.page
-      .locator(`math[xmlns="${MATHML_NS}"][display="block"]`)
-      .count();
-    assert.ok(
-      count > 0,
-      `Expected at least one block MathML element; found ${count}. The $$…$$ display-math path is broken.`,
+    await assertMathMLCount(
+      this.page,
+      "block",
+      "The $$…$$ display-math path is broken.",
     );
   },
 );

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -28,6 +28,19 @@ Then(
 );
 
 Then(
+  "the page contains a MathML element",
+  async function (this: EmanoteWorld) {
+    // texmath writes `<math xmlns="…">` for every expression; a single
+    // locator hit is enough to prove the build-time pipeline fired.
+    const count = await this.page.locator("math").count();
+    assert.ok(
+      count > 0,
+      "Expected at least one <math> element; found 0 — emanote.staticMath default may have regressed.",
+    );
+  },
+);
+
+Then(
   "the resolved primary palette differs from the noted value",
   async function (this: EmanoteWorld) {
     assert.ok(

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -27,15 +27,51 @@ Then(
   },
 );
 
+// texmath emits `<math xmlns="http://www.w3.org/1998/Math/MathML" display="...">`
+// for every expression. Assert on the namespace *and* display attribute so a
+// regression to raw `\(…\)` delimiters (for client-side MathJax/KaTeX) — which
+// would produce 0 math elements — fails loudly.
+const MATHML_NS = "http://www.w3.org/1998/Math/MathML";
+
 Then(
-  "the page contains a MathML element",
+  "the page contains an inline <math> element in the MathML namespace",
   async function (this: EmanoteWorld) {
-    // texmath writes `<math xmlns="…">` for every expression; a single
-    // locator hit is enough to prove the build-time pipeline fired.
-    const count = await this.page.locator("math").count();
+    const count = await this.page
+      .locator(`math[xmlns="${MATHML_NS}"][display="inline"]`)
+      .count();
     assert.ok(
       count > 0,
-      "Expected at least one <math> element; found 0 — emanote.staticMath default may have regressed.",
+      `Expected at least one inline MathML element; found ${count}. emanote.staticMath default may have regressed, or texmath's InlineMath → display="inline" mapping changed.`,
+    );
+  },
+);
+
+Then(
+  "the page contains a block <math> element in the MathML namespace",
+  async function (this: EmanoteWorld) {
+    const count = await this.page
+      .locator(`math[xmlns="${MATHML_NS}"][display="block"]`)
+      .count();
+    assert.ok(
+      count > 0,
+      `Expected at least one block MathML element; found ${count}. The $$…$$ display-math path is broken.`,
+    );
+  },
+);
+
+Then(
+  "no KaTeX stylesheet is referenced",
+  async function (this: EmanoteWorld) {
+    // The js.katex snippet was removed from the default config in the same PR
+    // that flipped staticMath on. Default-config sites should therefore never
+    // emit a katex stylesheet link.
+    const count = await this.page
+      .locator('link[href*="katex"], script[src*="katex"]')
+      .count();
+    assert.strictEqual(
+      count,
+      0,
+      `Default config should not pull in KaTeX; found ${count} katex asset reference(s). Did the js.katex snippet or a default \`page.headHtml\` leak back in?`,
     );
   },
 );


### PR DESCRIPTION
**`$...$` / `$$...$$` now render to MathML at build time**, so a minimal Emanote site ships zero math JavaScript by default. Uses the new `RenderFeatures` API from [heist-extra#11](https://github.com/srid/heist-extra/pull/11), which swaps a grab-bag of per-feature `Bool`s on `RenderCtx` for a single record with sum-typed backends (`CodeBackend`, `MathBackend`). Closes #626.

Modern browsers (Firefox, Safari, Chrome ≥109) render MathML natively, so the default flips to `emanote.staticMath: true`. The `js.katex` snippet is **removed** from the default config — KaTeX is a minor enough alternative path that shipping a pinned CDN loader with SRI hashes that diverge from the KaTeX docs was doing readers a disservice. The MathJax snippet stays because it's the documented fallback. *Existing sites referencing `<snippet var="js.katex" />` will need to paste the loader directly into `page.headHtml` — see the rewritten `docs/tips/js/math.md` for the exact lines.*

An e2e smoke scenario asserts every build produces a `<math display="inline">` and a `<math display="block">` on the math fixture page, and that no KaTeX asset is referenced on a default-config page.

### Try it locally

```sh
nix run github:srid/emanote/static-math -- run -L docs
```