### PR TITLE
MCP server, phase 1: in-process transport and handshake

### DIFF
--- a/.agents/skills/dpella-mcp/SKILL.md
+++ b/.agents/skills/dpella-mcp/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: dpella-mcp
+description: Reference for the dpella/mcp Haskell library — types, handler shape, transports, and the conventions Emanote uses. Load this before adding MCP resources/tools/subscriptions so you don't re-discover the API by WebFetch.
+user-invocable: false
+---
+
+# dpella/mcp reference
+
+Canonical source: <https://github.com/dpella/mcp>. Two Hackage packages: `mcp-types` (pure types, minimal deps) and `mcp` (Servant-based server with HTTP/Stdio transports). MCP protocol version `2025-06-18`. Depends on `jsonrpc` (also a DPella package, not in nixpkgs).
+
+## Versions to pin
+
+Use GitHub sources rather than Hackage when the target GHC's `all-cabal-hashes` snapshot lags behind:
+
+```nix
+# flake.nix inputs
+dpella-mcp.url = "github:dpella/mcp";
+dpella-mcp.flake = false;
+dpella-jsonrpc.url = "github:dpella/jsonrpc";
+dpella-jsonrpc.flake = false;
+```
+
+```nix
+# haskell-flake
+packages.mcp.source       = inputs.dpella-mcp + /mcp-server;
+packages.mcp-types.source = inputs.dpella-mcp + /mcp-types;
+packages.jsonrpc.source   = inputs.dpella-jsonrpc;
+```
+
+Supported GHC: 9.6–9.12 (via `base >=4.18 && <4.22`). `servant-auth-server` 0.4.x and `warp` 3.4.x are sibling deps.
+
+## Required type-family instances
+
+Every user of `MCP.Server` must provide both:
+
+```haskell
+type instance MCPHandlerState = YourSessionState
+type instance MCPHandlerUser  = YourUserPayload  -- for JWT; use () when using simpleHttpApp
+```
+
+Instances must live in a module that gets compiled before `initMCPServerState` is called.
+
+## Three transports
+
+| Transport | Auth | Entry point | Notes |
+|---|---|---|---|
+| HTTP + JWT | servant-auth-server | `mcpAPI stateVar` via `serveWithContext (Proxy @MCPAPI) ctx` | Production web |
+| Simple HTTP | none | `simpleHttpApp stateVar :: Application` | Local/loopback only; pair with `Warp.run` or `Warp.runSettings` |
+| Stdio | none | `serveStdio stdin stdout initialState` | Subprocess integrations |
+
+For HTTP use `Warp.setBeforeMainLoop` to log after the socket is bound — do not print before `Warp.run`/`runSettings`, the bind hasn't happened yet and the log lies.
+
+## `initMCPServerState` signature
+
+```haskell
+initMCPServerState
+  :: MCPHandlerState                                                  -- initial state
+  -> Maybe (MCPHandlerUser -> MCPHandlerState -> IO MCPHandlerState)  -- onInitialize (JWT only)
+  -> Maybe (MCPHandlerState -> IO MCPHandlerState)                    -- onFinalize (after each req)
+  -> ServerCapabilities                                               -- what to advertise
+  -> Implementation                                                   -- name/version/title
+  -> Maybe Text                                                       -- free-text instructions
+  -> ProcessHandlers                                                  -- the actual handlers
+  -> MCPServerState
+```
+
+Wrap the result in an `MVar` — `simpleHttpApp` / `mcpAPI` both take `MVar MCPServerState`.
+
+## `ServerCapabilities` record
+
+```haskell
+ServerCapabilities
+  { logging      :: Maybe LoggingCapability
+  , prompts      :: Maybe PromptsCapability    { listChanged :: Maybe Bool }
+  , resources    :: Maybe ResourcesCapability  { listChanged, subscribe :: Maybe Bool }
+  , tools        :: Maybe ToolsCapability      { listChanged :: Maybe Bool }
+  , completions  :: Maybe CompletionsCapability
+  , experimental :: Maybe ...
+  }
+```
+
+Advertising `Just …` without providing a matching handler means clients will call it and hit the library's `method_not_found`. For Phase-1-style stubs, provide an empty-list handler (e.g. `listResourcesHandler = Just (\_ -> pure $ ProcessSuccess ListResourcesResult{..})`).
+
+## `ProcessHandlers` record
+
+Every field is a `Maybe` — set only what the server implements:
+
+- `listResourcesHandler`, `readResourceHandler`, `listResourceTemplatesHandler`
+- `listToolsHandler`, `callToolHandler` — **don't set manually**; use `withToolHandlers :: [ToolHandler] -> ProcessHandlers -> ProcessHandlers` which wires both based on a list of `ToolHandler`s.
+- `listPromptsHandler`, `getPromptHandler`
+- `completeHandler`
+- `subscribeHandler`, `unsubscribeHandler`
+
+Start from `defaultProcessHandlers` (all `Nothing`) and override.
+
+## `ToolHandler` construction
+
+```haskell
+toolHandler
+  :: Text                         -- name
+  -> Maybe Text                   -- description
+  -> InputSchema                  -- JSON schema for args
+  -> (Maybe (Map Text Value)      -- handler body
+        -> MCPServerT (ProcessResult CallToolResult))
+  -> ToolHandler
+```
+
+`InputSchema "object" (Just propsMap) (Just ["req1", "req2"])` is the typical shape. `withToolHandlers` validates required args before calling the handler.
+
+Returning results: `toolTextResult [Text]` for plain text; build `CallToolResult` directly when you need structured output (`structuredContent :: Maybe (Map Text Value)`).
+
+## Logging
+
+`mcp_log_level :: Maybe LoggingLevel` on `MCPServerState` — defaults to `Just Warning`. Set to `Just Debug` to get one `[request]` / `[response]` stdout line per JSON-RPC call (see `MCP/Server/HTTP/Internal.hs`). The library does **not** emit anything else on its own; wire your own startup log via Warp's `setBeforeMainLoop`.
+
+Clients can also change the level at runtime via `logging/setLevel` if the server advertises `logging = Just LoggingCapability`.
+
+## `ProcessResult` shape
+
+```haskell
+data ProcessResult a
+  = ProcessSuccess a
+  | ProcessRPCError Int Text             -- JSON-RPC error (400-ish, 404-ish, …)
+  | ProcessServerError Text              -- internal
+  | ProcessClientInput Text Value cont   -- request additional input from client (sampling, elicitation)
+```
+
+Return `ProcessRPCError 404 ("resource not found: " <> uri)` for unknown URIs; the library turns this into a well-formed JSON-RPC error.
+
+## `DuplicateRecordFields` is required
+
+MCP types reuse `name`, `_meta`, `title`, etc. across many records (`Implementation`, `Tool`, `Prompt`, `Resource`, …). Enable `{-# LANGUAGE DuplicateRecordFields #-}` at the use site. Field disambiguation sometimes needs a qualified prefix: `MCP.name = …`, `MCP._meta = …` where `import MCP.Server qualified as MCP`.
+
+## Emanote-specific conventions (phase 1)
+
+- MCP runs beside the live server via `UnliftIO.Async.race_` under the `run` subcommand only.
+- CLI flag: `emanote run --mcp-port PORT` (top-level `--verbose` flips library log level to `Debug`).
+- Startup line: `[mcp] listening on http://localhost:PORT/mcp` via `Warp.setBeforeMainLoop`.
+- Transport: `simpleHttpApp` (no auth). Authentication deferred per the issue's open question.
+- State types: `MCPHandlerState = ()`, `MCPHandlerUser = ()`.
+- Handlers advertise `resources` and `tools` capabilities; empty inventories today.
+- See `emanote/src/Emanote/MCP.hs` for the canonical shape.
+
+Rollout tracker: [srid/emanote#645](https://github.com/srid/emanote/issues/645). Phases 2–5 will add notebook-backed resources, query tools, subscriptions, and optional prompts respectively.
+
+## Common pitfalls
+
+1. **Version tax**: Hackage's `mcp` moves faster than nixpkgs' `all-cabal-hashes`. Pin GitHub sources in `flake.nix` inputs when the Hackage-via-nixpkgs path refuses to build.
+2. **`newMVar` ambiguity**: importing `Control.Concurrent.MVar` alongside Relude produces an ambiguous `newMVar`. Drop the explicit import — Relude's is fine.
+3. **`NamedFieldPuns` with qualified imports**: `ReadResourceParams {uri}` only works if `uri` is unqualified. If you import `MCP.Server` qualified, either enable `NamedFieldPuns` and use the unqualified name, or bind fields positionally.
+4. **Ambiguous `_meta`**: field is shared across a dozen records; with `DuplicateRecordFields` on, GHC often still demands a qualified prefix (`MCP._meta`) at construction sites. `fourmolu` will re-add the qualifier if removed.
+5. **Don't advertise `subscribe = Just True`** until the server actually implements `subscribeHandler` / `unsubscribeHandler`. The library has no built-in defaults for those.

--- a/.apm/skills/dpella-mcp/SKILL.md
+++ b/.apm/skills/dpella-mcp/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: dpella-mcp
+description: Reference for the dpella/mcp Haskell library — types, handler shape, transports, and the conventions Emanote uses. Load this before adding MCP resources/tools/subscriptions so you don't re-discover the API by WebFetch.
+user-invocable: false
+---
+
+# dpella/mcp reference
+
+Canonical source: <https://github.com/dpella/mcp>. Two Hackage packages: `mcp-types` (pure types, minimal deps) and `mcp` (Servant-based server with HTTP/Stdio transports). MCP protocol version `2025-06-18`. Depends on `jsonrpc` (also a DPella package, not in nixpkgs).
+
+## Versions to pin
+
+Use GitHub sources rather than Hackage when the target GHC's `all-cabal-hashes` snapshot lags behind:
+
+```nix
+# flake.nix inputs
+dpella-mcp.url = "github:dpella/mcp";
+dpella-mcp.flake = false;
+dpella-jsonrpc.url = "github:dpella/jsonrpc";
+dpella-jsonrpc.flake = false;
+```
+
+```nix
+# haskell-flake
+packages.mcp.source       = inputs.dpella-mcp + /mcp-server;
+packages.mcp-types.source = inputs.dpella-mcp + /mcp-types;
+packages.jsonrpc.source   = inputs.dpella-jsonrpc;
+```
+
+Supported GHC: 9.6–9.12 (via `base >=4.18 && <4.22`). `servant-auth-server` 0.4.x and `warp` 3.4.x are sibling deps.
+
+## Required type-family instances
+
+Every user of `MCP.Server` must provide both:
+
+```haskell
+type instance MCPHandlerState = YourSessionState
+type instance MCPHandlerUser  = YourUserPayload  -- for JWT; use () when using simpleHttpApp
+```
+
+Instances must live in a module that gets compiled before `initMCPServerState` is called.
+
+## Three transports
+
+| Transport | Auth | Entry point | Notes |
+|---|---|---|---|
+| HTTP + JWT | servant-auth-server | `mcpAPI stateVar` via `serveWithContext (Proxy @MCPAPI) ctx` | Production web |
+| Simple HTTP | none | `simpleHttpApp stateVar :: Application` | Local/loopback only; pair with `Warp.run` or `Warp.runSettings` |
+| Stdio | none | `serveStdio stdin stdout initialState` | Subprocess integrations |
+
+For HTTP use `Warp.setBeforeMainLoop` to log after the socket is bound — do not print before `Warp.run`/`runSettings`, the bind hasn't happened yet and the log lies.
+
+## `initMCPServerState` signature
+
+```haskell
+initMCPServerState
+  :: MCPHandlerState                                                  -- initial state
+  -> Maybe (MCPHandlerUser -> MCPHandlerState -> IO MCPHandlerState)  -- onInitialize (JWT only)
+  -> Maybe (MCPHandlerState -> IO MCPHandlerState)                    -- onFinalize (after each req)
+  -> ServerCapabilities                                               -- what to advertise
+  -> Implementation                                                   -- name/version/title
+  -> Maybe Text                                                       -- free-text instructions
+  -> ProcessHandlers                                                  -- the actual handlers
+  -> MCPServerState
+```
+
+Wrap the result in an `MVar` — `simpleHttpApp` / `mcpAPI` both take `MVar MCPServerState`.
+
+## `ServerCapabilities` record
+
+```haskell
+ServerCapabilities
+  { logging      :: Maybe LoggingCapability
+  , prompts      :: Maybe PromptsCapability    { listChanged :: Maybe Bool }
+  , resources    :: Maybe ResourcesCapability  { listChanged, subscribe :: Maybe Bool }
+  , tools        :: Maybe ToolsCapability      { listChanged :: Maybe Bool }
+  , completions  :: Maybe CompletionsCapability
+  , experimental :: Maybe ...
+  }
+```
+
+Advertising `Just …` without providing a matching handler means clients will call it and hit the library's `method_not_found`. For Phase-1-style stubs, provide an empty-list handler (e.g. `listResourcesHandler = Just (\_ -> pure $ ProcessSuccess ListResourcesResult{..})`).
+
+## `ProcessHandlers` record
+
+Every field is a `Maybe` — set only what the server implements:
+
+- `listResourcesHandler`, `readResourceHandler`, `listResourceTemplatesHandler`
+- `listToolsHandler`, `callToolHandler` — **don't set manually**; use `withToolHandlers :: [ToolHandler] -> ProcessHandlers -> ProcessHandlers` which wires both based on a list of `ToolHandler`s.
+- `listPromptsHandler`, `getPromptHandler`
+- `completeHandler`
+- `subscribeHandler`, `unsubscribeHandler`
+
+Start from `defaultProcessHandlers` (all `Nothing`) and override.
+
+## `ToolHandler` construction
+
+```haskell
+toolHandler
+  :: Text                         -- name
+  -> Maybe Text                   -- description
+  -> InputSchema                  -- JSON schema for args
+  -> (Maybe (Map Text Value)      -- handler body
+        -> MCPServerT (ProcessResult CallToolResult))
+  -> ToolHandler
+```
+
+`InputSchema "object" (Just propsMap) (Just ["req1", "req2"])` is the typical shape. `withToolHandlers` validates required args before calling the handler.
+
+Returning results: `toolTextResult [Text]` for plain text; build `CallToolResult` directly when you need structured output (`structuredContent :: Maybe (Map Text Value)`).
+
+## Logging
+
+`mcp_log_level :: Maybe LoggingLevel` on `MCPServerState` — defaults to `Just Warning`. Set to `Just Debug` to get one `[request]` / `[response]` stdout line per JSON-RPC call (see `MCP/Server/HTTP/Internal.hs`). The library does **not** emit anything else on its own; wire your own startup log via Warp's `setBeforeMainLoop`.
+
+Clients can also change the level at runtime via `logging/setLevel` if the server advertises `logging = Just LoggingCapability`.
+
+## `ProcessResult` shape
+
+```haskell
+data ProcessResult a
+  = ProcessSuccess a
+  | ProcessRPCError Int Text             -- JSON-RPC error (400-ish, 404-ish, …)
+  | ProcessServerError Text              -- internal
+  | ProcessClientInput Text Value cont   -- request additional input from client (sampling, elicitation)
+```
+
+Return `ProcessRPCError 404 ("resource not found: " <> uri)` for unknown URIs; the library turns this into a well-formed JSON-RPC error.
+
+## `DuplicateRecordFields` is required
+
+MCP types reuse `name`, `_meta`, `title`, etc. across many records (`Implementation`, `Tool`, `Prompt`, `Resource`, …). Enable `{-# LANGUAGE DuplicateRecordFields #-}` at the use site. Field disambiguation sometimes needs a qualified prefix: `MCP.name = …`, `MCP._meta = …` where `import MCP.Server qualified as MCP`.
+
+## Emanote-specific conventions (phase 1)
+
+- MCP runs beside the live server via `UnliftIO.Async.race_` under the `run` subcommand only.
+- CLI flag: `emanote run --mcp-port PORT` (top-level `--verbose` flips library log level to `Debug`).
+- Startup line: `[mcp] listening on http://localhost:PORT/mcp` via `Warp.setBeforeMainLoop`.
+- Transport: `simpleHttpApp` (no auth). Authentication deferred per the issue's open question.
+- State types: `MCPHandlerState = ()`, `MCPHandlerUser = ()`.
+- Handlers advertise `resources` and `tools` capabilities; empty inventories today.
+- See `emanote/src/Emanote/MCP.hs` for the canonical shape.
+
+Rollout tracker: [srid/emanote#645](https://github.com/srid/emanote/issues/645). Phases 2–5 will add notebook-backed resources, query tools, subscriptions, and optional prompts respectively.
+
+## Common pitfalls
+
+1. **Version tax**: Hackage's `mcp` moves faster than nixpkgs' `all-cabal-hashes`. Pin GitHub sources in `flake.nix` inputs when the Hackage-via-nixpkgs path refuses to build.
+2. **`newMVar` ambiguity**: importing `Control.Concurrent.MVar` alongside Relude produces an ambiguous `newMVar`. Drop the explicit import — Relude's is fine.
+3. **`NamedFieldPuns` with qualified imports**: `ReadResourceParams {uri}` only works if `uri` is unqualified. If you import `MCP.Server` qualified, either enable `NamedFieldPuns` and use the unqualified name, or bind fields positionally.
+4. **Ambiguous `_meta`**: field is shared across a dozen records; with `DuplicateRecordFields` on, GHC often still demands a qualified prefix (`MCP._meta`) at construction sites. `fourmolu` will re-add the qualifier if removed.
+5. **Don't advertise `subscribe = Just True`** until the server actually implements `subscribeHandler` / `unsubscribeHandler`. The library has no built-in defaults for those.

--- a/.claude/skills/dpella-mcp/SKILL.md
+++ b/.claude/skills/dpella-mcp/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: dpella-mcp
+description: Reference for the dpella/mcp Haskell library — types, handler shape, transports, and the conventions Emanote uses. Load this before adding MCP resources/tools/subscriptions so you don't re-discover the API by WebFetch.
+user-invocable: false
+---
+
+# dpella/mcp reference
+
+Canonical source: <https://github.com/dpella/mcp>. Two Hackage packages: `mcp-types` (pure types, minimal deps) and `mcp` (Servant-based server with HTTP/Stdio transports). MCP protocol version `2025-06-18`. Depends on `jsonrpc` (also a DPella package, not in nixpkgs).
+
+## Versions to pin
+
+Use GitHub sources rather than Hackage when the target GHC's `all-cabal-hashes` snapshot lags behind:
+
+```nix
+# flake.nix inputs
+dpella-mcp.url = "github:dpella/mcp";
+dpella-mcp.flake = false;
+dpella-jsonrpc.url = "github:dpella/jsonrpc";
+dpella-jsonrpc.flake = false;
+```
+
+```nix
+# haskell-flake
+packages.mcp.source       = inputs.dpella-mcp + /mcp-server;
+packages.mcp-types.source = inputs.dpella-mcp + /mcp-types;
+packages.jsonrpc.source   = inputs.dpella-jsonrpc;
+```
+
+Supported GHC: 9.6–9.12 (via `base >=4.18 && <4.22`). `servant-auth-server` 0.4.x and `warp` 3.4.x are sibling deps.
+
+## Required type-family instances
+
+Every user of `MCP.Server` must provide both:
+
+```haskell
+type instance MCPHandlerState = YourSessionState
+type instance MCPHandlerUser  = YourUserPayload  -- for JWT; use () when using simpleHttpApp
+```
+
+Instances must live in a module that gets compiled before `initMCPServerState` is called.
+
+## Three transports
+
+| Transport | Auth | Entry point | Notes |
+|---|---|---|---|
+| HTTP + JWT | servant-auth-server | `mcpAPI stateVar` via `serveWithContext (Proxy @MCPAPI) ctx` | Production web |
+| Simple HTTP | none | `simpleHttpApp stateVar :: Application` | Local/loopback only; pair with `Warp.run` or `Warp.runSettings` |
+| Stdio | none | `serveStdio stdin stdout initialState` | Subprocess integrations |
+
+For HTTP use `Warp.setBeforeMainLoop` to log after the socket is bound — do not print before `Warp.run`/`runSettings`, the bind hasn't happened yet and the log lies.
+
+## `initMCPServerState` signature
+
+```haskell
+initMCPServerState
+  :: MCPHandlerState                                                  -- initial state
+  -> Maybe (MCPHandlerUser -> MCPHandlerState -> IO MCPHandlerState)  -- onInitialize (JWT only)
+  -> Maybe (MCPHandlerState -> IO MCPHandlerState)                    -- onFinalize (after each req)
+  -> ServerCapabilities                                               -- what to advertise
+  -> Implementation                                                   -- name/version/title
+  -> Maybe Text                                                       -- free-text instructions
+  -> ProcessHandlers                                                  -- the actual handlers
+  -> MCPServerState
+```
+
+Wrap the result in an `MVar` — `simpleHttpApp` / `mcpAPI` both take `MVar MCPServerState`.
+
+## `ServerCapabilities` record
+
+```haskell
+ServerCapabilities
+  { logging      :: Maybe LoggingCapability
+  , prompts      :: Maybe PromptsCapability    { listChanged :: Maybe Bool }
+  , resources    :: Maybe ResourcesCapability  { listChanged, subscribe :: Maybe Bool }
+  , tools        :: Maybe ToolsCapability      { listChanged :: Maybe Bool }
+  , completions  :: Maybe CompletionsCapability
+  , experimental :: Maybe ...
+  }
+```
+
+Advertising `Just …` without providing a matching handler means clients will call it and hit the library's `method_not_found`. For Phase-1-style stubs, provide an empty-list handler (e.g. `listResourcesHandler = Just (\_ -> pure $ ProcessSuccess ListResourcesResult{..})`).
+
+## `ProcessHandlers` record
+
+Every field is a `Maybe` — set only what the server implements:
+
+- `listResourcesHandler`, `readResourceHandler`, `listResourceTemplatesHandler`
+- `listToolsHandler`, `callToolHandler` — **don't set manually**; use `withToolHandlers :: [ToolHandler] -> ProcessHandlers -> ProcessHandlers` which wires both based on a list of `ToolHandler`s.
+- `listPromptsHandler`, `getPromptHandler`
+- `completeHandler`
+- `subscribeHandler`, `unsubscribeHandler`
+
+Start from `defaultProcessHandlers` (all `Nothing`) and override.
+
+## `ToolHandler` construction
+
+```haskell
+toolHandler
+  :: Text                         -- name
+  -> Maybe Text                   -- description
+  -> InputSchema                  -- JSON schema for args
+  -> (Maybe (Map Text Value)      -- handler body
+        -> MCPServerT (ProcessResult CallToolResult))
+  -> ToolHandler
+```
+
+`InputSchema "object" (Just propsMap) (Just ["req1", "req2"])` is the typical shape. `withToolHandlers` validates required args before calling the handler.
+
+Returning results: `toolTextResult [Text]` for plain text; build `CallToolResult` directly when you need structured output (`structuredContent :: Maybe (Map Text Value)`).
+
+## Logging
+
+`mcp_log_level :: Maybe LoggingLevel` on `MCPServerState` — defaults to `Just Warning`. Set to `Just Debug` to get one `[request]` / `[response]` stdout line per JSON-RPC call (see `MCP/Server/HTTP/Internal.hs`). The library does **not** emit anything else on its own; wire your own startup log via Warp's `setBeforeMainLoop`.
+
+Clients can also change the level at runtime via `logging/setLevel` if the server advertises `logging = Just LoggingCapability`.
+
+## `ProcessResult` shape
+
+```haskell
+data ProcessResult a
+  = ProcessSuccess a
+  | ProcessRPCError Int Text             -- JSON-RPC error (400-ish, 404-ish, …)
+  | ProcessServerError Text              -- internal
+  | ProcessClientInput Text Value cont   -- request additional input from client (sampling, elicitation)
+```
+
+Return `ProcessRPCError 404 ("resource not found: " <> uri)` for unknown URIs; the library turns this into a well-formed JSON-RPC error.
+
+## `DuplicateRecordFields` is required
+
+MCP types reuse `name`, `_meta`, `title`, etc. across many records (`Implementation`, `Tool`, `Prompt`, `Resource`, …). Enable `{-# LANGUAGE DuplicateRecordFields #-}` at the use site. Field disambiguation sometimes needs a qualified prefix: `MCP.name = …`, `MCP._meta = …` where `import MCP.Server qualified as MCP`.
+
+## Emanote-specific conventions (phase 1)
+
+- MCP runs beside the live server via `UnliftIO.Async.race_` under the `run` subcommand only.
+- CLI flag: `emanote run --mcp-port PORT` (top-level `--verbose` flips library log level to `Debug`).
+- Startup line: `[mcp] listening on http://localhost:PORT/mcp` via `Warp.setBeforeMainLoop`.
+- Transport: `simpleHttpApp` (no auth). Authentication deferred per the issue's open question.
+- State types: `MCPHandlerState = ()`, `MCPHandlerUser = ()`.
+- Handlers advertise `resources` and `tools` capabilities; empty inventories today.
+- See `emanote/src/Emanote/MCP.hs` for the canonical shape.
+
+Rollout tracker: [srid/emanote#645](https://github.com/srid/emanote/issues/645). Phases 2–5 will add notebook-backed resources, query tools, subscriptions, and optional prompts respectively.
+
+## Common pitfalls
+
+1. **Version tax**: Hackage's `mcp` moves faster than nixpkgs' `all-cabal-hashes`. Pin GitHub sources in `flake.nix` inputs when the Hackage-via-nixpkgs path refuses to build.
+2. **`newMVar` ambiguity**: importing `Control.Concurrent.MVar` alongside Relude produces an ambiguous `newMVar`. Drop the explicit import — Relude's is fine.
+3. **`NamedFieldPuns` with qualified imports**: `ReadResourceParams {uri}` only works if `uri` is unqualified. If you import `MCP.Server` qualified, either enable `NamedFieldPuns` and use the unqualified name, or bind fields positionally.
+4. **Ambiguous `_meta`**: field is shared across a dozen records; with `DuplicateRecordFields` on, GHC often still demands a qualified prefix (`MCP._meta`) at construction sites. `fourmolu` will re-add the qualifier if removed.
+5. **Don't advertise `subscribe = Just True`** until the server actually implements `subscribeHandler` / `unsubscribeHandler`. The library has no built-in defaults for those.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,6 +1,6 @@
 lockfile_version: '1'
-generated_at: '2026-04-22T13:21:28.955255+00:00'
-apm_version: 0.9.1
+generated_at: '2026-04-23T20:15:02.314767+00:00'
+apm_version: 0.9.2
 dependencies:
 - repo_url: anthropics/skills
   host: github.com
@@ -24,7 +24,7 @@ dependencies:
   content_hash: sha256:8f48e067e59da48c3ac90b4e2228ebb4ecfd988375b40efe831339d9a493accd
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: dc414175815fa9cc95acb00c4a0ba26e485b842f
+  resolved_commit: f031519fc0b11e5230a74eef76e7baf15ff32efe
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -62,3 +62,6 @@ dependencies:
     .codex/agents/lowy.toml: sha256:c57b72c43687ef255a4490f65984fe556325cb9847a5626e43c2a7addea049e4
     .codex/hooks/agency/scripts/do-stop-guard.sh: sha256:b9d316555a1509eabb610d32cccdcd1dacaf926b2fd831a3178c30d283756d69
   content_hash: sha256:f309878ce79ee166620ef89812d093707f07b79cbebaa74725dc6f32f3cac8d3
+local_deployed_files:
+- .agents/skills/dpella-mcp
+- .claude/skills/dpella-mcp

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -1,0 +1,74 @@
+---
+slug: mcp
+---
+
+# MCP server
+
+> [!warning] Work in progress
+> MCP support is rolling out in phases ([#645](https://github.com/srid/emanote/issues/645)). The current release ships only the HTTP transport and the lifecycle handshake — resources, tools, and subscriptions arrive in later PRs. Expect the surface to grow and the wire details to shift until this notice is removed.
+
+Emanote can expose an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) endpoint beside its [[live-server|live server]], so that [Claude Code](https://claude.com/claude-code), [Codex](https://github.com/openai/codex), or any other MCP-aware client can query your notebook directly from the same process that renders it.
+
+Enable it by passing `--mcp-port PORT` to `emanote run`:
+
+```sh
+emanote run --port 9010 --mcp-port 8079
+```
+
+Emanote prints one line to stderr once the MCP endpoint is ready:
+
+```
+[mcp] listening on http://localhost:8079/mcp
+```
+
+## Client setup
+
+### Claude Code
+
+Claude Code reads MCP server configuration from `.mcp.json` in your project root (or your home directory). Point it at the running Emanote:
+
+```json
+{
+  "mcpServers": {
+    "emanote": {
+      "url": "http://localhost:8079/mcp"
+    }
+  }
+}
+```
+
+Start Emanote in one terminal (`emanote run --mcp-port 8079`), launch Claude Code in the same directory, and it will connect on startup. Use `/mcp` inside Claude Code to verify the server appears and list its tools/resources.
+
+### Codex
+
+Codex uses [`~/.codex/config.toml`](https://github.com/openai/codex#mcp-servers) for MCP servers. HTTP transport wiring looks like:
+
+```toml
+[mcp_servers.emanote]
+url = "http://localhost:8079/mcp"
+```
+
+Restart Codex after editing the config; it will pick up the server on next launch.
+
+### Quick sanity check with `curl`
+
+MCP is JSON-RPC over HTTP with SSE responses. A raw `initialize` call:
+
+```sh
+curl -sS -N -X POST http://localhost:8079/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+```
+
+You should see an SSE `event: message` frame carrying the server's implementation metadata and advertised capabilities.
+
+## Debugging
+
+- Pass `-v` / `--verbose` to Emanote and the underlying `mcp` library will print one `[request]` / `[response]` line per JSON-RPC call to stdout. Useful when a client is misbehaving or you want to see exactly what a tool call looks like.
+- If MCP fails to bind (port already in use, privileged port without capability), Emanote exits with the socket exception — MCP and the live server share process lifetime, so neither runs when the other can't start.
+- MCP is not enabled unless `--mcp-port` is present under the `run` subcommand. `emanote gen` never starts MCP.
+
+## Authentication
+
+There is none today. The server is intended for local use, bound to a loopback port. Do not expose the MCP port to the public internet or to an untrusted network.

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Notable features**
 
+- **MCP server** scaffolding: new `--mcp-port PORT` flag runs an in-process Model Context Protocol HTTP endpoint beside the live server. Phase 1 ships only the lifecycle handshake and empty resource/tool inventories; richer surfaces follow in later phases ([#645](https://github.com/srid/emanote/issues/645))
 - **Tailwind v3 → v4 migration** with CSS-variable design tokens ([#633](https://github.com/srid/emanote/pull/633))
 - Built-in static syntax highlighting using skylighting, replacing client-side JS highlighters ([#624](https://github.com/srid/emanote/pull/624))
 - Built-in static math rendering (LaTeX → MathML at build time via `texmath`) ([#639](https://github.com/srid/emanote/pull/639))

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Notable features**
 
-- **MCP server** scaffolding: new `--mcp-port PORT` flag runs an in-process Model Context Protocol HTTP endpoint beside the live server. Phase 1 ships only the lifecycle handshake and empty resource/tool inventories; richer surfaces follow in later phases ([#645](https://github.com/srid/emanote/issues/645))
+- **MCP server** scaffolding: new `emanote run --mcp-port PORT` flag runs an in-process Model Context Protocol HTTP endpoint beside the live server. Phase 1 ships only the lifecycle handshake and empty resource/tool inventories; richer surfaces follow in later phases ([#645](https://github.com/srid/emanote/issues/645))
 - **Tailwind v3 → v4 migration** with CSS-variable design tokens ([#633](https://github.com/srid/emanote/pull/633))
 - Built-in static syntax highlighting using skylighting, replacing client-side JS highlighters ([#624](https://github.com/srid/emanote/pull/624))
 - Built-in static math rendering (LaTeX → MathML at build time via `texmath`) ([#639](https://github.com/srid/emanote/pull/639))

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -121,6 +121,8 @@ common library-common
     , hspec-hedgehog
     , ixset-typed            >=0.5.1.0
     , map-syntax
+    , mcp                    >=0.3     && <0.4
+    , mcp-types              >=0.1     && <0.2
     , megaparsec
     , monad-logger
     , monad-logger-extras
@@ -150,6 +152,7 @@ common library-common
     , uri-encode
     , url-slug
     , uuid
+    , warp
     , which
     , with-utf8
     , xmlhtml
@@ -161,6 +164,7 @@ library
   exposed-modules:
     Emanote
     Emanote.CLI
+    Emanote.MCP
     Emanote.Model
     Emanote.Model.Calendar
     Emanote.Model.Calendar.Parser

--- a/emanote/src/Emanote.hs
+++ b/emanote/src/Emanote.hs
@@ -77,7 +77,7 @@ run cfg@EmanoteConfig {..} = do
           ema = Ema.runSiteWith @SiteRoute emaCfg cfg >>= postRun cfg
       case CLI.runMcpPort runCmd of
         Nothing -> ema
-        Just port -> race_ (MCP.run port) ema
+        Just port -> race_ (MCP.run port (CLI.verbose _emanoteConfigCli)) ema
     CLI.Cmd_Gen dest -> do
       let emaCfg = SiteConfig (toEmaCli (CLI.Cmd_Gen dest)) def
       Ema.runSiteWith @SiteRoute emaCfg cfg >>= postRun cfg

--- a/emanote/src/Emanote.hs
+++ b/emanote/src/Emanote.hs
@@ -22,6 +22,7 @@ import Ema (
 import Ema.CLI qualified
 import Ema.Dynamic (Dynamic (Dynamic))
 import Emanote.CLI qualified as CLI
+import Emanote.MCP qualified as MCP
 import Emanote.Model.Graph qualified as G
 import Emanote.Model.Link.Rel (ResolvedRelTarget (..))
 import Emanote.Model.Type (modelCompileTailwind)
@@ -43,6 +44,7 @@ import Emanote.View.Template qualified as View
 import Optics.Core ((.~), (^.))
 import Relude
 import System.FilePath ((</>))
+import UnliftIO.Async (race_)
 
 instance IsRoute SiteRoute where
   type RouteModel SiteRoute = Model.ModelEma
@@ -72,8 +74,10 @@ run cfg@EmanoteConfig {..} = do
   case CLI.cmd _emanoteConfigCli of
     CLI.Cmd_Ema emaCli -> do
       let emaCfg = SiteConfig emaCli def
-      Ema.runSiteWith @SiteRoute emaCfg cfg
-        >>= postRun cfg
+          ema = Ema.runSiteWith @SiteRoute emaCfg cfg >>= postRun cfg
+      case CLI.mcpPort _emanoteConfigCli of
+        Nothing -> ema
+        Just port -> race_ (MCP.run port) ema
     CLI.Cmd_Export exportFormat -> do
       Dynamic (unModelEma -> model0, _) <-
         flip runLoggerLoggingT oneOffLogger

--- a/emanote/src/Emanote.hs
+++ b/emanote/src/Emanote.hs
@@ -72,12 +72,15 @@ defaultEmanoteConfig cli =
 run :: EmanoteConfig -> IO ()
 run cfg@EmanoteConfig {..} = do
   case CLI.cmd _emanoteConfigCli of
-    CLI.Cmd_Ema emaCli -> do
-      let emaCfg = SiteConfig emaCli def
+    CLI.Cmd_Run runCmd -> do
+      let emaCfg = SiteConfig (toEmaCli (CLI.Cmd_Run runCmd)) def
           ema = Ema.runSiteWith @SiteRoute emaCfg cfg >>= postRun cfg
-      case CLI.mcpPort _emanoteConfigCli of
+      case CLI.runMcpPort runCmd of
         Nothing -> ema
         Just port -> race_ (MCP.run port) ema
+    CLI.Cmd_Gen dest -> do
+      let emaCfg = SiteConfig (toEmaCli (CLI.Cmd_Gen dest)) def
+      Ema.runSiteWith @SiteRoute emaCfg cfg >>= postRun cfg
     CLI.Cmd_Export exportFormat -> do
       Dynamic (unModelEma -> model0, _) <-
         flip runLoggerLoggingT oneOffLogger
@@ -85,6 +88,12 @@ run cfg@EmanoteConfig {..} = do
       content <- Export.renderExport exportFormat model0
       putLBSLn content
   where
+    toEmaCli :: CLI.Cmd -> Ema.CLI.Cli
+    toEmaCli = \case
+      CLI.Cmd_Run rc -> mkEmaCli $ Ema.CLI.Run (CLI.runEmaArgs rc)
+      CLI.Cmd_Gen dest -> mkEmaCli $ Ema.CLI.Generate dest
+      CLI.Cmd_Export _ -> mkEmaCli $ Ema.CLI.action def
+    mkEmaCli action = Ema.CLI.Cli {Ema.CLI.action = action, Ema.CLI.verbose = CLI.verbose _emanoteConfigCli}
     -- A logger suited for running one-off commands.
     oneOffLogger =
       logToStderr

--- a/emanote/src/Emanote/CLI.hs
+++ b/emanote/src/Emanote/CLI.hs
@@ -5,10 +5,12 @@ module Emanote.CLI (
   Cli (..),
   Layer (..),
   Cmd (..),
+  RunCmd (..),
   parseCli,
   cliParser,
 ) where
 
+import Data.Default (def)
 import Data.Text qualified as T
 import Data.Version (showVersion)
 import Ema.CLI qualified
@@ -21,7 +23,7 @@ import UnliftIO.Directory (getCurrentDirectory)
 data Cli = Cli
   { layers :: NonEmpty Layer
   , allowBrokenInternalLinks :: Bool
-  , mcpPort :: Maybe Int
+  , verbose :: Bool
   , cmd :: Cmd
   }
 
@@ -31,36 +33,61 @@ data Layer = Layer
   }
 
 data Cmd
-  = Cmd_Ema Ema.CLI.Cli
+  = Cmd_Run RunCmd
+  | Cmd_Gen FilePath
   | Cmd_Export ExportFormat
 
-exportParser :: Parser Cmd
-exportParser = do
-  exportCmd <-
-    subparser
-      ( command "metadata" (info (pure ExportFormat_Metadata) (progDesc "Export metadata JSON"))
-          <> command "content" (info contentParser (progDesc "Export all notes to single Markdown file to stdout (uses baseUrl from notebook config)"))
-      )
-  pure $ Cmd_Export exportCmd
+-- | Arguments for the 'run' subcommand: Ema's live-server args plus Emanote's additions.
+data RunCmd = RunCmd
+  { runEmaArgs :: Ema.CLI.RunArgs
+  , runMcpPort :: Maybe Int
+  }
+
+cmdParser :: Parser Cmd
+cmdParser =
+  hsubparser
+    ( mconcat
+        [ command "run" (info (Cmd_Run <$> runCmdParser) (progDesc "Run the live server"))
+        , command "gen" (info (Cmd_Gen <$> argument str (metavar "DEST")) (progDesc "Generate the static site"))
+        , command "export" (info (Cmd_Export <$> exportParser) (progDesc "Export commands"))
+        ]
+    )
+    <|> pure (Cmd_Run defaultRunCmd)
   where
-    contentParser :: Parser ExportFormat
-    contentParser = pure ExportFormat_Content
+    defaultRunCmd = RunCmd def Nothing
+
+runCmdParser :: Parser RunCmd
+runCmdParser =
+  RunCmd
+    <$> Ema.CLI.runArgsParser
+    <*> optional
+      ( option portReader
+          $ mconcat
+            [ long "mcp-port"
+            , metavar "PORT"
+            , help "Expose an MCP (Model Context Protocol) server on this port alongside the live server"
+            ]
+      )
+
+exportParser :: Parser ExportFormat
+exportParser =
+  subparser
+    ( command "metadata" (info (pure ExportFormat_Metadata) (progDesc "Export metadata JSON"))
+        <> command "content" (info (pure ExportFormat_Content) (progDesc "Export all notes to single Markdown file to stdout (uses baseUrl from notebook config)"))
+    )
+
+portReader :: ReadM Int
+portReader = eitherReader $ \s ->
+  case readMaybe s of
+    Just n | n >= 1 && n <= 65535 -> Right n
+    _ -> Left $ "Port must be an integer in [1, 65535], got: " <> s
 
 cliParser :: FilePath -> Parser Cli
 cliParser cwd = do
   layers <- layerList $ one $ Layer cwd Nothing
   allowBrokenInternalLinks <- switch (long "allow-broken-internal-links" <> help "Report but do not fail on broken internal links")
-  mcpPort <-
-    optional
-      $ option portReader
-      $ mconcat
-        [ long "mcp-port"
-        , metavar "PORT"
-        , help "Expose an MCP (Model Context Protocol) server on this port alongside the live server"
-        ]
-  cmd <-
-    fmap Cmd_Ema Ema.CLI.cliParser
-      <|> subparser (command "export" (info exportParser (progDesc "Export commands")))
+  verbose <- switch (long "verbose" <> short 'v' <> help "Enable verbose logging")
+  cmd <- cmdParser
   pure Cli {..}
   where
     layerList defaultPath = do
@@ -72,11 +99,6 @@ cliParser cwd = do
           , value defaultPath
           , help "List of (semicolon delimited) notebook folders to 'union mount', with the left-side folders being overlaid on top of the right-side ones. The default layer is implicitly included at the end of this list."
           ]
-    portReader :: ReadM Int
-    portReader = eitherReader $ \s ->
-      case readMaybe s of
-        Just n | n >= 1 && n <= 65535 -> Right n
-        _ -> Left $ "Port must be an integer in [1, 65535], got: " <> s
     layerListReader :: ReadM (NonEmpty Layer)
     layerListReader = do
       let partition s =

--- a/emanote/src/Emanote/CLI.hs
+++ b/emanote/src/Emanote/CLI.hs
@@ -52,7 +52,7 @@ cliParser cwd = do
   allowBrokenInternalLinks <- switch (long "allow-broken-internal-links" <> help "Report but do not fail on broken internal links")
   mcpPort <-
     optional
-      $ option auto
+      $ option portReader
       $ mconcat
         [ long "mcp-port"
         , metavar "PORT"
@@ -72,6 +72,11 @@ cliParser cwd = do
           , value defaultPath
           , help "List of (semicolon delimited) notebook folders to 'union mount', with the left-side folders being overlaid on top of the right-side ones. The default layer is implicitly included at the end of this list."
           ]
+    portReader :: ReadM Int
+    portReader = eitherReader $ \s ->
+      case readMaybe s of
+        Just n | n >= 1 && n <= 65535 -> Right n
+        _ -> Left $ "Port must be an integer in [1, 65535], got: " <> s
     layerListReader :: ReadM (NonEmpty Layer)
     layerListReader = do
       let partition s =

--- a/emanote/src/Emanote/CLI.hs
+++ b/emanote/src/Emanote/CLI.hs
@@ -21,6 +21,7 @@ import UnliftIO.Directory (getCurrentDirectory)
 data Cli = Cli
   { layers :: NonEmpty Layer
   , allowBrokenInternalLinks :: Bool
+  , mcpPort :: Maybe Int
   , cmd :: Cmd
   }
 
@@ -49,6 +50,14 @@ cliParser :: FilePath -> Parser Cli
 cliParser cwd = do
   layers <- layerList $ one $ Layer cwd Nothing
   allowBrokenInternalLinks <- switch (long "allow-broken-internal-links" <> help "Report but do not fail on broken internal links")
+  mcpPort <-
+    optional
+      $ option auto
+      $ mconcat
+        [ long "mcp-port"
+        , metavar "PORT"
+        , help "Expose an MCP (Model Context Protocol) server on this port alongside the live server"
+        ]
   cmd <-
     fmap Cmd_Ema Ema.CLI.cliParser
       <|> subparser (command "export" (info exportParser (progDesc "Export commands")))

--- a/emanote/src/Emanote/MCP.hs
+++ b/emanote/src/Emanote/MCP.hs
@@ -18,10 +18,8 @@ import Data.Version (showVersion)
 import MCP.Server (
   Implementation (..),
   ListResourcesResult (..),
-  LoggingLevel (..),
   MCPHandlerState,
   MCPHandlerUser,
-  MCPServerState (..),
   ProcessResult (..),
   ReadResourceParams (..),
   ResourcesCapability (..),
@@ -55,14 +53,8 @@ server via 'UnliftIO.Async.race_'.
 -}
 run :: Int -> IO ()
 run port = do
-  stateVar <- newMVar initialState
+  stateVar <- newMVar $ initMCPServerState () Nothing Nothing capabilities implementation instructions handlers
   Warp.run port (simpleHttpApp stateVar)
-
-initialState :: MCPServerState
-initialState =
-  (initMCPServerState () Nothing Nothing capabilities implementation instructions handlers)
-    { mcp_log_level = Just Warning
-    }
 
 implementation :: Implementation
 implementation =

--- a/emanote/src/Emanote/MCP.hs
+++ b/emanote/src/Emanote/MCP.hs
@@ -56,7 +56,6 @@ server via 'UnliftIO.Async.race_'.
 run :: Int -> IO ()
 run port = do
   stateVar <- newMVar initialState
-  putStrLn $ "MCP server listening on http://localhost:" <> show port <> "/mcp"
   Warp.run port (simpleHttpApp stateVar)
 
 initialState :: MCPServerState

--- a/emanote/src/Emanote/MCP.hs
+++ b/emanote/src/Emanote/MCP.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | MCP (Model Context Protocol) server.
+
+Runs alongside the Emanote live server in the same process, exposing a
+read-only surface over HTTP. Phase 1 establishes the transport and the
+minimal lifecycle (@initialize@, @resources/list@, @resources/read@,
+@tools/list@, @tools/call@) with empty resource and tool inventories;
+notebook-backed resources and query tools arrive in later phases.
+-}
+module Emanote.MCP (
+  run,
+) where
+
+import Data.Version (showVersion)
+import MCP.Server (
+  Implementation (..),
+  ListResourcesResult (..),
+  LoggingLevel (..),
+  MCPHandlerState,
+  MCPHandlerUser,
+  MCPServerState (..),
+  ProcessResult (..),
+  ReadResourceParams (..),
+  ResourcesCapability (..),
+  ServerCapabilities (..),
+  ToolsCapability (..),
+  defaultProcessHandlers,
+  initMCPServerState,
+  listResourcesHandler,
+  readResourceHandler,
+  simpleHttpApp,
+  withToolHandlers,
+ )
+import MCP.Server qualified as MCP
+import Network.Wai.Handler.Warp qualified as Warp
+import Paths_emanote qualified
+import Relude
+
+-- | No per-session state is required for Phase 1.
+type instance MCPHandlerState = ()
+
+{- | No authenticated user type is required because we serve over
+'simpleHttpApp', which bypasses the JWT pipeline entirely. The instance
+exists only to satisfy the library's type-family constraint.
+-}
+type instance MCPHandlerUser = ()
+
+{- | Start the MCP HTTP server on the given port.
+
+This blocks. Intended to be run concurrently with the Emanote live
+server via 'UnliftIO.Async.race_'.
+-}
+run :: Int -> IO ()
+run port = do
+  stateVar <- newMVar initialState
+  putStrLn $ "MCP server listening on http://localhost:" <> show port <> "/mcp"
+  Warp.run port (simpleHttpApp stateVar)
+
+initialState :: MCPServerState
+initialState =
+  (initMCPServerState () Nothing Nothing capabilities implementation instructions handlers)
+    { mcp_log_level = Just Warning
+    }
+
+implementation :: Implementation
+implementation =
+  Implementation
+    { MCP.name = "emanote"
+    , version = toText $ showVersion Paths_emanote.version
+    , title = Just "Emanote MCP Server"
+    }
+
+instructions :: Maybe Text
+instructions =
+  Just
+    "Emanote exposes its live notebook model over MCP. Phase 1 provides only the handshake; resources and tools arrive in later phases."
+
+capabilities :: ServerCapabilities
+capabilities =
+  ServerCapabilities
+    { logging = Nothing
+    , prompts = Nothing
+    , resources = Just ResourcesCapability {listChanged = Nothing, subscribe = Nothing}
+    , tools = Just ToolsCapability {listChanged = Nothing}
+    , completions = Nothing
+    , experimental = Nothing
+    }
+
+handlers :: MCP.ProcessHandlers
+handlers =
+  withToolHandlers
+    []
+    defaultProcessHandlers
+      { listResourcesHandler = Just $ \_ ->
+          pure
+            $ ProcessSuccess
+            $ ListResourcesResult
+              { resources = []
+              , nextCursor = Nothing
+              , MCP._meta = Nothing
+              }
+      , readResourceHandler = Just $ \ReadResourceParams {uri} ->
+          pure $ ProcessRPCError 404 $ "Resource not found: " <> uri
+      }

--- a/emanote/src/Emanote/MCP.hs
+++ b/emanote/src/Emanote/MCP.hs
@@ -17,8 +17,10 @@ import Data.Version (showVersion)
 import MCP.Server (
   Implementation (..),
   ListResourcesResult (..),
+  LoggingLevel (..),
   MCPHandlerState,
   MCPHandlerUser,
+  MCPServerState (..),
   ProcessResult (..),
   ReadResourceParams (..),
   ResourcesCapability (..),
@@ -35,6 +37,7 @@ import MCP.Server qualified as MCP
 import Network.Wai.Handler.Warp qualified as Warp
 import Paths_emanote qualified
 import Relude
+import System.IO (hPutStrLn)
 
 type instance MCPHandlerState = ()
 
@@ -44,12 +47,24 @@ type instance MCPHandlerUser = ()
 {- | Start the MCP HTTP server on the given port.
 
 This blocks. Intended to be run concurrently with the Emanote live
-server via 'UnliftIO.Async.race_'.
+server via 'UnliftIO.Async.race_'. Prints a single @listening@ line
+to stderr once Warp has bound the socket. When @verbose@ is set, the
+underlying @mcp@ library emits one line per request/response to
+stdout.
 -}
-run :: Int -> IO ()
-run port = do
-  stateVar <- newMVar $ initMCPServerState () Nothing Nothing capabilities implementation instructions handlers
-  Warp.run port (simpleHttpApp stateVar)
+run :: Int -> Bool -> IO ()
+run port verbose = do
+  stateVar <-
+    newMVar
+      (initMCPServerState () Nothing Nothing capabilities implementation instructions handlers)
+        { mcp_log_level = Just (if verbose then Debug else Warning)
+        }
+  let settings =
+        Warp.defaultSettings
+          & Warp.setPort port
+          & Warp.setBeforeMainLoop
+            (hPutStrLn stderr $ "[mcp] listening on http://localhost:" <> show port <> "/mcp")
+  Warp.runSettings settings (simpleHttpApp stateVar)
 
 implementation :: Implementation
 implementation =

--- a/emanote/src/Emanote/MCP.hs
+++ b/emanote/src/Emanote/MCP.hs
@@ -5,10 +5,9 @@
 {- | MCP (Model Context Protocol) server.
 
 Runs alongside the Emanote live server in the same process, exposing a
-read-only surface over HTTP. Phase 1 establishes the transport and the
-minimal lifecycle (@initialize@, @resources/list@, @resources/read@,
-@tools/list@, @tools/call@) with empty resource and tool inventories;
-notebook-backed resources and query tools arrive in later phases.
+read-only surface over HTTP. Advertises the @resources@ and @tools@
+capabilities; current handlers return empty inventories and a
+not-found reply for unknown URIs.
 -}
 module Emanote.MCP (
   run,
@@ -37,13 +36,9 @@ import Network.Wai.Handler.Warp qualified as Warp
 import Paths_emanote qualified
 import Relude
 
--- | No per-session state is required for Phase 1.
 type instance MCPHandlerState = ()
 
-{- | No authenticated user type is required because we serve over
-'simpleHttpApp', which bypasses the JWT pipeline entirely. The instance
-exists only to satisfy the library's type-family constraint.
--}
+-- | Unused: 'simpleHttpApp' bypasses the JWT pipeline that would consume this.
 type instance MCPHandlerUser = ()
 
 {- | Start the MCP HTTP server on the given port.
@@ -65,9 +60,7 @@ implementation =
     }
 
 instructions :: Maybe Text
-instructions =
-  Just
-    "Emanote exposes its live notebook model over MCP. Phase 1 provides only the handshake; resources and tools arrive in later phases."
+instructions = Just "Emanote notebook exposed over MCP."
 
 capabilities :: ServerCapabilities
 capabilities =

--- a/flake.lock
+++ b/flake.lock
@@ -71,16 +71,15 @@
     "ema": {
       "flake": false,
       "locked": {
-        "lastModified": 1753226458,
-        "narHash": "sha256-vDhjw+Cm7HniaiIHirwM0B2yzzLYLO3HHMaZsQRL3uw=",
+        "lastModified": 1776974157,
+        "narHash": "sha256-rMb1a7VzMS2nmfEWAtJEKgZYg9Mc5JdSNK4y+z1S/ec=",
         "owner": "srid",
         "repo": "ema",
-        "rev": "7ff434cf8f494c62de7fe6c1a36d8681929beb93",
+        "rev": "e92e52dbefea57de08ef64b4db0ea795170d6b81",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "0.12.0.0",
         "repo": "ema",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -34,6 +34,40 @@
         "type": "github"
       }
     },
+    "dpella-jsonrpc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771256709,
+        "narHash": "sha256-gdBzrXo/tm9Xcs35yYiZkf9OI3S/FEV/5eGY183ywm4=",
+        "owner": "dpella",
+        "repo": "jsonrpc",
+        "rev": "0a708eb6c2744e1d69822d1cb90e9e352455a51b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dpella",
+        "repo": "jsonrpc",
+        "rev": "0a708eb6c2744e1d69822d1cb90e9e352455a51b",
+        "type": "github"
+      }
+    },
+    "dpella-mcp": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771505470,
+        "narHash": "sha256-wfh76/wO6j5JCIB++vfZn4LaFz1KAdy7hBjaFIpW5ZI=",
+        "owner": "dpella",
+        "repo": "mcp",
+        "rev": "52d13472d23ec11b9f6109f0fbf5159e9fda93da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dpella",
+        "repo": "mcp",
+        "rev": "52d13472d23ec11b9f6109f0fbf5159e9fda93da",
+        "type": "github"
+      }
+    },
     "ema": {
       "flake": false,
       "locked": {
@@ -201,6 +235,8 @@
       "inputs": {
         "commonmark-simple": "commonmark-simple",
         "commonmark-wikilink": "commonmark-wikilink",
+        "dpella-jsonrpc": "dpella-jsonrpc",
+        "dpella-mcp": "dpella-mcp",
         "ema": "ema",
         "emanote-template": "emanote-template",
         "flake-parts": "flake-parts",

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,13 @@
 
     emanote-template.url = "github:srid/emanote-template";
     emanote-template.flake = false;
+
+    # dpella/mcp is newer on GitHub than in nixpkgs' all-cabal-hashes,
+    # so pin the source directly. mcp-server/ and mcp-types/ are subdirs.
+    dpella-mcp.url = "github:dpella/mcp/52d13472d23ec11b9f6109f0fbf5159e9fda93da";
+    dpella-mcp.flake = false;
+    dpella-jsonrpc.url = "github:dpella/jsonrpc/0a708eb6c2744e1d69822d1cb90e9e352455a51b";
+    dpella-jsonrpc.flake = false;
   };
   outputs = inputs:
     inputs.nixos-unified.lib.mkFlake { inherit inputs; root = ./.; };

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     nixos-unified.url = "github:srid/nixos-unified";
 
     # These are not (necessarily) upstreamed to nixpkgs, yet.
-    ema.url = "github:srid/ema/0.12.0.0";
+    ema.url = "github:srid/ema";
     ema.flake = false;
     lvar.url = "github:srid/lvar/0.2.0.0";
     lvar.flake = false;

--- a/nix/modules/flake-parts/haskell.nix
+++ b/nix/modules/flake-parts/haskell.nix
@@ -32,6 +32,14 @@
         ghcid.source = "0.8.8";
         heist-extra.source = inputs.heist-extra;
 
+        # MCP (Model Context Protocol) server library.
+        # Pulled from GitHub because 0.3.1.0 isn't in the pinned
+        # all-cabal-hashes snapshot and mcp-types isn't packaged in nixpkgs.
+        mcp.source = inputs.dpella-mcp + /mcp-server;
+        mcp-types.source = inputs.dpella-mcp + /mcp-types;
+        # jsonrpc is an mcp-types dependency missing from nixpkgs.
+        jsonrpc.source = inputs.dpella-jsonrpc;
+
         ema.source = inputs.ema + /ema;
         ema-generics.source = inputs.ema + /ema-generics;
         ema-extra.source = inputs.ema + /ema-extra;


### PR DESCRIPTION
**Emanote can now expose a Model Context Protocol endpoint beside its live server**, started by the new `--mcp-port PORT` flag. This is phase 1 of #645 — the transport, lifecycle, and empty resource/tool inventories land here so phase 2 has something to plug notebook-backed handlers into. Nothing reads the live model yet; `resources/list` returns `[]` and `resources/read` returns a 404 on any URI.

Under the hood the MCP server is `dpella/mcp`'s `simpleHttpApp` on its own Warp port, raced against `Ema.runSiteWith` via `UnliftIO.Async.race_`. *Authentication is deferred per the issue's open question — `simpleHttpApp` bypasses the JWT pipeline, which is appropriate for same-process local use; revisiting this comes later in the rollout.* The CLI flag validates its port at parse time rather than failing with an opaque socket error downstream.

`mcp` 0.3.1.0 isn't yet in nixpkgs' pinned `all-cabal-hashes` snapshot and `mcp-types`/`jsonrpc` aren't in nixpkgs at all, so the three DPella packages are pulled from GitHub via flake inputs.

> **Deferred to phase 2+:** sharing the live notebook model (query-service interface), real resource/tool handlers, `race_` → supervised-restart once subscriptions land. Tracked by #645.

### Try it locally

```sh
nix run github:srid/emanote/feat/mcp-server-phase1 -- --mcp-port 8079 run
```

Then from another shell:

```sh
curl -sS -X POST http://localhost:8079/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
```

Refs #645.