### PR TITLE
Atom feed: empty query results no longer crash the build

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Mermaid: add `elk` layout ([#618](https://github.com/srid/emanote/pull/618))
 - Home Manager module: macOS support via launchd ([#623](https://github.com/srid/emanote/pull/623))
 
+**Fixes**
+
+- Atom feed: misconfigured feeds (missing query block, empty query results) no longer crash the whole build; an empty-but-valid Atom document is emitted instead ([#490](https://github.com/srid/emanote/issues/490))
+
 ## 1.4.0.0 (2025-08-18)
 
 **Notable features**

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 **Fixes**
 
-- Atom feed: misconfigured feeds (missing query block, empty query results) no longer crash the whole build; an empty-but-valid Atom document is emitted instead ([#490](https://github.com/srid/emanote/issues/490), [#650](https://github.com/srid/emanote/pull/650))
+- Atom feed: a feed query that matches no notes no longer crashes the build; an empty-but-valid Atom document is emitted instead. Configuration errors (missing/invalid query block, missing `page.siteUrl`) still fail loudly ([#490](https://github.com/srid/emanote/issues/490), [#650](https://github.com/srid/emanote/pull/650))
 
 ## 1.4.0.0 (2025-08-18)
 

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 **Fixes**
 
-- Atom feed: misconfigured feeds (missing query block, empty query results) no longer crash the whole build; an empty-but-valid Atom document is emitted instead ([#490](https://github.com/srid/emanote/issues/490))
+- Atom feed: misconfigured feeds (missing query block, empty query results) no longer crash the whole build; an empty-but-valid Atom document is emitted instead ([#490](https://github.com/srid/emanote/issues/490), [#650](https://github.com/srid/emanote/pull/650))
 
 ## 1.4.0.0 (2025-08-18)
 

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -255,3 +255,4 @@ test-suite test
       Emanote.Pandoc.ExternalLinkSpec
       Emanote.Pandoc.Renderer.CalloutSpec
       Emanote.Route.RSpec
+      Emanote.View.FeedSpec

--- a/emanote/src/Emanote/View/Feed.hs
+++ b/emanote/src/Emanote/View/Feed.hs
@@ -112,10 +112,16 @@ renderFeed model baseNote = case eFeedText of
 
 {- | A minimal valid Atom feed with no entries. Used as a safe fallback when the
 real feed cannot be generated (see 'renderFeed' and issue #490).
+
+Crashes only if the atom-feed library cannot serialize a fully hardcoded
+@nullFeed@ — a library bug worth surfacing loudly, not the user-facing
+misconfiguration this fallback exists to absorb.
 -}
 renderEmptyFeed :: Note -> LByteString
 renderEmptyFeed baseNote =
   let feedName = Atom.TextString $ toPlain $ _noteTitle baseNote
       feedId = show (_noteRoute baseNote)
       atomFeed = Atom.nullFeed feedId feedName "1970-01-01T00:00:00Z"
-   in maybe mempty encodeUtf8 (Export.textFeed atomFeed)
+   in encodeUtf8
+        $ fromMaybe (error "Emanote.View.Feed.renderEmptyFeed: atom-feed library failed to serialize a nullFeed")
+        $ Export.textFeed atomFeed

--- a/emanote/src/Emanote/View/Feed.hs
+++ b/emanote/src/Emanote/View/Feed.hs
@@ -121,7 +121,7 @@ renderEmptyFeed :: Note -> LByteString
 renderEmptyFeed baseNote =
   let feedName = Atom.TextString $ toPlain $ _noteTitle baseNote
       feedId = show (_noteRoute baseNote)
-      atomFeed = Atom.nullFeed feedId feedName "1970-01-01T00:00:00Z"
+      atomFeed = Atom.nullFeed feedId feedName (getNoteDate baseNote)
    in encodeUtf8
         $ fromMaybe (error "Emanote.View.Feed.renderEmptyFeed: atom-feed library failed to serialize a nullFeed")
         $ Export.textFeed atomFeed

--- a/emanote/src/Emanote/View/Feed.hs
+++ b/emanote/src/Emanote/View/Feed.hs
@@ -62,55 +62,56 @@ getNoteQuery note = case _noteDoc note of
           Left _ -> Right query
       _ -> go rest
 
--- | Render an Atom feed for a feed-enabled note. Falls back to an empty-but-valid feed on misconfiguration. See issue #490.
-renderFeed :: Model -> Note -> LByteString
-renderFeed model baseNote = case eFeedText of
-  Left _err -> renderEmptyFeed baseNote
-  Right feedText -> encodeUtf8 feedText
+{- | Render an Atom feed for a feed-enabled note.
+
+Configuration errors (missing/invalid query block, missing
+@page.siteUrl@) are reported as 'Left' so the caller can fail loudly.
+An empty query result set is treated as a normal runtime state — a
+blog with no posts yet — and yields an empty-but-valid Atom feed. See
+issue #490.
+-}
+renderFeed :: Model -> Note -> Either LText LByteString
+renderFeed model baseNote = encodeUtf8 <$> eFeedText
   where
+    eFeedText :: Either LText LText
     eFeedText = do
-      -- get the note feed
       feed <- maybeToRight "feed attribute missing" $ _noteFeed baseNote
-
-      -- find the query and get the feed notes
       feedQuery <- getNoteQuery baseNote
-      notes <- case runQuery (_noteRoute baseNote) model feedQuery of
-        [] -> Left "no notes matched the query"
-        x : xs -> Right (x :| xs)
+      case nonEmpty (runQuery (_noteRoute baseNote) model feedQuery) of
+        Nothing -> Right (renderEmptyFeed baseNote)
+        Just notes -> renderPopulatedFeed model baseNote feed notes
 
-      -- lookup the feedUrl
-      let feedMeta :: Aeson.Value
-          feedMeta = getEffectiveRouteMeta (_noteRoute baseNote) model
-      let mFeedUrl :: Maybe Text
-          mFeedUrl = lookupAeson Nothing ("page" :| ["siteUrl"]) feedMeta
-      feedUrl <- maybeToRight "index.yaml or note doesn't have page.siteUrl" mFeedUrl
+renderPopulatedFeed :: Model -> Note -> Feed -> NonEmpty Note -> Either LText LText
+renderPopulatedFeed model baseNote feed notes = do
+  let feedMeta :: Aeson.Value
+      feedMeta = getEffectiveRouteMeta (_noteRoute baseNote) model
+  let mFeedUrl :: Maybe Text
+      mFeedUrl = lookupAeson Nothing ("page" :| ["siteUrl"]) feedMeta
+  feedUrl <- maybeToRight "index.yaml or note doesn't have page.siteUrl" mFeedUrl
 
-      -- process the notes
-      let noteUrl note =
-            let sr = SiteRoute_ResourceRoute $ ResourceRoute_LML LMLView_Html $ _noteRoute note
-             in siteRouteUrl model sr
-      let takeNotes = case _feedLimit feed of
-            Nothing -> id
-            Just x -> take (fromIntegral x)
-      let feedEntries = noteToEntry feedUrl noteUrl <$> takeNotes (toList notes)
+  let noteUrl note =
+        let sr = SiteRoute_ResourceRoute $ ResourceRoute_LML LMLView_Html $ _noteRoute note
+         in siteRouteUrl model sr
+  let takeNotes = case _feedLimit feed of
+        Nothing -> id
+        Just x -> take (fromIntegral x)
+  let feedEntries = noteToEntry feedUrl noteUrl <$> takeNotes (toList notes)
 
-      -- render the feed
-      let feedTitle = fromMaybe (toPlain $ _noteTitle baseNote) (_feedTitle feed)
-      let feedName = Atom.TextString feedTitle
-      let feedUpdated = getNoteDate (head notes)
-      let feedLinks =
-            [ (Atom.nullLink (feedUrl <> "/" <> noteUrl baseNote)) {Atom.linkRel = Just (Left "alternate")}
-            , (Atom.nullLink (feedUrl <> "/" <> siteRouteUrl model (noteFeedSiteRoute baseNote))) {Atom.linkRel = Just (Left "self")}
-            ]
-      let atomFeed = (Atom.nullFeed feedUrl feedName feedUpdated) {Atom.feedEntries, Atom.feedLinks}
-      maybeToRight "invalid feed" $ Export.textFeed atomFeed
+  let feedTitle = fromMaybe (toPlain $ _noteTitle baseNote) (_feedTitle feed)
+  let feedName = Atom.TextString feedTitle
+  let feedUpdated = getNoteDate (head notes)
+  let feedLinks =
+        [ (Atom.nullLink (feedUrl <> "/" <> noteUrl baseNote)) {Atom.linkRel = Just (Left "alternate")}
+        , (Atom.nullLink (feedUrl <> "/" <> siteRouteUrl model (noteFeedSiteRoute baseNote))) {Atom.linkRel = Just (Left "self")}
+        ]
+  let atomFeed = (Atom.nullFeed feedUrl feedName feedUpdated) {Atom.feedEntries, Atom.feedLinks}
+  maybeToRight "invalid feed" $ Export.textFeed atomFeed
 
--- | A minimal valid Atom feed with no entries. Safe fallback for 'renderFeed'.
-renderEmptyFeed :: Note -> LByteString
+-- | A minimal valid Atom feed with no entries, used when a feed query matches no notes.
+renderEmptyFeed :: Note -> LText
 renderEmptyFeed baseNote =
   let feedName = Atom.TextString $ toPlain $ _noteTitle baseNote
       feedId = show (_noteRoute baseNote)
       atomFeed = Atom.nullFeed feedId feedName (getNoteDate baseNote)
-   in encodeUtf8
-        $ fromMaybe (error "Emanote.View.Feed.renderEmptyFeed: atom-feed library failed to serialize a nullFeed")
+   in fromMaybe (error "Emanote.View.Feed.renderEmptyFeed: atom-feed library failed to serialize a nullFeed")
         $ Export.textFeed atomFeed

--- a/emanote/src/Emanote/View/Feed.hs
+++ b/emanote/src/Emanote/View/Feed.hs
@@ -62,12 +62,7 @@ getNoteQuery note = case _noteDoc note of
           Left _ -> Right query
       _ -> go rest
 
-{- | Render an Atom feed for a feed-enabled note.
-
-A malformed feed configuration (missing/invalid query, empty query results) used
-to crash the entire build at 'Emanote.View.Template.renderResourceRoute'. We now
-fall back to an empty-but-valid Atom feed; see issue #490.
--}
+-- | Render an Atom feed for a feed-enabled note. Falls back to an empty-but-valid feed on misconfiguration. See issue #490.
 renderFeed :: Model -> Note -> LByteString
 renderFeed model baseNote = case eFeedText of
   Left _err -> renderEmptyFeed baseNote
@@ -110,13 +105,7 @@ renderFeed model baseNote = case eFeedText of
       let atomFeed = (Atom.nullFeed feedUrl feedName feedUpdated) {Atom.feedEntries, Atom.feedLinks}
       maybeToRight "invalid feed" $ Export.textFeed atomFeed
 
-{- | A minimal valid Atom feed with no entries. Used as a safe fallback when the
-real feed cannot be generated (see 'renderFeed' and issue #490).
-
-Crashes only if the atom-feed library cannot serialize a fully hardcoded
-@nullFeed@ — a library bug worth surfacing loudly, not the user-facing
-misconfiguration this fallback exists to absorb.
--}
+-- | A minimal valid Atom feed with no entries. Safe fallback for 'renderFeed'.
 renderEmptyFeed :: Note -> LByteString
 renderEmptyFeed baseNote =
   let feedName = Atom.TextString $ toPlain $ _noteTitle baseNote

--- a/emanote/src/Emanote/View/Feed.hs
+++ b/emanote/src/Emanote/View/Feed.hs
@@ -62,10 +62,16 @@ getNoteQuery note = case _noteDoc note of
           Left _ -> Right query
       _ -> go rest
 
-renderFeed :: Model -> Note -> Either LText LByteString
+{- | Render an Atom feed for a feed-enabled note.
+
+A malformed feed configuration (missing/invalid query, empty query results) used
+to crash the entire build at 'Emanote.View.Template.renderResourceRoute'. We now
+fall back to an empty-but-valid Atom feed; see issue #490.
+-}
+renderFeed :: Model -> Note -> LByteString
 renderFeed model baseNote = case eFeedText of
-  Left err -> Left err
-  Right feedText -> Right (encodeUtf8 feedText)
+  Left _err -> renderEmptyFeed baseNote
+  Right feedText -> encodeUtf8 feedText
   where
     eFeedText = do
       -- get the note feed
@@ -103,3 +109,13 @@ renderFeed model baseNote = case eFeedText of
             ]
       let atomFeed = (Atom.nullFeed feedUrl feedName feedUpdated) {Atom.feedEntries, Atom.feedLinks}
       maybeToRight "invalid feed" $ Export.textFeed atomFeed
+
+{- | A minimal valid Atom feed with no entries. Used as a safe fallback when the
+real feed cannot be generated (see 'renderFeed' and issue #490).
+-}
+renderEmptyFeed :: Note -> LByteString
+renderEmptyFeed baseNote =
+  let feedName = Atom.TextString $ toPlain $ _noteTitle baseNote
+      feedId = show (_noteRoute baseNote)
+      atomFeed = Atom.nullFeed feedId feedName "1970-01-01T00:00:00Z"
+   in maybe mempty encodeUtf8 (Export.textFeed atomFeed)

--- a/emanote/src/Emanote/View/Template.hs
+++ b/emanote/src/Emanote/View/Template.hs
@@ -95,7 +95,9 @@ renderResourceRoute m = \case
       Just (R.LMLView_Html, note) ->
         Ema.AssetGenerated Ema.Html $ renderLmlHtml m note
       Just (R.LMLView_Atom, note) ->
-        Ema.AssetGenerated Ema.Other $ renderFeed m note
+        case renderFeed m note of
+          Left err -> error $ toStrict $ "Bad feed: " <> show r <> ": " <> err
+          Right feed -> Ema.AssetGenerated Ema.Other feed
       Nothing ->
         -- This should never be reached because decodeRoute looks up the model.
         error $ "Bad route: " <> show r

--- a/emanote/src/Emanote/View/Template.hs
+++ b/emanote/src/Emanote/View/Template.hs
@@ -95,9 +95,7 @@ renderResourceRoute m = \case
       Just (R.LMLView_Html, note) ->
         Ema.AssetGenerated Ema.Html $ renderLmlHtml m note
       Just (R.LMLView_Atom, note) ->
-        case renderFeed m note of
-          Left err -> error $ toStrict $ "Bad feed: " <> show r <> ": " <> err
-          Right feed -> Ema.AssetGenerated Ema.Other feed
+        Ema.AssetGenerated Ema.Other $ renderFeed m note
       Nothing ->
         -- This should never be reached because decodeRoute looks up the model.
         error $ "Bad route: " <> show r

--- a/emanote/test/Emanote/View/FeedSpec.hs
+++ b/emanote/test/Emanote/View/FeedSpec.hs
@@ -1,6 +1,6 @@
 module Emanote.View.FeedSpec where
 
-import Data.ByteString.Lazy qualified as LBS
+import Data.Text.Lazy qualified as LT
 import Emanote.Model.Note (mkEmptyNoteWith)
 import Emanote.Model.Query (Query (QueryByPathPattern))
 import Emanote.Route qualified as R
@@ -13,7 +13,7 @@ import Text.Pandoc.Definition
 spec :: Spec
 spec = do
   describe "getNoteQuery" $ do
-    it "returns Left on a note with no query block (regression: issue #490)" $ do
+    it "returns Left on a note with no query block" $ do
       let note = mkEmptyNoteWith lmlRoute [Para [Str "just prose, no query"]]
       getNoteQuery note `shouldBe` Left "can't find note query"
     it "returns Left on an empty note" $ do
@@ -30,10 +30,11 @@ spec = do
       getNoteQuery note `shouldBe` Right (QueryByPathPattern "./*")
 
   describe "renderEmptyFeed" $ do
-    it "produces valid Atom XML (regression: issue #490 no longer crashes)" $ do
-      let note = mkEmptyNoteWith lmlRoute [Para [Str "just prose, no query"]]
-          bytes = renderEmptyFeed note
-      LBS.take 5 bytes `shouldBe` "<?xml"
+    it "produces valid Atom XML for an empty query result (regression: issue #490)" $ do
+      let note = mkEmptyNoteWith lmlRoute [queryBlock "path:./does-not-exist/*"]
+          xml = renderEmptyFeed note
+      LT.take 5 xml `shouldBe` "<?xml"
+      ("<feed" `LT.isInfixOf` xml) `shouldBe` True
 
 lmlRoute :: LMLRoute
 lmlRoute = LMLRoute_Md $ fromMaybe (error "bad route") $ R.mkRouteFromFilePath "blog.md"

--- a/emanote/test/Emanote/View/FeedSpec.hs
+++ b/emanote/test/Emanote/View/FeedSpec.hs
@@ -1,0 +1,42 @@
+module Emanote.View.FeedSpec where
+
+import Data.ByteString.Lazy qualified as LBS
+import Emanote.Model.Note (mkEmptyNoteWith)
+import Emanote.Model.Query (Query (QueryByPathPattern))
+import Emanote.Route qualified as R
+import Emanote.Route.ModelRoute (LMLRoute (LMLRoute_Md))
+import Emanote.View.Feed (getNoteQuery, renderEmptyFeed)
+import Relude
+import Test.Hspec
+import Text.Pandoc.Definition
+
+spec :: Spec
+spec = do
+  describe "getNoteQuery" $ do
+    it "returns Left on a note with no query block (regression: issue #490)" $ do
+      let note = mkEmptyNoteWith lmlRoute [Para [Str "just prose, no query"]]
+      getNoteQuery note `shouldBe` Left "can't find note query"
+    it "returns Left on an empty note" $ do
+      let note = mkEmptyNoteWith lmlRoute []
+      getNoteQuery note `shouldBe` Left "empty note"
+    it "returns Left on a note whose query is syntactically invalid" $ do
+      let note = mkEmptyNoteWith lmlRoute [queryBlock "not-a-valid-query"]
+      getNoteQuery note `shouldBe` Left "invalid query: not-a-valid-query"
+    it "returns Left on a note with multiple query blocks" $ do
+      let note = mkEmptyNoteWith lmlRoute [queryBlock "path:./*", queryBlock "path:./*"]
+      getNoteQuery note `shouldBe` Left "multiple ```query found"
+    it "returns Right on a note with a single valid query" $ do
+      let note = mkEmptyNoteWith lmlRoute [queryBlock "path:./*"]
+      getNoteQuery note `shouldBe` Right (QueryByPathPattern "./*")
+
+  describe "renderEmptyFeed" $ do
+    it "produces valid Atom XML (regression: issue #490 no longer crashes)" $ do
+      let note = mkEmptyNoteWith lmlRoute [Para [Str "just prose, no query"]]
+          bytes = renderEmptyFeed note
+      LBS.take 5 bytes `shouldBe` "<?xml"
+
+lmlRoute :: LMLRoute
+lmlRoute = LMLRoute_Md $ fromMaybe (error "bad route") $ R.mkRouteFromFilePath "blog.md"
+
+queryBlock :: Text -> Block
+queryBlock = CodeBlock ("", ["query"], [])

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -39,6 +39,10 @@ Feature: Smoke
     And I click the footnote ref with index "1" inside an embedded note
     Then the footnote popup contains "EMBED_FOOTNOTE_BODY"
 
+  Scenario: A feed-enabled note without a query block does not crash the build (regression: #490)
+    When I fetch "/empty-feed.xml"
+    Then the response is a valid Atom feed
+
   Scenario: The footnote list is hidden on screen but rendered in print mode
     When I open "/footnotes.html"
     Then no footnote list is visible on screen

--- a/tests/fixtures/notebook/empty-feed.md
+++ b/tests/fixtures/notebook/empty-feed.md
@@ -5,8 +5,13 @@ feed:
 
 # Empty feed
 
-A feed-enabled note that contains no `query` code block. Before issue
+A feed-enabled note whose query matches no notes. Before issue
 [#490](https://github.com/srid/emanote/issues/490) this aborted
-`emanote gen` with `Bad feed: ... can't find note query` and broke the
-live server's atom route for the note. The fix degrades gracefully to
-an empty-but-valid Atom feed.
+`emanote gen` with `Bad feed: ... no notes matched the query` and broke
+the live server's atom route. The fix degrades the empty-result case
+to a valid empty Atom feed; configuration errors (missing `query`
+block, invalid query) still fail loud.
+
+```query
+path:./does-not-exist/*
+```

--- a/tests/fixtures/notebook/empty-feed.md
+++ b/tests/fixtures/notebook/empty-feed.md
@@ -1,0 +1,12 @@
+---
+feed:
+  enable: true
+---
+
+# Empty feed
+
+A feed-enabled note that contains no `query` code block. Before issue
+[#490](https://github.com/srid/emanote/issues/490) this aborted
+`emanote gen` with `Bad feed: ... can't find note query` and broke the
+live server's atom route for the note. The fix degrades gracefully to
+an empty-but-valid Atom feed.

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -6,6 +6,32 @@ When("I open {string}", async function (this: EmanoteWorld, url: string) {
   await this.page.goto(url, { waitUntil: "domcontentloaded" });
 });
 
+When("I fetch {string}", async function (this: EmanoteWorld, url: string) {
+  this.lastResponse = await this.page.request.get(url);
+});
+
+Then(
+  "the response is a valid Atom feed",
+  async function (this: EmanoteWorld) {
+    const resp = this.lastResponse;
+    assert.ok(resp, "No prior `When I fetch …` recorded a response.");
+    assert.strictEqual(
+      resp.status(),
+      200,
+      `Expected 200; got ${resp.status()}. The feed route should serve an empty-but-valid Atom document, not error out (see #490).`,
+    );
+    const body = await resp.text();
+    assert.ok(
+      body.startsWith("<?xml"),
+      `Expected an XML prolog; first 100 chars: ${JSON.stringify(body.slice(0, 100))}.`,
+    );
+    assert.ok(
+      body.includes("<feed"),
+      `Expected a top-level <feed> element; body did not contain one. First 200 chars: ${JSON.stringify(body.slice(0, 200))}.`,
+    );
+  },
+);
+
 Given(
   "I note the resolved primary palette at {string}",
   async function (this: EmanoteWorld, url: string) {

--- a/tests/support/world.ts
+++ b/tests/support/world.ts
@@ -3,7 +3,7 @@ import {
   setWorldConstructor,
   setDefaultTimeout,
 } from "@cucumber/cucumber";
-import type { Browser, BrowserContext, Page } from "playwright";
+import type { APIResponse, Browser, BrowserContext, Page } from "playwright";
 
 setDefaultTimeout(60_000);
 
@@ -19,6 +19,7 @@ export class EmanoteWorld extends World {
   context!: BrowserContext;
   page!: Page;
   notedPrimary500?: string;
+  lastResponse?: APIResponse;
 
   /** Poll `--color-primary-500` on `:root` until it resolves to a
    *  non-empty value, then return it. Times out with the regression


### PR DESCRIPTION
**A `feed.enable: true` note whose `query` matches no notes — say a blog with no posts yet — used to abort the build** with `emanote: Bad feed: ... no notes matched the query`. `Emanote.View.Template.renderResourceRoute` was calling `error` whenever `renderFeed` returned a `Left`, treating a runtime emptiness state as a fatal program error.

`renderFeed` keeps its `Either LText LByteString` signature so configuration mistakes (missing/invalid `query` block, multiple queries, missing `page.siteUrl`) still surface as `Left` and **still fail the build loud** — those are user errors that need to be visible. Only the `runQuery [] -> empty-feed` case is rerouted: when a query is syntactically valid and present but the model has no matching notes, `renderFeed` now returns a minimal valid Atom document (id derived from the note's route, title from the note's title, date from `_noteMeta.date` or a 1970 fallback) via a new `renderEmptyFeed` helper. _The fix narrowed scope after the first review pass — earlier commits on this branch over-corrected by absorbing every `Left` and have since been reverted at the policy level._

Test coverage is in `Emanote.View.FeedSpec` (5 cases pinning down `getNoteQuery`'s failure classifications + 1 case for `renderEmptyFeed`'s XML output), plus a Cucumber e2e scenario that fetches `/empty-feed.xml` from a fixture whose query matches nothing — exercised in both live and static modes.

Closes #490.