### PR TITLE
chore: sync talk skill from apm

### DIFF
--- a/.agents/skills/talk/SKILL.md
+++ b/.agents/skills/talk/SKILL.md
@@ -1,6 +1,7 @@
 ---
-argument-hint: '[--no-laconic] [--review-model=<opus|sonnet|haiku>] <topic or question>'
+name: talk
 description: Enter talk mode — conversation only, no file changes
+argument-hint: "[--no-laconic] [--review-model=<opus|sonnet|haiku>] <topic or question>"
 ---
 
 # Probe (Talk Mode)
@@ -13,7 +14,7 @@ You are now in **talk mode**. Have a conversation with the user — discuss idea
 - **Do NOT run destructive commands.** No `git commit`, `git push`, or anything that mutates the repo.
 - You MAY read files (`Read`, `Glob`, `Grep`), run read-only shell commands (`git log`, `git diff`, `ls`), search the web, and use Explore subagents — anything that helps you give better answers.
 - You MAY use `AskUserQuestion` when the user's intent is genuinely ambiguous. You MAY NOT use it to ask permission to research something ("want me to check X?", "should I look at Y?") — if you're tempted to ask, just do the research and report back. Asking to research is the single most common way talk mode fails.
-- **Talk mode ends when the user invokes an action command** (e.g., `/do`). Until then, stay in talk mode.
+- **Talk mode ends when the user invokes an action skill** (e.g., `do`). Until then, stay in talk mode.
 
 ## Research before answering — MANDATORY
 
@@ -64,13 +65,13 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 ## Behavior
 
 - Be direct, opinionated, and concise.
-- If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
+- If the user asks you to implement something, remind them to use `do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
 
 ## Auto-Lowy
 
 Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `lowy` sub-agent on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold its findings into the recommendation (flag boundaries that track functionality instead of volatility, flag where a seam would cleanly encapsulate an axis of change) rather than dumping raw sub-agent output on top. Use `Agent(subagent_type="lowy")`, not the `Skill` tool — the sub-agent runs in an isolated context and keeps the main turn lean.
 
-Hickey's complecting critique deliberately does **not** run here. It needs a concrete diff to bite — running it on a sketch tends to surface generic concerns rather than the specific interleavings that matter. `/do` runs hickey post-implement on the real diff. Talk mode sticks with Lowy because volatility-based decomposition is the design-level lens that's useful while the design is still a sketch.
+Hickey's complecting critique deliberately does **not** run here. It needs a concrete diff to bite — running it on a sketch tends to surface generic concerns rather than the specific interleavings that matter. `do` runs hickey post-implement on the real diff. Talk mode sticks with Lowy because volatility-based decomposition is the design-level lens that's useful while the design is still a sketch.
 
 Skip the Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
 

--- a/.claude/skills/talk/SKILL.md
+++ b/.claude/skills/talk/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: talk
+description: Enter talk mode — conversation only, no file changes
+argument-hint: "[--no-laconic] [--review-model=<opus|sonnet|haiku>] <topic or question>"
+---
+
+# Probe (Talk Mode)
+
+You are now in **talk mode**. Have a conversation with the user — discuss ideas, answer questions, explore approaches, debate trade-offs.
+
+## Rules
+
+- **Do NOT edit, write, or create any files.** No `Edit`, `Write`, `NotebookEdit` tool calls, and no Bash commands that create or modify files (`echo >`, `tee`, `sed -i`, etc.). Period.
+- **Do NOT run destructive commands.** No `git commit`, `git push`, or anything that mutates the repo.
+- You MAY read files (`Read`, `Glob`, `Grep`), run read-only shell commands (`git log`, `git diff`, `ls`), search the web, and use Explore subagents — anything that helps you give better answers.
+- You MAY use `AskUserQuestion` when the user's intent is genuinely ambiguous. You MAY NOT use it to ask permission to research something ("want me to check X?", "should I look at Y?") — if you're tempted to ask, just do the research and report back. Asking to research is the single most common way talk mode fails.
+- **Talk mode ends when the user invokes an action skill** (e.g., `do`). Until then, stay in talk mode.
+
+## Research before answering — MANDATORY
+
+Talk mode is a research-first workflow, not an off-the-cuff conversation. Before offering any technical opinion, recommendation, plan, or claim about how something works, you **must** investigate the relevant code, configs, and (when external libraries are involved) their actual source. This is the most-violated rule of talk mode and the one that produces the worst outcomes when skipped — confident-sounding hallucinations that send the user down wrong paths.
+
+**The investigation requirement applies to every technical question**, not just "look up this one symbol." It applies even when you think you already know the answer.
+
+### First-turn gate
+
+Your first substantive response must not contain recommendations, fixes, "suspects," or claims about third-party library behavior unless you have **already read the relevant source in this session**. If you haven't yet, your first response is the research itself — normally a single `Agent(subagent_type=Explore)` call. Direct `Read`s in the main turn are allowed only for narrow, single-file lookups you can name up front. Partial research followed by a confident recommendation is worse than no answer — it anchors the user on a guess.
+
+### When to use the Explore subagent
+
+Use `Agent(subagent_type=Explore)` for any of:
+
+- Questions about a third-party library's behavior (read the library source in `node_modules/`, `vendor/`, etc. — do not rely on memory of how the library worked in some other version).
+- Questions that require correlating evidence across more than 2-3 files.
+- Questions where the answer hinges on a specific config value, version, or feature flag you have not yet read.
+- "Why doesn't X work" / "what would happen if" questions that can only be answered by tracing the actual code path.
+
+For narrow, single-file lookups, `Grep`/`Read` directly is fine. The line is: if you would be guessing without reading, you must read first.
+
+**When the source isn't on disk.** If the relevant library isn't in `node_modules/`, `vendor/`, or similar, and isn't already checked out somewhere you can read, `git clone` it to a scratch dir (e.g. `/tmp/<name>`) at the version the project actually uses, then read it there. Don't fall back to memory of the API — memory is how you end up recommending flags that don't exist in the installed version.
+
+**Subagent output is a lead, not ground truth.** Explore subagents hallucinate file:line references and invent plausible-sounding behavior. If you haven't verified a claim yourself, mark it "per subagent, unverified" so the user can weigh it — don't launder subagent guesses into confident statements.
+
+### Citation requirement
+
+Every non-trivial claim in your response must be backed by a `file:line` reference you actually read in this session. If you cannot cite a file:line for a claim, either go read the source and come back, or explicitly mark the claim as a guess (e.g. "I'm guessing — haven't verified") so the user can weigh it accordingly.
+
+**Claims about third-party library behavior require file:line references inside that library's source** — not just citations in your own project. "`Terminal.tsx:139` calls `clearTextureAtlas()`" tells you nothing about what `clearTextureAtlas()` *does*; you need a citation in the library's own file to back any claim about its effect.
+
+### Hedge words are a stop signal
+
+If you're about to emit "probably", "almost certainly", "I suspect", "my #1 suspect", "I think", "should be", or similar hedged language about a technical claim, **stop and go read the source instead**. Hedge words in talk mode mean you haven't done the work yet. Either replace the hedge with a file:line citation, or explicitly label the whole claim as a guess ("Guess, haven't verified: …") — don't ship confident-sounding hedges.
+
+### Anti-patterns
+
+- ❌ "I think xterm.js handles touch via..." (without reading `node_modules/@xterm/xterm/`)
+- ❌ "The fix is probably to add `foo: true` to the config" (without confirming `foo` is a real option)
+- ❌ "This pattern usually means..." (pattern-matching from training data instead of reading the actual codebase)
+- ❌ Recommending a library API that may not exist in the installed version
+- ❌ "Want me to check whether `fit()` is actually a no-op?" — don't ask, check.
+- ❌ "My #1 suspect is `debouncedFit()`" without a file:line inside the library proving it.
+- ❌ Citing a subagent's claim about `FitAddon.ts:45` without opening `FitAddon.ts:45` yourself first.
+- ✅ "I read `Viewport.ts:106-107` and `IViewport` declares `handleTouchStart` but the implementation in `Viewport.ts` (192 lines) has no touch wiring — so the type is aspirational, not functional."
+
+## Behavior
+
+- Be direct, opinionated, and concise.
+- If the user asks you to implement something, remind them to use `do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
+
+## Auto-Lowy
+
+Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `lowy` sub-agent on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold its findings into the recommendation (flag boundaries that track functionality instead of volatility, flag where a seam would cleanly encapsulate an axis of change) rather than dumping raw sub-agent output on top. Use `Agent(subagent_type="lowy")`, not the `Skill` tool — the sub-agent runs in an isolated context and keeps the main turn lean.
+
+Hickey's complecting critique deliberately does **not** run here. It needs a concrete diff to bite — running it on a sketch tends to surface generic concerns rather than the specific interleavings that matter. `do` runs hickey post-implement on the real diff. Talk mode sticks with Lowy because volatility-based decomposition is the design-level lens that's useful while the design is still a sketch.
+
+Skip the Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
+
+**Model override.** If `ARGUMENTS` contains `--review-model=<model>` (accept `opus`, `sonnet`, or `haiku`; strip the flag before treating the rest as the topic), pass `model: "<model>"` in the `Agent(subagent_type="lowy")` call. This overrides the `model: sonnet` in `lowy`'s agent frontmatter via the `Agent` tool's built-in `model` parameter. Without the flag, omit `model` so the default (sonnet) applies. Reject unknown values with a one-line error instead of silently falling back — a typo shouldn't quietly erase a budget decision.
+
+## Laconic mode (default)
+
+Laconic mode is **on by default**. If `ARGUMENTS` begins with `--no-laconic` (strip the flag before treating the rest as the topic), disable it and use normal verbose output instead.
+
+When laconic mode is active:
+
+- One or two sentences when it will do. A single word when *that* will do.
+- No preamble, no recap of the question, no "great question", no closing offers to help further.
+- Drop bullet lists unless the answer is genuinely a list. No headings.
+- Keep file:line citations — brevity does not override the research/citation rules above. Research silently; show only the conclusion plus its citations.
+- Code blocks only when code is the answer.
+
+Laconic mode trims the *output*, not the *investigation*. Do the same reading you would otherwise; just say less about it.
+
+ARGUMENTS: $ARGUMENTS

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -24,7 +24,7 @@ dependencies:
   content_hash: sha256:8f48e067e59da48c3ac90b4e2228ebb4ecfd988375b40efe831339d9a493accd
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 84fbf4c80dea64fe895cd4a9447263a5d0e04f67
+  resolved_commit: dc414175815fa9cc95acb00c4a0ba26e485b842f
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -36,9 +36,9 @@ dependencies:
   - .agents/skills/hickey
   - .agents/skills/lowy
   - .agents/skills/ralph
+  - .agents/skills/talk
   - .claude/agents/hickey.md
   - .claude/agents/lowy.md
-  - .claude/commands/talk.md
   - .claude/hooks/agency/scripts/do-stop-guard.sh
   - .claude/rules/apm-sources.md
   - .claude/skills/code-police
@@ -49,16 +49,16 @@ dependencies:
   - .claude/skills/hickey
   - .claude/skills/lowy
   - .claude/skills/ralph
+  - .claude/skills/talk
   - .codex/agents/hickey.toml
   - .codex/agents/lowy.toml
   - .codex/hooks/agency/scripts/do-stop-guard.sh
   deployed_file_hashes:
     .claude/agents/hickey.md: sha256:edde9b0d3b27b947b7372f662b2e8652d136e0bb9af7924892b00450a1e586bc
     .claude/agents/lowy.md: sha256:a1c8e5ba115439bcfa0d7e331f96e71b2d690ff2e5fb9b824bb5f588eb43ac75
-    .claude/commands/talk.md: sha256:30423c86208657540d909ecd9a5a0b7212550b292daaece4cd0df976675d6fb1
     .claude/hooks/agency/scripts/do-stop-guard.sh: sha256:b9d316555a1509eabb610d32cccdcd1dacaf926b2fd831a3178c30d283756d69
     .claude/rules/apm-sources.md: sha256:8707579e05e2a39f01278b2d225f3cb2ec97912c65c94aa57e5830954f98eab1
     .codex/agents/hickey.toml: sha256:f508bacedcac2916cf1e29a11f2ac161483ffc2acf182c8f1c00c26d14073c00
     .codex/agents/lowy.toml: sha256:c57b72c43687ef255a4490f65984fe556325cb9847a5626e43c2a7addea049e4
     .codex/hooks/agency/scripts/do-stop-guard.sh: sha256:b9d316555a1509eabb610d32cccdcd1dacaf926b2fd831a3178c30d283756d69
-  content_hash: sha256:4f923948340d1045b46b86db32ff72789fad055778d951e4fe584b07e95ea46a
+  content_hash: sha256:f309878ce79ee166620ef89812d093707f07b79cbebaa74725dc6f32f3cac8d3


### PR DESCRIPTION
This syncs the `talk` skill layout with the current APM package state.

The change is intentionally small:
- move the shared `talk` skill content to `.agents/skills/talk/SKILL.md`
- add the Claude-facing `.claude/skills/talk/SKILL.md` copy
- update `apm.lock.yaml` to the new `srid/agency` commit and deployed file list

No runtime code changes are included.
