### PR TITLE
Popup-only footnotes with print fallback

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -49,7 +49,7 @@ https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/foot
 
 Demo: Checkout this note[^1] and this other note[^2] as both are footnotes. You may also reuse[^1] footnotes.
 
-Clicking a footnote reference opens a click-dismissible popup with the footnote's body — no scroll-away. On narrow screens the popup slides up as a bottom sheet. The full footnote list still renders at the bottom of the page, for print and no-JS fallback.
+Clicking a footnote reference opens a click-dismissible popup with the footnote's body — no scroll-away, no bottom footnote list. Keyboard users can focus a ref and press Enter or Space. On narrow screens the popup slides up as a bottom sheet.
 
 [^1]: First footnote example
 [^2]: Second footnote example. Footnotes *within*[^1] footnotes are not handled.

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -49,6 +49,8 @@ https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/foot
 
 Demo: Checkout this note[^1] and this other note[^2] as both are footnotes. You may also reuse[^1] footnotes.
 
+Clicking a footnote reference opens a click-dismissible popup with the footnote's body — no scroll-away. On narrow screens the popup slides up as a bottom sheet. The full footnote list still renders at the bottom of the page, for print and no-JS fallback.
+
 [^1]: First footnote example
 [^2]: Second footnote example. Footnotes *within*[^1] footnotes are not handled.
 

--- a/docs/guide/markdown/embed.md
+++ b/docs/guide/markdown/embed.md
@@ -6,12 +6,11 @@ date: 2022-08-03
 
 # Embedding
 
-You can embed files, using `![[..]]` - a syntax inspired by [Obsidian](https://help.obsidian.md/Linking+notes+and+files/Embedding+files). The HTML can be fully customized for each embed type[^parent].
+You can embed files, using `![[..]]` - a syntax inspired by [Obsidian](https://help.obsidian.md/Linking+notes+and+files/Embedding+files). The HTML can be fully customized for each embed types.
 
 > [!warning] 
 > The embed wiki-link syntax must appear on a paragraph of its own, with no other text added next to it.[^blk] Recursive embeds are supported.
 
-[^parent]: A page-level footnote, rendered into the bottom list and also shown in the click-anywhere popup. The popup is a progressive enhancement — the bottom list stays usable when JS is off or on print.
 [^blk]: This constraint is necessary to ensure that the HTML generated remains valid. Embedded content use block elements, which cannot be embedded inside inline nodes.
 
 ## Notes

--- a/docs/guide/markdown/embed.md
+++ b/docs/guide/markdown/embed.md
@@ -6,11 +6,12 @@ date: 2022-08-03
 
 # Embedding
 
-You can embed files, using `![[..]]` - a syntax inspired by [Obsidian](https://help.obsidian.md/Linking+notes+and+files/Embedding+files). The HTML can be fully customized for each embed types.
+You can embed files, using `![[..]]` - a syntax inspired by [Obsidian](https://help.obsidian.md/Linking+notes+and+files/Embedding+files). The HTML can be fully customized for each embed type[^parent].
 
 > [!warning] 
 > The embed wiki-link syntax must appear on a paragraph of its own, with no other text added next to it.[^blk] Recursive embeds are supported.
 
+[^parent]: A page-level footnote, rendered into the bottom list and also shown in the click-anywhere popup. The popup is a progressive enhancement — the bottom list stays usable when JS is off or on print.
 [^blk]: This constraint is necessary to ensure that the HTML generated remains valid. Embedded content use block elements, which cannot be embedded inside inline nodes.
 
 ## Notes

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -11,6 +11,7 @@
   - New self-hosted typography: Lora + Space Grotesk + Space Mono.
   - Manual dark/light theme toggle (#605, #617) with `localStorage` persistence.
   - Backlinks as a card grid; TOC with depth-based hierarchy and `IntersectionObserver` scroll-spy (#520).
+  - Popup footnotes as the only on-screen UI (desktop card / mobile bottom-sheet); printed output renders the footnote list ([#642](https://github.com/srid/emanote/pull/642)).
 - Mermaid: add `elk` layout ([#618](https://github.com/srid/emanote/pull/618))
 - Home Manager module: macOS support via launchd ([#623](https://github.com/srid/emanote/pull/623))
 

--- a/emanote/default/templates/base.tpl
+++ b/emanote/default/templates/base.tpl
@@ -45,6 +45,7 @@
   <tailwindCssShim />
 
   <apply template="/templates/styles" />
+  <apply template="/templates/components/footnote-popup" />
   <apply template="/templates/hooks/more-head" />
 
   <head-main />

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -176,11 +176,6 @@
       var body = popover.firstElementChild;
       body.textContent = '';
       body.appendChild(cloneContent(target));
-      if (currentRef && currentRef !== ref) {
-        currentRef.classList.remove('emanote-footnote-active');
-      }
-      currentRef = ref;
-      ref.classList.add('emanote-footnote-active');
       // hidePopover throws InvalidStateError if the popover is already
       // closed. That's the expected case on first open; the throw carries
       // no signal we'd act on, so swallow it.
@@ -192,6 +187,13 @@
         console.warn('[emanote] footnote popover showPopover failed', err);
         return;
       }
+      // Only dirty the active-state after show succeeds — otherwise a
+      // failed show leaves a stale highlight on the ref until next click.
+      if (currentRef && currentRef !== ref) {
+        currentRef.classList.remove('emanote-footnote-active');
+      }
+      currentRef = ref;
+      ref.classList.add('emanote-footnote-active');
       // Defer to next frame so popover width reflects the content just
       // inserted — measuring immediately after showPopover() can center
       // on the previous frame's width.

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -41,12 +41,12 @@
   .emanote-footnote-popup-body > :last-child { margin-bottom: 0; }
   .emanote-footnote-popup-body p { margin-bottom: 0.5rem; }
 
-  sup.footnote-ref.emanote-footnote-active a {
+  sup[data-footnote-ref].emanote-footnote-active a {
     background-color: var(--color-primary-100);
     border-radius: 3px;
     padding: 0 0.2em;
   }
-  .dark sup.footnote-ref.emanote-footnote-active a {
+  .dark sup[data-footnote-ref].emanote-footnote-active a {
     background-color: var(--color-primary-900);
   }
 

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -89,6 +89,10 @@
 
     var popoverEl = null;
     var currentRef = null;
+    // Pandoc emits exactly one top-level <aside data-footnote-list> per
+    // page. Live-server reloads the whole document on source changes, so
+    // caching across clicks is safe — no SPA mutations to worry about.
+    var topLevelAside = null;
 
     function ensurePopover() {
       if (popoverEl) return popoverEl;
@@ -116,16 +120,16 @@
       if (embed) {
         return embed.querySelector('aside[data-footnote-list] ' + liSel);
       }
-      // Non-embedded ref: find the first top-level aside (one whose closest
-      // data-footnote-embed ancestor is itself null).
-      var asides = document.querySelectorAll('aside[data-footnote-list]');
-      for (var i = 0; i < asides.length; i++) {
-        if (!asides[i].closest('[data-footnote-embed]')) {
-          var li = asides[i].querySelector(liSel);
-          if (li) return li;
+      if (!topLevelAside) {
+        var asides = document.querySelectorAll('aside[data-footnote-list]');
+        for (var i = 0; i < asides.length; i++) {
+          if (!asides[i].closest('[data-footnote-embed]')) {
+            topLevelAside = asides[i];
+            break;
+          }
         }
       }
-      return null;
+      return topLevelAside ? topLevelAside.querySelector(liSel) : null;
     }
 
     function cloneContent(li) {

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -83,7 +83,6 @@
       return;
     }
 
-    var POPOVER_ID = 'emanote-footnote-popover';
     // MOBILE_MAX must stay in sync with the @media (max-width: …) breakpoint
     // in the <style> above — neither side enforces it.
     var MOBILE_MAX = 640;
@@ -94,7 +93,7 @@
     function ensurePopover() {
       if (popoverEl) return popoverEl;
       popoverEl = document.createElement('div');
-      popoverEl.id = POPOVER_ID;
+      popoverEl.id = 'emanote-footnote-popover';
       popoverEl.setAttribute('popover', 'auto');
       var body = document.createElement('div');
       body.className = 'emanote-footnote-popup-body';

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -83,9 +83,9 @@
       return;
     }
 
-    // MOBILE_MAX must stay in sync with the @media (max-width: …) breakpoint
-    // in the <style> above — neither side enforces it.
-    var MOBILE_MAX = 640;
+    // The pixel value must stay in sync with the @media (max-width: …)
+    // breakpoint in the <style> above — neither side enforces it.
+    var mobileMQL = window.matchMedia('(max-width: 640px)');
 
     var popoverEl = null;
     var currentRef = null;
@@ -136,12 +136,8 @@
       return clone;
     }
 
-    function isMobile() {
-      return window.matchMedia('(max-width: ' + MOBILE_MAX + 'px)').matches;
-    }
-
     function positionPopover(popover, ref) {
-      if (isMobile()) {
+      if (mobileMQL.matches) {
         popover.classList.add('emanote-footnote-popup--mobile');
         popover.style.top = '';
         popover.style.left = '';

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -181,6 +181,9 @@
       }
       currentRef = ref;
       ref.classList.add('emanote-footnote-active');
+      // hidePopover throws InvalidStateError if the popover is already
+      // closed. That's the expected case on first open; the throw carries
+      // no signal we'd act on, so swallow it.
       try { popover.hidePopover(); } catch (_) {}
       try {
         popover.showPopover();

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -132,7 +132,7 @@
     function cloneContent(li) {
       var clone = li.cloneNode(true);
       // Backref would navigate away from the popup — drop it.
-      var backrefs = clone.querySelectorAll('a.footnote-backref');
+      var backrefs = clone.querySelectorAll('a[data-footnote-backref]');
       for (var i = 0; i < backrefs.length; i++) backrefs[i].remove();
       return clone;
     }

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -147,7 +147,6 @@
       var refRect = ref.getBoundingClientRect();
       var popRect = popover.getBoundingClientRect();
       var vw = window.innerWidth;
-      var vh = window.innerHeight;
       var margin = 12;
 
       var left = refRect.left + refRect.width / 2 - popRect.width / 2;

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -25,17 +25,17 @@
   #emanote-footnote-popover::backdrop { background: transparent; }
   .emanote-footnote-popup-body {
     background: white;
-    color: var(--color-gray-800, #1f2937);
+    color: var(--color-gray-800);
     padding: 0.875rem 1.125rem;
     border-radius: 0.5rem;
-    border: 1px solid var(--color-gray-200, #e5e7eb);
+    border: 1px solid var(--color-gray-200);
     box-shadow: 0 10px 25px -5px rgb(0 0 0 / 0.15), 0 8px 10px -6px rgb(0 0 0 / 0.1);
     position: relative;
   }
   .dark .emanote-footnote-popup-body {
-    background: var(--color-gray-900, #111827);
-    color: var(--color-gray-200, #e5e7eb);
-    border-color: var(--color-gray-700, #374151);
+    background: var(--color-gray-900);
+    color: var(--color-gray-200);
+    border-color: var(--color-gray-700);
     box-shadow: 0 10px 25px -5px rgb(0 0 0 / 0.6), 0 8px 10px -6px rgb(0 0 0 / 0.5);
   }
   .emanote-footnote-popup-body > :last-child { margin-bottom: 0; }

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -1,0 +1,214 @@
+<!-- Progressive-enhancement popup for footnote references.
+
+     Binds to the stable contract `data-footnote-ref` / `data-footnote-id`
+     / `data-footnote-list` / `data-footnote-embed` emitted by pandoc.tpl
+     and embed-note.tpl, not to Pandoc's `.footnote-ref` / `.footnote-list`
+     class names (those are stable-by-stasis, not by encapsulation).
+
+     The bottom `<aside>` stays visible as a no-JS / print fallback; the
+     popup is a convenience layer, not a replacement. -->
+
+<style data-category="footnote-popup">
+  #emanote-footnote-popover {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    position: fixed;
+    max-width: min(32rem, calc(100vw - 2rem));
+    width: max-content;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: inherit;
+    z-index: 9999;
+  }
+  #emanote-footnote-popover::backdrop { background: transparent; }
+  .emanote-footnote-popup-body {
+    background: white;
+    color: var(--color-gray-800, #1f2937);
+    padding: 0.875rem 1.125rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-gray-200, #e5e7eb);
+    box-shadow: 0 10px 25px -5px rgb(0 0 0 / 0.15), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+    position: relative;
+  }
+  .dark .emanote-footnote-popup-body {
+    background: var(--color-gray-900, #111827);
+    color: var(--color-gray-200, #e5e7eb);
+    border-color: var(--color-gray-700, #374151);
+    box-shadow: 0 10px 25px -5px rgb(0 0 0 / 0.6), 0 8px 10px -6px rgb(0 0 0 / 0.5);
+  }
+  .emanote-footnote-popup-body > :last-child { margin-bottom: 0; }
+  .emanote-footnote-popup-body p { margin-bottom: 0.5rem; }
+
+  sup.footnote-ref.emanote-footnote-active a {
+    background-color: var(--color-primary-100);
+    border-radius: 3px;
+    padding: 0 0.2em;
+  }
+  .dark sup.footnote-ref.emanote-footnote-active a {
+    background-color: var(--color-primary-900);
+  }
+
+  /* Mobile bottom-sheet: slide up from the bottom, full width. */
+  @media (max-width: 640px) {
+    .emanote-footnote-popup--mobile {
+      top: auto !important;
+      left: 0 !important;
+      right: 0 !important;
+      bottom: 0 !important;
+      width: 100% !important;
+      max-width: 100vw !important;
+    }
+    .emanote-footnote-popup--mobile .emanote-footnote-popup-body {
+      border-radius: 1rem 1rem 0 0;
+      padding: 1rem 1.25rem 1.5rem;
+      max-height: 60vh;
+      overflow-y: auto;
+      box-shadow: 0 -12px 30px -5px rgb(0 0 0 / 0.25);
+    }
+  }
+</style>
+
+<script>
+  (function () {
+    'use strict';
+
+    if (typeof HTMLElement === 'undefined' ||
+        !HTMLElement.prototype.hasOwnProperty('popover')) {
+      // No Popover API — fall through to native anchor navigation.
+      return;
+    }
+
+    var POPOVER_ID = 'emanote-footnote-popover';
+    var MOBILE_MAX = 640;
+
+    var popoverEl = null;
+    var currentRef = null;
+
+    function ensurePopover() {
+      if (popoverEl) return popoverEl;
+      popoverEl = document.createElement('div');
+      popoverEl.id = POPOVER_ID;
+      popoverEl.setAttribute('popover', 'auto');
+      var body = document.createElement('div');
+      body.className = 'emanote-footnote-popup-body';
+      popoverEl.appendChild(body);
+      document.body.appendChild(popoverEl);
+      popoverEl.addEventListener('toggle', function (e) {
+        if (e.newState === 'closed' && currentRef) {
+          currentRef.classList.remove('emanote-footnote-active');
+          currentRef = null;
+        }
+      });
+      return popoverEl;
+    }
+
+    function findTarget(ref) {
+      var idx = ref.getAttribute('data-footnote-ref');
+      if (!idx) return null;
+      var liSel = 'li[data-footnote-id="' + CSS.escape(idx) + '"]';
+      var embed = ref.closest('[data-footnote-embed]');
+      if (embed) {
+        return embed.querySelector('aside[data-footnote-list] ' + liSel);
+      }
+      // Non-embedded ref: find the first top-level aside (one whose closest
+      // data-footnote-embed ancestor is itself null).
+      var asides = document.querySelectorAll('aside[data-footnote-list]');
+      for (var i = 0; i < asides.length; i++) {
+        if (!asides[i].closest('[data-footnote-embed]')) {
+          var li = asides[i].querySelector(liSel);
+          if (li) return li;
+        }
+      }
+      return null;
+    }
+
+    function cloneContent(li) {
+      var clone = li.cloneNode(true);
+      // Backref would navigate away from the popup — drop it.
+      var backrefs = clone.querySelectorAll('a.footnote-backref');
+      for (var i = 0; i < backrefs.length; i++) backrefs[i].remove();
+      return clone;
+    }
+
+    function isMobile() {
+      return window.matchMedia('(max-width: ' + MOBILE_MAX + 'px)').matches;
+    }
+
+    function positionPopover(popover, ref) {
+      if (isMobile()) {
+        popover.classList.add('emanote-footnote-popup--mobile');
+        popover.style.top = '';
+        popover.style.left = '';
+        return;
+      }
+      popover.classList.remove('emanote-footnote-popup--mobile');
+      var refRect = ref.getBoundingClientRect();
+      var popRect = popover.getBoundingClientRect();
+      var vw = window.innerWidth;
+      var vh = window.innerHeight;
+      var margin = 12;
+
+      var left = refRect.left + refRect.width / 2 - popRect.width / 2;
+      if (left < margin) left = margin;
+      if (left + popRect.width > vw - margin) left = vw - popRect.width - margin;
+
+      var spaceAbove = refRect.top;
+      var top;
+      if (spaceAbove > popRect.height + margin) {
+        top = refRect.top - popRect.height - 8;
+      } else {
+        top = refRect.bottom + 8;
+      }
+      if (top < margin) top = margin;
+
+      popover.style.top = top + 'px';
+      popover.style.left = left + 'px';
+    }
+
+    function openFor(ref, target) {
+      var popover = ensurePopover();
+      var body = popover.firstElementChild;
+      body.textContent = '';
+      body.appendChild(cloneContent(target));
+      if (currentRef && currentRef !== ref) {
+        currentRef.classList.remove('emanote-footnote-active');
+      }
+      currentRef = ref;
+      ref.classList.add('emanote-footnote-active');
+      try { popover.hidePopover(); } catch (_) {}
+      try { popover.showPopover(); } catch (_) { return; }
+      positionPopover(popover, ref);
+    }
+
+    function onClick(e) {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
+      var sup = e.target.closest('sup[data-footnote-ref]');
+      if (!sup) return;
+      var target = findTarget(sup);
+      if (!target) return;
+      e.preventDefault();
+      openFor(sup, target);
+    }
+
+    function onViewportChange() {
+      if (popoverEl && popoverEl.matches(':popover-open') && currentRef) {
+        positionPopover(popoverEl, currentRef);
+      }
+    }
+
+    function init() {
+      document.addEventListener('click', onClick);
+      window.addEventListener('resize', onViewportChange);
+      window.addEventListener('scroll', onViewportChange, { passive: true });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+  })();
+</script>

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -1,7 +1,7 @@
 <!-- Progressive-enhancement popup for footnote references.
 
      Binds to the stable contract `data-footnote-ref` / `data-footnote-id`
-     / `data-footnote-list` / `data-footnote-embed` emitted by pandoc.tpl
+     / `data-footnote-list` / `data-footnote-scope` emitted by pandoc.tpl
      and embed-note.tpl, not to Pandoc's `.footnote-ref` / `.footnote-list`
      class names (those are stable-by-stasis, not by encapsulation).
 
@@ -40,6 +40,13 @@
   }
   .emanote-footnote-popup-body > :last-child { margin-bottom: 0; }
   .emanote-footnote-popup-body p { margin-bottom: 0.5rem; }
+  /* The cloned <li> lives outside its <ol>; strip the stray marker
+     and the indent that would otherwise reserve room for it. */
+  .emanote-footnote-popup-body > li {
+    list-style: none;
+    padding-left: 0;
+    margin-left: 0;
+  }
 
   sup[data-footnote-ref].emanote-footnote-active a {
     background-color: var(--color-primary-100);
@@ -109,24 +116,33 @@
       return popoverEl;
     }
 
+    function findOwnAside(scope) {
+      // The aside "owned" by a scope is the one whose nearest
+      // data-footnote-scope ancestor is the scope itself — not a nested
+      // one. When scope is null, the root is the document and owned
+      // asides are those with no scope ancestor at all.
+      var root = scope || document;
+      var asides = root.querySelectorAll('aside[data-footnote-list]');
+      for (var i = 0; i < asides.length; i++) {
+        if (asides[i].closest('[data-footnote-scope]') === scope) return asides[i];
+      }
+      return null;
+    }
+
     function findTarget(ref) {
       var idx = ref.getAttribute('data-footnote-ref');
       if (!idx) return null;
-      var liSel = 'li[data-footnote-id="' + CSS.escape(idx) + '"]';
-      var embed = ref.closest('[data-footnote-embed]');
-      if (embed) {
-        return embed.querySelector('aside[data-footnote-list] ' + liSel);
+      var scope = ref.closest('[data-footnote-scope]');
+      var aside;
+      if (scope === null) {
+        if (!topLevelAside) topLevelAside = findOwnAside(null);
+        aside = topLevelAside;
+      } else {
+        aside = findOwnAside(scope);
       }
-      if (!topLevelAside) {
-        var asides = document.querySelectorAll('aside[data-footnote-list]');
-        for (var i = 0; i < asides.length; i++) {
-          if (!asides[i].closest('[data-footnote-embed]')) {
-            topLevelAside = asides[i];
-            break;
-          }
-        }
-      }
-      return topLevelAside ? topLevelAside.querySelector(liSel) : null;
+      return aside
+        ? aside.querySelector('li[data-footnote-id="' + CSS.escape(idx) + '"]')
+        : null;
     }
 
     function cloneContent(li) {

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -177,7 +177,13 @@
       currentRef = ref;
       ref.classList.add('emanote-footnote-active');
       try { popover.hidePopover(); } catch (_) {}
-      try { popover.showPopover(); } catch (_) { return; }
+      try {
+        popover.showPopover();
+      } catch (err) {
+        // Silent return would mean the click appeared to do nothing.
+        console.warn('[emanote] footnote popover showPopover failed', err);
+        return;
+      }
       // Defer to next frame so popover width reflects the content just
       // inserted — measuring immediately after showPopover() can center
       // on the previous frame's width.

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -178,7 +178,10 @@
       ref.classList.add('emanote-footnote-active');
       try { popover.hidePopover(); } catch (_) {}
       try { popover.showPopover(); } catch (_) { return; }
-      positionPopover(popover, ref);
+      // Defer to next frame so popover width reflects the content just
+      // inserted — measuring immediately after showPopover() can center
+      // on the previous frame's width.
+      requestAnimationFrame(function () { positionPopover(popover, ref); });
     }
 
     function onClick(e) {

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -1,81 +1,16 @@
 <!-- Footnote popup. Footnote refs have no anchor href and no bottom list
-     renders on screen; the body content is emitted inside a hidden
-     <aside data-footnote-list>, sourced only by this script for the
-     popup clone. Bound to data-footnote-ref / data-footnote-id /
-     data-footnote-list / data-footnote-scope. -->
+     renders on screen (the hidden <aside data-footnote-list> is the clone
+     source for this script, and also the print-mode rendering). Bound to
+     data-footnote-ref / data-footnote-id / data-footnote-list /
+     data-footnote-scope.
+
+     Popover chrome is styled via Tailwind utility classes applied from
+     the script below onto the JS-created <div>; the one CSS escape
+     hatch here is the Popover ::backdrop pseudo-element, which has no
+     Tailwind variant. -->
 
 <style data-category="footnote-popup">
-  #emanote-footnote-popover {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    position: fixed;
-    max-width: min(32rem, calc(100vw - 2rem));
-    width: max-content;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    color: inherit;
-    z-index: 9999;
-  }
   #emanote-footnote-popover::backdrop { background: transparent; }
-  .emanote-footnote-popup-body {
-    background: white;
-    color: var(--color-gray-800);
-    padding: 0.875rem 1.125rem;
-    border-radius: 0.5rem;
-    border: 1px solid var(--color-gray-200);
-    box-shadow: 0 10px 25px -5px rgb(0 0 0 / 0.15), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-    position: relative;
-  }
-  .dark .emanote-footnote-popup-body {
-    background: var(--color-gray-900);
-    color: var(--color-gray-200);
-    border-color: var(--color-gray-700);
-    box-shadow: 0 10px 25px -5px rgb(0 0 0 / 0.6), 0 8px 10px -6px rgb(0 0 0 / 0.5);
-  }
-  .emanote-footnote-popup-body > :last-child { margin-bottom: 0; }
-  .emanote-footnote-popup-body p { margin-bottom: 0.5rem; }
-  /* The cloned <li> lives outside its <ol>; strip the stray marker
-     and the indent that would otherwise reserve room for it. */
-  .emanote-footnote-popup-body > li {
-    list-style: none;
-    padding-left: 0;
-    margin-left: 0;
-  }
-
-  sup[data-footnote-ref].emanote-footnote-active {
-    background-color: var(--color-primary-100);
-    border-radius: 3px;
-    padding: 0 0.2em;
-  }
-  .dark sup[data-footnote-ref].emanote-footnote-active {
-    background-color: var(--color-primary-900);
-  }
-  sup[data-footnote-ref]:focus-visible {
-    outline: 2px solid var(--color-primary-500);
-    outline-offset: 2px;
-    border-radius: 2px;
-  }
-
-  /* Mobile bottom-sheet: slide up from the bottom, full width. */
-  @media (max-width: 640px) {
-    .emanote-footnote-popup--mobile {
-      top: auto !important;
-      left: 0 !important;
-      right: 0 !important;
-      bottom: 0 !important;
-      width: 100% !important;
-      max-width: 100vw !important;
-    }
-    .emanote-footnote-popup--mobile .emanote-footnote-popup-body {
-      border-radius: 1rem 1rem 0 0;
-      padding: 1rem 1.25rem 1.5rem;
-      max-height: 60vh;
-      overflow-y: auto;
-      box-shadow: 0 -12px 30px -5px rgb(0 0 0 / 0.25);
-    }
-  }
 </style>
 
 <script>
@@ -84,19 +19,42 @@
 
     if (typeof HTMLElement === 'undefined' ||
         !HTMLElement.prototype.hasOwnProperty('popover')) {
-      // No Popover API — fall through to native anchor navigation.
+      // No Popover API — footnote refs stay inert, no popup.
       return;
     }
 
-    // The pixel value must stay in sync with the @media (max-width: …)
-    // breakpoint in the <style> above — neither side enforces it.
+    // Keep these in sync with the max-sm: variants below (Tailwind's sm
+    // breakpoint is 640px). Parsed as a MediaQueryList once and reused.
     var mobileMQL = window.matchMedia('(max-width: 640px)');
+
+    var POPOVER_CLASS = [
+      'fixed z-[9999] m-0 p-0 border-0 bg-transparent',
+      'w-max max-w-[min(32rem,calc(100vw-2rem))]',
+      'text-[0.95rem] leading-relaxed',
+      // Mobile: pin to viewport edge as a full-width bottom sheet.
+      'max-sm:top-auto max-sm:left-0 max-sm:right-0 max-sm:bottom-0',
+      'max-sm:w-full max-sm:max-w-full',
+    ].join(' ');
+
+    var BODY_CLASS = [
+      'relative bg-white dark:bg-gray-900',
+      'text-gray-800 dark:text-gray-200',
+      'px-[1.125rem] py-[0.875rem]',
+      'rounded-lg border border-gray-200 dark:border-gray-700',
+      'shadow-xl',
+      // Cloned pandoc content inherits styling from the surrounding page
+      // (paragraphs, stray <li> left from the <ol> the <li> came from).
+      '[&>:last-child]:mb-0 [&_p]:mb-2',
+      '[&>li]:list-none [&>li]:pl-0 [&>li]:ml-0',
+      // Mobile bottom-sheet shape.
+      'max-sm:rounded-t-2xl max-sm:rounded-b-none',
+      'max-sm:px-5 max-sm:pt-4 max-sm:pb-6',
+      'max-sm:max-h-[60vh] max-sm:overflow-y-auto',
+      'max-sm:shadow-2xl',
+    ].join(' ');
 
     var popoverEl = null;
     var currentRef = null;
-    // Pandoc emits exactly one top-level <aside data-footnote-list> per
-    // page. Live-server reloads the whole document on source changes, so
-    // caching across clicks is safe — no SPA mutations to worry about.
     var topLevelAside = null;
 
     function ensurePopover() {
@@ -106,8 +64,9 @@
       popoverEl = document.createElement('div');
       popoverEl.id = 'emanote-footnote-popover';
       popoverEl.setAttribute('popover', 'auto');
+      popoverEl.className = POPOVER_CLASS;
       var body = document.createElement('div');
-      body.className = 'emanote-footnote-popup-body';
+      body.className = BODY_CLASS;
       popoverEl.appendChild(body);
       document.body.appendChild(popoverEl);
       popoverEl.addEventListener('toggle', function (e) {
@@ -151,18 +110,14 @@
         : null;
     }
 
-    function cloneContent(li) {
-      return li.cloneNode(true);
-    }
-
     function positionPopover(popover, ref) {
       if (mobileMQL.matches) {
-        popover.classList.add('emanote-footnote-popup--mobile');
+        // Bottom-sheet layout comes from max-sm: utilities on POPOVER_CLASS;
+        // just clear any inline top/left left over from a prior desktop open.
         popover.style.top = '';
         popover.style.left = '';
         return;
       }
-      popover.classList.remove('emanote-footnote-popup--mobile');
       var refRect = ref.getBoundingClientRect();
       var popRect = popover.getBoundingClientRect();
       var vw = window.innerWidth;
@@ -189,7 +144,7 @@
       var popover = ensurePopover();
       var body = popover.firstElementChild;
       body.textContent = '';
-      body.appendChild(cloneContent(target));
+      body.appendChild(target.cloneNode(true));
       // hidePopover throws InvalidStateError if the popover is already
       // closed. That's the expected case on first open; the throw carries
       // no signal we'd act on, so swallow it.

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -50,10 +50,7 @@
     background-color: var(--color-primary-900);
   }
 
-  /* Mobile bottom-sheet: slide up from the bottom, full width.
-     The 640px breakpoint must stay in sync with MOBILE_MAX in the
-     <script> below — the JS side toggles the --mobile class, the CSS
-     side owns what that class looks like. */
+  /* Mobile bottom-sheet: slide up from the bottom, full width. */
   @media (max-width: 640px) {
     .emanote-footnote-popup--mobile {
       top: auto !important;

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -209,10 +209,20 @@
       openFor(sup, target);
     }
 
+    // Scroll fires at ≥ 60 Hz; coalesce repositions into the browser's
+    // next animation frame so we do one layout read per frame, not per
+    // scroll tick.
+    var viewportTick = false;
     function onViewportChange() {
-      if (popoverEl && popoverEl.matches(':popover-open') && currentRef) {
-        positionPopover(popoverEl, currentRef);
-      }
+      if (viewportTick) return;
+      if (!popoverEl || !popoverEl.matches(':popover-open') || !currentRef) return;
+      viewportTick = true;
+      requestAnimationFrame(function () {
+        viewportTick = false;
+        if (popoverEl && popoverEl.matches(':popover-open') && currentRef) {
+          positionPopover(popoverEl, currentRef);
+        }
+      });
     }
 
     function init() {

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -1,12 +1,8 @@
-<!-- Progressive-enhancement popup for footnote references.
-
-     Binds to the stable contract `data-footnote-ref` / `data-footnote-id`
-     / `data-footnote-list` / `data-footnote-scope` emitted by pandoc.tpl
-     and embed-note.tpl, not to Pandoc's `.footnote-ref` / `.footnote-list`
-     class names (those are stable-by-stasis, not by encapsulation).
-
-     The bottom `<aside>` stays visible as a no-JS / print fallback; the
-     popup is a convenience layer, not a replacement. -->
+<!-- Footnote popup. Footnote refs have no anchor href and no bottom list
+     renders on screen; the body content is emitted inside a hidden
+     <aside data-footnote-list>, sourced only by this script for the
+     popup clone. Bound to data-footnote-ref / data-footnote-id /
+     data-footnote-list / data-footnote-scope. -->
 
 <style data-category="footnote-popup">
   #emanote-footnote-popover {
@@ -48,13 +44,18 @@
     margin-left: 0;
   }
 
-  sup[data-footnote-ref].emanote-footnote-active a {
+  sup[data-footnote-ref].emanote-footnote-active {
     background-color: var(--color-primary-100);
     border-radius: 3px;
     padding: 0 0.2em;
   }
-  .dark sup[data-footnote-ref].emanote-footnote-active a {
+  .dark sup[data-footnote-ref].emanote-footnote-active {
     background-color: var(--color-primary-900);
+  }
+  sup[data-footnote-ref]:focus-visible {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 
   /* Mobile bottom-sheet: slide up from the bottom, full width. */
@@ -99,7 +100,9 @@
     var topLevelAside = null;
 
     function ensurePopover() {
-      if (popoverEl) return popoverEl;
+      // Emanote's live-server patches the DOM on source changes, which can
+      // detach a previously appended popover. Recreate when that happens.
+      if (popoverEl && popoverEl.isConnected) return popoverEl;
       popoverEl = document.createElement('div');
       popoverEl.id = 'emanote-footnote-popover';
       popoverEl.setAttribute('popover', 'auto');
@@ -135,7 +138,10 @@
       var scope = ref.closest('[data-footnote-scope]');
       var aside;
       if (scope === null) {
-        if (!topLevelAside) topLevelAside = findOwnAside(null);
+        // Re-resolve if the cached aside got swapped out by a live-reload patch.
+        if (!topLevelAside || !topLevelAside.isConnected) {
+          topLevelAside = findOwnAside(null);
+        }
         aside = topLevelAside;
       } else {
         aside = findOwnAside(scope);
@@ -146,11 +152,7 @@
     }
 
     function cloneContent(li) {
-      var clone = li.cloneNode(true);
-      // Backref would navigate away from the popup — drop it.
-      var backrefs = clone.querySelectorAll('a[data-footnote-backref]');
-      for (var i = 0; i < backrefs.length; i++) backrefs[i].remove();
-      return clone;
+      return li.cloneNode(true);
     }
 
     function positionPopover(popover, ref) {
@@ -212,15 +214,24 @@
       requestAnimationFrame(function () { positionPopover(popover, ref); });
     }
 
-    function onClick(e) {
-      if (e.defaultPrevented) return;
-      if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
-      var sup = e.target.closest('sup[data-footnote-ref]');
-      if (!sup) return;
+    function activate(e, sup) {
       var target = findTarget(sup);
       if (!target) return;
       e.preventDefault();
       openFor(sup, target);
+    }
+
+    function onClick(e) {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
+      var sup = e.target.closest('sup[data-footnote-ref]');
+      if (sup) activate(e, sup);
+    }
+
+    function onKeydown(e) {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      var sup = e.target.closest('sup[data-footnote-ref]');
+      if (sup) activate(e, sup);
     }
 
     // Scroll fires at ≥ 60 Hz; coalesce repositions into the browser's
@@ -241,6 +252,7 @@
 
     function init() {
       document.addEventListener('click', onClick);
+      document.addEventListener('keydown', onKeydown);
       window.addEventListener('resize', onViewportChange);
       window.addEventListener('scroll', onViewportChange, { passive: true });
     }

--- a/emanote/default/templates/components/footnote-popup.tpl
+++ b/emanote/default/templates/components/footnote-popup.tpl
@@ -50,7 +50,10 @@
     background-color: var(--color-primary-900);
   }
 
-  /* Mobile bottom-sheet: slide up from the bottom, full width. */
+  /* Mobile bottom-sheet: slide up from the bottom, full width.
+     The 640px breakpoint must stay in sync with MOBILE_MAX in the
+     <script> below — the JS side toggles the --mobile class, the CSS
+     side owns what that class looks like. */
   @media (max-width: 640px) {
     .emanote-footnote-popup--mobile {
       top: auto !important;
@@ -81,6 +84,8 @@
     }
 
     var POPOVER_ID = 'emanote-footnote-popover';
+    // MOBILE_MAX must stay in sync with the @media (max-width: …) breakpoint
+    // in the <style> above — neither side enforces it.
     var MOBILE_MAX = 640;
 
     var popoverEl = null;

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -67,14 +67,14 @@
       </DefinitionList:Items>
     </dl>
   </DefinitionList>
-  <Note:Ref><sup id="fnref${footnote:idx}" class="footnote-ref text-[0.7em] leading-[0] align-super pr-[0.08em] font-medium [font-variant-numeric:lining-nums]"><a class="text-primary-600 dark:text-primary-400 no-underline hover:underline hover:underline-offset-2 hover:decoration-1" href="${ema:note:url}#fn${footnote:idx}"><footnote:idx /></a></sup></Note:Ref>
+  <Note:Ref><sup id="fnref${footnote:idx}" data-footnote-ref="${footnote:idx}" class="footnote-ref text-[0.7em] leading-[0] align-super pr-[0.08em] font-medium [font-variant-numeric:lining-nums]"><a class="text-primary-600 dark:text-primary-400 no-underline hover:underline hover:underline-offset-2 hover:decoration-1" href="${ema:note:url}#fn${footnote:idx}"><footnote:idx /></a></sup></Note:Ref>
   <Note:List>
-    <aside title="Footnotes"
+    <aside title="Footnotes" data-footnote-list
       class="relative mt-14 pt-7 max-w-[44rem] text-sm leading-relaxed text-gray-600 dark:text-gray-400 before:content-[''] before:absolute before:top-0 before:left-0 before:w-14 before:h-[2px] before:bg-primary-500 after:content-[''] after:absolute after:top-px after:left-14 after:right-0 after:h-px after:bg-gray-200 dark:after:bg-gray-800">
       <header class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Footnotes</header>
       <ol class="footnote-list list-decimal pl-6 space-y-3 marker:text-primary-600 dark:marker:text-primary-400 marker:font-medium [font-variant-numeric:oldstyle-nums]">
         <footnote>
-          <li id="fn${footnote:idx}" class="pl-2">
+          <li id="fn${footnote:idx}" data-footnote-id="${footnote:idx}" class="pl-2">
             <footnote:content />
             <a href="${ema:note:url}#fnref${footnote:idx}" class="footnote-backref ml-2 inline-block no-underline text-gray-400 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 transition hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:translate-y-0" aria-label="Back to content">↩</a>
           </li>

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -67,10 +67,13 @@
       </DefinitionList:Items>
     </dl>
   </DefinitionList>
-  <Note:Ref><sup data-footnote-ref="${footnote:idx}" role="button" tabindex="0" aria-label="Footnote ${footnote:idx}" class="footnote-ref text-[0.7em] leading-[0] align-super pr-[0.08em] font-medium cursor-pointer select-none text-primary-600 dark:text-primary-400 hover:underline hover:underline-offset-2 hover:decoration-1 [font-variant-numeric:lining-nums]"><footnote:idx /></sup></Note:Ref>
+  <Note:Ref><sup data-footnote-ref="${footnote:idx}" role="button" tabindex="0" aria-label="Footnote ${footnote:idx}" class="footnote-ref text-[0.7em] leading-[0] align-super pr-[0.08em] font-medium cursor-pointer select-none text-primary-600 dark:text-primary-400 hover:underline hover:underline-offset-2 hover:decoration-1 [font-variant-numeric:lining-nums] [&.emanote-footnote-active]:bg-primary-100 dark:[&.emanote-footnote-active]:bg-primary-900 [&.emanote-footnote-active]:rounded [&.emanote-footnote-active]:px-[0.2em] focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:rounded-sm focus-visible:outline-none"><footnote:idx /></sup></Note:Ref>
   <Note:List>
-    <aside data-footnote-list aria-hidden="true" hidden>
-      <ol>
+    <!-- Screen: hidden (popup is the UI). Print: revealed with standard
+         footnote-list styling so printed output includes the cited bodies. -->
+    <aside data-footnote-list aria-hidden="true" class="hidden print:block mt-10 text-sm">
+      <header class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Footnotes</header>
+      <ol class="list-decimal pl-6 space-y-2">
         <footnote>
           <li data-footnote-id="${footnote:idx}">
             <footnote:content />

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -76,7 +76,7 @@
         <footnote>
           <li id="fn${footnote:idx}" data-footnote-id="${footnote:idx}" class="pl-2">
             <footnote:content />
-            <a href="${ema:note:url}#fnref${footnote:idx}" class="footnote-backref ml-2 inline-block no-underline text-gray-400 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 transition hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:translate-y-0" aria-label="Back to content">↩</a>
+            <a href="${ema:note:url}#fnref${footnote:idx}" data-footnote-backref class="footnote-backref ml-2 inline-block no-underline text-gray-400 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 transition hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:translate-y-0" aria-label="Back to content">↩</a>
           </li>
         </footnote>
       </ol>

--- a/emanote/default/templates/components/pandoc.tpl
+++ b/emanote/default/templates/components/pandoc.tpl
@@ -67,16 +67,13 @@
       </DefinitionList:Items>
     </dl>
   </DefinitionList>
-  <Note:Ref><sup id="fnref${footnote:idx}" data-footnote-ref="${footnote:idx}" class="footnote-ref text-[0.7em] leading-[0] align-super pr-[0.08em] font-medium [font-variant-numeric:lining-nums]"><a class="text-primary-600 dark:text-primary-400 no-underline hover:underline hover:underline-offset-2 hover:decoration-1" href="${ema:note:url}#fn${footnote:idx}"><footnote:idx /></a></sup></Note:Ref>
+  <Note:Ref><sup data-footnote-ref="${footnote:idx}" role="button" tabindex="0" aria-label="Footnote ${footnote:idx}" class="footnote-ref text-[0.7em] leading-[0] align-super pr-[0.08em] font-medium cursor-pointer select-none text-primary-600 dark:text-primary-400 hover:underline hover:underline-offset-2 hover:decoration-1 [font-variant-numeric:lining-nums]"><footnote:idx /></sup></Note:Ref>
   <Note:List>
-    <aside title="Footnotes" data-footnote-list
-      class="relative mt-14 pt-7 max-w-[44rem] text-sm leading-relaxed text-gray-600 dark:text-gray-400 before:content-[''] before:absolute before:top-0 before:left-0 before:w-14 before:h-[2px] before:bg-primary-500 after:content-[''] after:absolute after:top-px after:left-14 after:right-0 after:h-px after:bg-gray-200 dark:after:bg-gray-800">
-      <header class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Footnotes</header>
-      <ol class="footnote-list list-decimal pl-6 space-y-3 marker:text-primary-600 dark:marker:text-primary-400 marker:font-medium [font-variant-numeric:oldstyle-nums]">
+    <aside data-footnote-list aria-hidden="true" hidden>
+      <ol>
         <footnote>
-          <li id="fn${footnote:idx}" data-footnote-id="${footnote:idx}" class="pl-2">
+          <li data-footnote-id="${footnote:idx}">
             <footnote:content />
-            <a href="${ema:note:url}#fnref${footnote:idx}" data-footnote-backref class="footnote-backref ml-2 inline-block no-underline text-gray-400 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 transition hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:translate-y-0" aria-label="Back to content">↩</a>
           </li>
         </footnote>
       </ol>

--- a/emanote/default/templates/filters/callout/_base.tpl
+++ b/emanote/default/templates/filters/callout/_base.tpl
@@ -1,4 +1,4 @@
-<div data-callout-metadata="" data-callout-fold="" data-callout="${callout:type}"
+<div data-callout-metadata="" data-callout-fold="" data-callout="${callout:type}" data-footnote-scope
   class="callout p-5 pt-4 pb-3 rounded-xl mb-6 border-l-4 shadow-sm" role="note"
   style="background-color: color-mix(in srgb, ${color} 8%, transparent); border-left-color: ${color}">
   <path

--- a/emanote/default/templates/filters/embed-note.tpl
+++ b/emanote/default/templates/filters/embed-note.tpl
@@ -1,4 +1,4 @@
-<section title="Embedded note" data-footnote-embed class="p-4 mx-2 mb-2 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-lg shadow-inner">
+<section title="Embedded note" data-footnote-scope class="p-4 mx-2 mb-2 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-lg shadow-inner">
   <header
     class="flex items-center justify-center text-2xl italic bg-primary-50 dark:bg-primary-900 rounded py-1 px-2 mb-3">
     <a href="${ema:note:url}">

--- a/emanote/default/templates/filters/embed-note.tpl
+++ b/emanote/default/templates/filters/embed-note.tpl
@@ -1,4 +1,4 @@
-<section title="Embedded note" class="p-4 mx-2 mb-2 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-lg shadow-inner">
+<section title="Embedded note" data-footnote-embed class="p-4 mx-2 mb-2 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-lg shadow-inner">
   <header
     class="flex items-center justify-center text-2xl italic bg-primary-50 dark:bg-primary-900 rounded py-1 px-2 mb-3">
     <a href="${ema:note:url}">

--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -85,27 +85,6 @@
   }
 </style>
 
-<style data-category="footnotes">
-  /* Only the :target flash and its keyframes live here — Tailwind can't
-     express @keyframes or a theme-scoped start color for one animation.
-     Everything else (aside rules, markers, sup, backref) is inline
-     utilities in components/pandoc.tpl. */
-  :root { --footnote-flash-start: var(--color-primary-100); }
-  .dark { --footnote-flash-start: var(--color-primary-900); }
-  ol.footnote-list li:target,
-  sup.footnote-ref:target a {
-    animation: footnote-flash 0.5s ease-out;
-  }
-  @keyframes footnote-flash {
-    0%   { background-color: var(--footnote-flash-start); }
-    100% { background-color: transparent; }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    ol.footnote-list li:target,
-    sup.footnote-ref:target a { animation: none; }
-  }
-</style>
-
 <style data-category="callout">
   /* To prevent overemphasis of link styles in callout titles */
   .callout .callout-title a {

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -23,3 +23,18 @@ Feature: Smoke
   Scenario: KaTeX is not loaded by default
     When I open "/math.html"
     Then no KaTeX stylesheet is referenced
+
+  Scenario: Clicking a parent-level footnote ref opens the popup
+    When I open "/footnotes.html"
+    And I click the footnote ref with index "1" in the parent body
+    Then the footnote popup contains "PARENT_FOOTNOTE_BODY"
+
+  Scenario: Clicking a footnote ref inside a callout opens the popup
+    When I open "/footnotes.html"
+    And I click the footnote ref with index "2" in the parent body
+    Then the footnote popup contains "CALLOUT_FOOTNOTE_BODY"
+
+  Scenario: Clicking a footnote ref inside an embedded note opens the popup with the embed's footnote body
+    When I open "/footnotes.html"
+    And I click the footnote ref with index "1" inside an embedded note
+    Then the footnote popup contains "EMBED_FOOTNOTE_BODY"

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -38,3 +38,10 @@ Feature: Smoke
     When I open "/footnotes.html"
     And I click the footnote ref with index "1" inside an embedded note
     Then the footnote popup contains "EMBED_FOOTNOTE_BODY"
+
+  Scenario: The footnote list is hidden on screen but rendered in print mode
+    When I open "/footnotes.html"
+    Then no footnote list is visible on screen
+    When the page is emulated as print media
+    Then at least one footnote list is visible
+    And the printed footnote list contains "PARENT_FOOTNOTE_BODY"

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -29,9 +29,9 @@ Feature: Smoke
     And I click the footnote ref with index "1" in the parent body
     Then the footnote popup contains "PARENT_FOOTNOTE_BODY"
 
-  Scenario: Clicking a footnote ref inside a callout opens the popup
+  Scenario: Clicking a footnote ref inside a callout resolves to that callout's footnote body
     When I open "/footnotes.html"
-    And I click the footnote ref with index "2" in the parent body
+    And I click the footnote ref with index "1" inside a callout
     Then the footnote popup contains "CALLOUT_FOOTNOTE_BODY"
 
   Scenario: Clicking a footnote ref inside an embedded note opens the popup with the embed's footnote body

--- a/tests/fixtures/notebook/fn-embed-target.md
+++ b/tests/fixtures/notebook/fn-embed-target.md
@@ -1,0 +1,5 @@
+# Footnote embed target
+
+This embedded note has its own footnote[^embed].
+
+[^embed]: Embedded footnote body. Unique marker: EMBED_FOOTNOTE_BODY.

--- a/tests/fixtures/notebook/footnotes.md
+++ b/tests/fixtures/notebook/footnotes.md
@@ -1,0 +1,11 @@
+# Footnotes fixture
+
+This paragraph cites a parent footnote[^parent].
+
+> [!note] Callout with footnote
+> The callout body cites another footnote[^callout].
+
+![[fn-embed-target]]
+
+[^parent]: Parent body text for the popup. Unique marker: PARENT_FOOTNOTE_BODY.
+[^callout]: Callout body text for the popup. Unique marker: CALLOUT_FOOTNOTE_BODY.

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -106,3 +106,67 @@ Then(
     );
   },
 );
+
+// Footnote popup scenarios. The popover lives at `#emanote-footnote-popover`
+// and is owned by the script in components/footnote-popup.tpl. Clicking a
+// `sup[data-footnote-ref]` that matches the scope (embedded vs. top-level)
+// must route the click to the right `<li data-footnote-id>`.
+const POPOVER_SEL = "#emanote-footnote-popover";
+
+When(
+  "I click the footnote ref with index {string} in the parent body",
+  async function (this: EmanoteWorld, idx: string) {
+    // Top-level refs are the ones whose closest [data-footnote-embed] is null.
+    // Playwright's `:not(:has(…ancestor))` trick doesn't exist, so filter in-page.
+    const handle = await this.page.evaluateHandle((i) => {
+      const refs = document.querySelectorAll(
+        `sup[data-footnote-ref="${i}"]`,
+      );
+      for (const r of refs) {
+        if (!r.closest("[data-footnote-embed]")) return r as HTMLElement;
+      }
+      return null;
+    }, idx);
+    const el = handle.asElement();
+    assert.ok(el, `No top-level sup[data-footnote-ref="${idx}"] on the page.`);
+    await el.click();
+  },
+);
+
+When(
+  "I click the footnote ref with index {string} inside an embedded note",
+  async function (this: EmanoteWorld, idx: string) {
+    const handle = await this.page.evaluateHandle((i) => {
+      const refs = document.querySelectorAll(
+        `[data-footnote-embed] sup[data-footnote-ref="${i}"]`,
+      );
+      return (refs[0] as HTMLElement) ?? null;
+    }, idx);
+    const el = handle.asElement();
+    assert.ok(
+      el,
+      `No [data-footnote-embed] sup[data-footnote-ref="${idx}"] on the page.`,
+    );
+    await el.click();
+  },
+);
+
+Then(
+  "the footnote popup contains {string}",
+  async function (this: EmanoteWorld, needle: string) {
+    const popover = this.page.locator(POPOVER_SEL);
+    await popover.waitFor({ state: "attached", timeout: 5_000 });
+    const isOpen = await popover.evaluate((el) =>
+      (el as HTMLElement).matches(":popover-open"),
+    );
+    assert.ok(
+      isOpen,
+      "Popover element exists but is not open — showPopover() likely failed or the click didn't reach the handler.",
+    );
+    const text = (await popover.textContent()) ?? "";
+    assert.ok(
+      text.includes(needle),
+      `Popover did not contain ${JSON.stringify(needle)}. Got: ${JSON.stringify(text)}.`,
+    );
+  },
+);

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -107,10 +107,6 @@ Then(
   },
 );
 
-// Footnote popup scenarios. The popover lives at `#emanote-footnote-popover`
-// and is owned by the script in components/footnote-popup.tpl. Clicking a
-// `sup[data-footnote-ref]` that matches the scope (embedded vs. top-level)
-// must route the click to the right `<li data-footnote-id>`.
 const POPOVER_SEL = "#emanote-footnote-popover";
 
 When(

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -112,14 +112,14 @@ const POPOVER_SEL = "#emanote-footnote-popover";
 When(
   "I click the footnote ref with index {string} in the parent body",
   async function (this: EmanoteWorld, idx: string) {
-    // Top-level refs are the ones whose closest [data-footnote-embed] is null.
+    // Top-level refs are the ones whose closest [data-footnote-scope] is null.
     // Playwright's `:not(:has(…ancestor))` trick doesn't exist, so filter in-page.
     const handle = await this.page.evaluateHandle((i) => {
       const refs = document.querySelectorAll(
         `sup[data-footnote-ref="${i}"]`,
       );
       for (const r of refs) {
-        if (!r.closest("[data-footnote-embed]")) return r as HTMLElement;
+        if (!r.closest("[data-footnote-scope]")) return r as HTMLElement;
       }
       return null;
     }, idx);
@@ -132,16 +132,37 @@ When(
 When(
   "I click the footnote ref with index {string} inside an embedded note",
   async function (this: EmanoteWorld, idx: string) {
+    // Embeds render as <section data-footnote-scope>; callouts as <div>.
+    // Match only the section form so this step doesn't pick up a
+    // callout-scoped ref by accident.
     const handle = await this.page.evaluateHandle((i) => {
       const refs = document.querySelectorAll(
-        `[data-footnote-embed] sup[data-footnote-ref="${i}"]`,
+        `section[data-footnote-scope] sup[data-footnote-ref="${i}"]`,
       );
       return (refs[0] as HTMLElement) ?? null;
     }, idx);
     const el = handle.asElement();
     assert.ok(
       el,
-      `No [data-footnote-embed] sup[data-footnote-ref="${idx}"] on the page.`,
+      `No section[data-footnote-scope] sup[data-footnote-ref="${idx}"] on the page.`,
+    );
+    await el.click();
+  },
+);
+
+When(
+  "I click the footnote ref with index {string} inside a callout",
+  async function (this: EmanoteWorld, idx: string) {
+    const handle = await this.page.evaluateHandle((i) => {
+      const refs = document.querySelectorAll(
+        `[data-callout] sup[data-footnote-ref="${i}"]`,
+      );
+      return (refs[0] as HTMLElement) ?? null;
+    }, idx);
+    const el = handle.asElement();
+    assert.ok(
+      el,
+      `No [data-callout] sup[data-footnote-ref="${idx}"] on the page.`,
     );
     await el.click();
   },

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -187,3 +187,64 @@ Then(
     );
   },
 );
+
+// Print-mode footnotes. The popup is screen-only; the hidden <aside
+// data-footnote-list> is revealed by `print:block` on paper so printed
+// copies still carry the cited bodies.
+async function countVisibleFootnoteAsides(page: EmanoteWorld["page"]) {
+  return page.evaluate(
+    () =>
+      Array.from(
+        document.querySelectorAll("aside[data-footnote-list]"),
+      ).filter((a) => getComputedStyle(a as Element).display !== "none").length,
+  );
+}
+
+Then(
+  "no footnote list is visible on screen",
+  async function (this: EmanoteWorld) {
+    const count = await countVisibleFootnoteAsides(this.page);
+    assert.strictEqual(
+      count,
+      0,
+      `Expected no visible <aside data-footnote-list> on screen; got ${count}. The popup is the only footnote UI on screen — a visible aside means hidden/print:block got reverted.`,
+    );
+  },
+);
+
+When(
+  "the page is emulated as print media",
+  async function (this: EmanoteWorld) {
+    await this.page.emulateMedia({ media: "print" });
+  },
+);
+
+Then(
+  "at least one footnote list is visible",
+  async function (this: EmanoteWorld) {
+    const count = await countVisibleFootnoteAsides(this.page);
+    assert.ok(
+      count > 0,
+      `Expected at least one <aside data-footnote-list> visible under print emulation; got ${count}. The print:block variant on the aside is missing or the parent hides it regardless.`,
+    );
+  },
+);
+
+Then(
+  "the printed footnote list contains {string}",
+  async function (this: EmanoteWorld, needle: string) {
+    const text = await this.page.evaluate(
+      () =>
+        Array.from(document.querySelectorAll("aside[data-footnote-list]"))
+          .filter((a) => getComputedStyle(a as Element).display !== "none")
+          .map((a) => (a as HTMLElement).textContent ?? "")
+          .join(" "),
+    );
+    assert.ok(
+      text.includes(needle),
+      `Visible print-mode footnote list did not contain ${JSON.stringify(
+        needle,
+      )}. Got: ${JSON.stringify(text.slice(0, 200))}.`,
+    );
+  },
+);


### PR DESCRIPTION
**Footnote refs open a popup — that's the only on-screen UI.** No `#fn1` anchor, no visible bottom list, no scroll-away. The `<sup>` is the click target (role=button, Enter/Space activates). Desktop gets a floating card; mobile gets a bottom-sheet. For print, the hidden `<aside>` flips to `print:block` with a decimal list so paper copies still carry the cited bodies.

The popup binds to a `data-footnote-*` contract (ref, id, list, scope), not Pandoc class names. Scope routing handles callouts and embedded notes as their own footnote boundaries — each one can legitimately carry a `fn1`.

Native HTML Popover API; no dep. Popover chrome styled entirely via inline Tailwind classes applied in JS; the only CSS rule that survives is `::backdrop { background: transparent }` (Tailwind has no variant for that pseudo-element).

### Verification

- Chrome-mcp real-click walk on `docs/guide/markdown/embed.html` — all refs (parent / callout / embed) route to correct bodies, `scrollY` stays 0, no hash.
- e2e (cucumber + playwright) covers all three popup paths plus a new print-mode scenario (`page.emulateMedia({ media: "print" })` → at least one aside visible, body content present).
- Vira CI green on `2a7c9238`.

### Try it locally

```sh
nix run github:srid/emanote/footnote-popups -- -L ./docs run
```