### PR TITLE
Resolve relative links from index.md against its own folder

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Mermaid: add `elk` layout ([#618](https://github.com/srid/emanote/pull/618))
 - Home Manager module: macOS support via launchd ([#623](https://github.com/srid/emanote/pull/623))
 
+**Bug fixes**
+
+- Resolve relative URLs inside `<dir>/index.md` against `<dir>/` instead of its parent ([#651](https://github.com/srid/emanote/pull/651), closes [#608](https://github.com/srid/emanote/issues/608))
+
 ## 1.4.0.0 (2025-08-18)
 
 **Notable features**

--- a/emanote/src/Emanote/Model/Link/Rel.hs
+++ b/emanote/src/Emanote/Model/Link/Rel.hs
@@ -10,7 +10,7 @@ import Data.IxSet.Typed qualified as Ix
 import Data.List.NonEmpty qualified as NEL
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
-import Emanote.Model.Note (Note, noteDoc, noteRoute)
+import Emanote.Model.Note (Note, noteDoc, noteResolveLinkBase, noteRoute)
 import Emanote.Route (LMLRoute, ModelRoute)
 import Emanote.Route qualified as R
 import Emanote.Route.SiteRoute.Type qualified as SR
@@ -71,7 +71,7 @@ noteRels note =
         $ flip concatMap (Map.toList m)
         $ \(url, instances) -> do
           flip mapMaybe (toList instances) $ \(attrs, ctx) -> do
-            let parentR = R.withLmlRoute R.routeParent $ note ^. noteRoute
+            let parentR = noteResolveLinkBase note
             (target, _manchor) <- parseUnresolvedRelTarget parentR attrs url
             pure $ Rel (note ^. noteRoute) target ctx
 

--- a/emanote/src/Emanote/Model/Note.hs
+++ b/emanote/src/Emanote/Model/Note.hs
@@ -32,7 +32,7 @@ import Network.URI.Slug (Slug)
 import Optics.Core ((%), (.~))
 import Optics.TH (makeLenses)
 import Relude
-import System.FilePath (takeFileName, (</>))
+import System.FilePath (takeDirectory, takeFileName, (</>))
 import Text.Pandoc (readerExtensions, runPure)
 import Text.Pandoc.Builder qualified as B
 import Text.Pandoc.Definition (Pandoc (..))
@@ -122,6 +122,31 @@ noteAncestors =
 
 noteParent :: Note -> Maybe (R 'R.Folder)
 noteParent = R.withLmlRoute R.routeParent . _noteRoute
+
+{- | Folder used as the base for resolving relative URLs from this note.
+
+For most notes, this is the parent folder of the note's route. For notes
+loaded from @\<dir\>/index.md@ (or @index.org@) the canonicalized route
+already drops the @index@ slug — but relative URLs should still resolve
+against the actual @\<dir\>/@ directory, not its parent. We use the note's
+on-disk source path (when known) to derive the correct base.
+
+See <https://github.com/srid/emanote/issues/608>.
+-}
+noteResolveLinkBase :: Note -> Maybe (R 'R.Folder)
+noteResolveLinkBase note =
+  case _noteSource note of
+    Just (_, fp) -> resolveLinkBaseFromFilePath fp
+    Nothing -> noteParent note
+
+-- | Folder route corresponding to the directory containing the given file.
+resolveLinkBaseFromFilePath :: FilePath -> Maybe (R 'R.Folder)
+resolveLinkBaseFromFilePath fp =
+  case takeDirectory fp of
+    "." -> Nothing
+    "" -> Nothing
+    "/" -> Nothing
+    dir -> R.mkRouteFromFilePath dir
 
 hasChildNotes :: R 'Folder -> IxNote -> Bool
 hasChildNotes r =

--- a/emanote/src/Emanote/Model/Type.hs
+++ b/emanote/src/Emanote/Model/Type.hs
@@ -257,6 +257,18 @@ modelLookupNoteByRoute' :: LMLRoute -> ModelT f -> Maybe Note
 modelLookupNoteByRoute' r =
   fmap snd . modelLookupNoteByRoute (R.LMLView_Html, r)
 
+{- | Folder used as the base for resolving relative URLs from the note at the
+given route. Uses the note's on-disk source path when the note exists; falls
+back to the canonical route parent for synthesized notes (and for routes that
+have no matching note in the model).
+-}
+modelResolveLinkBase :: ModelT f -> LMLRoute -> Maybe (R.R 'R.Folder)
+modelResolveLinkBase model r =
+  maybe
+    (R.withLmlRoute R.routeParent r)
+    N.noteResolveLinkBase
+    (modelLookupNoteByRoute' r model)
+
 modelLookupNoteByHtmlRoute :: R 'R.Html -> ModelT f -> Rel.ResolvedRelTarget Note
 modelLookupNoteByHtmlRoute r =
   Rel.resolvedRelTargetFromCandidates

--- a/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -32,9 +32,7 @@ embedBlockWikiLinkResolvingSplice model _nf ctx noteRoute node = do
   B.Para [inl] <- pure node
   (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
   guard $ inlRef == Link.InlineLink
-  let parentR =
-        maybe (R.withLmlRoute R.routeParent noteRoute) MN.noteResolveLinkBase
-          $ M.modelLookupNoteByRoute' noteRoute model
+  let parentR = M.modelResolveLinkBase model noteRoute
   -- TODO: Use anchor to embed a section?
   (Rel.URTWikiLink (WL.WikiLinkEmbed, wl), _mAnchor) <-
     Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
@@ -51,9 +49,7 @@ embedBlockRegularLinkResolvingSplice model _nf ctx noteRoute node = do
   B.Para [inl] <- pure node
   (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
   guard $ inlRef == Link.InlineImage
-  let parentR =
-        maybe (R.withLmlRoute R.routeParent noteRoute) MN.noteResolveLinkBase
-          $ M.modelLookupNoteByRoute' noteRoute model
+  let parentR = M.modelResolveLinkBase model noteRoute
   (Rel.URTResource mr, _mAnchor) <-
     Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveModelRoute model mr
@@ -64,9 +60,7 @@ embedInlineWikiLinkResolvingSplice :: PandocInlineRenderer Model R.LMLRoute
 embedInlineWikiLinkResolvingSplice model _nf ctx noteRoute inl = do
   (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
   guard $ inlRef == Link.InlineLink
-  let parentR =
-        maybe (R.withLmlRoute R.routeParent noteRoute) MN.noteResolveLinkBase
-          $ M.modelLookupNoteByRoute' noteRoute model
+  let parentR = M.modelResolveLinkBase model noteRoute
   (Rel.URTWikiLink (WL.WikiLinkEmbed, wl), _mAnchor) <- Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveWikiLinkMustExist model noteRoute wl
   RendererUrl.renderSomeInlineRefWith Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl

--- a/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -3,6 +3,7 @@ module Emanote.Pandoc.Renderer.Embed where
 import Commonmark.Extensions.WikiLink qualified as WL
 import Data.Map.Syntax ((##))
 import Emanote.Model (Model)
+import Emanote.Model qualified as M
 import Emanote.Model.Link.Rel qualified as Rel
 import Emanote.Model.Link.Resolve qualified as Resolve
 import Emanote.Model.Note qualified as MN
@@ -31,7 +32,9 @@ embedBlockWikiLinkResolvingSplice model _nf ctx noteRoute node = do
   B.Para [inl] <- pure node
   (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
   guard $ inlRef == Link.InlineLink
-  let parentR = R.withLmlRoute R.routeParent noteRoute
+  let parentR =
+        maybe (R.withLmlRoute R.routeParent noteRoute) MN.noteResolveLinkBase
+          $ M.modelLookupNoteByRoute' noteRoute model
   -- TODO: Use anchor to embed a section?
   (Rel.URTWikiLink (WL.WikiLinkEmbed, wl), _mAnchor) <-
     Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
@@ -48,7 +51,9 @@ embedBlockRegularLinkResolvingSplice model _nf ctx noteRoute node = do
   B.Para [inl] <- pure node
   (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
   guard $ inlRef == Link.InlineImage
-  let parentR = R.withLmlRoute R.routeParent noteRoute
+  let parentR =
+        maybe (R.withLmlRoute R.routeParent noteRoute) MN.noteResolveLinkBase
+          $ M.modelLookupNoteByRoute' noteRoute model
   (Rel.URTResource mr, _mAnchor) <-
     Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveModelRoute model mr
@@ -59,7 +64,9 @@ embedInlineWikiLinkResolvingSplice :: PandocInlineRenderer Model R.LMLRoute
 embedInlineWikiLinkResolvingSplice model _nf ctx noteRoute inl = do
   (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
   guard $ inlRef == Link.InlineLink
-  let parentR = R.withLmlRoute R.routeParent noteRoute
+  let parentR =
+        maybe (R.withLmlRoute R.routeParent noteRoute) MN.noteResolveLinkBase
+          $ M.modelLookupNoteByRoute' noteRoute model
   (Rel.URTWikiLink (WL.WikiLinkEmbed, wl), _mAnchor) <- Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveWikiLinkMustExist model noteRoute wl
   RendererUrl.renderSomeInlineRefWith Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl

--- a/emanote/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Url.hs
@@ -29,7 +29,9 @@ import Text.Pandoc.Walk qualified as W
 urlResolvingSplice :: PandocInlineRenderer Model R.LMLRoute
 urlResolvingSplice model _nf (ctxSansCustomSplicing -> ctx) noteRoute inl = do
   (inlRef, attr@(id', cls, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
-  let parentR = R.withLmlRoute R.routeParent noteRoute
+  let parentR =
+        maybe (R.withLmlRoute R.routeParent noteRoute) MN.noteResolveLinkBase
+          $ M.modelLookupNoteByRoute' noteRoute model
   (uRel, mAnchor) <- Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveUnresolvedRelTarget model noteRoute uRel
   renderSomeInlineRefWith id (is, (url, tit)) rRel model ctx inl $ \sr ->

--- a/emanote/src/Emanote/Pandoc/Renderer/Url.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Url.hs
@@ -29,9 +29,7 @@ import Text.Pandoc.Walk qualified as W
 urlResolvingSplice :: PandocInlineRenderer Model R.LMLRoute
 urlResolvingSplice model _nf (ctxSansCustomSplicing -> ctx) noteRoute inl = do
   (inlRef, attr@(id', cls, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
-  let parentR =
-        maybe (R.withLmlRoute R.routeParent noteRoute) MN.noteResolveLinkBase
-          $ M.modelLookupNoteByRoute' noteRoute model
+  let parentR = M.modelResolveLinkBase model noteRoute
   (uRel, mAnchor) <- Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
   let rRel = Resolve.resolveUnresolvedRelTarget model noteRoute uRel
   renderSomeInlineRefWith id (is, (url, tit)) rRel model ctx inl $ \sr ->

--- a/emanote/test/Emanote/Model/Link/RelSpec.hs
+++ b/emanote/test/Emanote/Model/Link/RelSpec.hs
@@ -1,6 +1,9 @@
 module Emanote.Model.Link.RelSpec where
 
 import Emanote.Model.Link.Rel
+import Emanote.Model.Note qualified as MN
+import Emanote.Route.ModelRoute (mkModelRouteFromFilePath)
+import Emanote.Route.R (R (..))
 import Hedgehog
 import Relude
 import Test.Hspec
@@ -26,6 +29,25 @@ spec = do
       dropDotDot "foo/.." === ""
       dropDotDot "foo/bar/.." === "foo"
       dropDotDot "foo/bar/../.." === ""
+  describe "resolveLinkBaseFromFilePath" $ do
+    it "top-level files have no base" . hedgehog $ do
+      MN.resolveLinkBaseFromFilePath "index.md" === Nothing
+      MN.resolveLinkBaseFromFilePath "foo.md" === Nothing
+    it "subfolder/index.md uses subfolder as base (issue #608)" . hedgehog $ do
+      MN.resolveLinkBaseFromFilePath "subfolder/index.md"
+        === Just (R ("subfolder" :| []))
+    it "subfolder/foo.md uses subfolder as base" . hedgehog $ do
+      MN.resolveLinkBaseFromFilePath "subfolder/foo.md"
+        === Just (R ("subfolder" :| []))
+    it "a/b/index.md uses a/b as base" . hedgehog $ do
+      MN.resolveLinkBaseFromFilePath "a/b/index.md"
+        === Just (R ("a" :| ["b"]))
+  describe "parseUnresolvedRelTarget (issue #608)" $ do
+    it "relative link from subfolder/index.md resolves under subfolder/" . hedgehog $ do
+      let base = MN.resolveLinkBaseFromFilePath "subfolder/index.md"
+          got = fst <$> parseUnresolvedRelTarget base [] "foo.md"
+          want = URTResource <$> mkModelRouteFromFilePath "subfolder/foo.md"
+      got === want
 
 -- https://github.com/hedgehogqa/haskell-hedgehog/issues/121
 once :: PropertyT IO () -> Property

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -39,6 +39,10 @@ Feature: Smoke
     And I click the footnote ref with index "1" inside an embedded note
     Then the footnote popup contains "EMBED_FOOTNOTE_BODY"
 
+  Scenario: Relative links from <dir>/index.md resolve against <dir>/ (issue #608)
+    When I open "/subfolder.html"
+    Then the article link with text "sibling" has href containing "subfolder/sibling"
+
   Scenario: The footnote list is hidden on screen but rendered in print mode
     When I open "/footnotes.html"
     Then no footnote list is visible on screen

--- a/tests/fixtures/notebook/subfolder/index.md
+++ b/tests/fixtures/notebook/subfolder/index.md
@@ -1,0 +1,3 @@
+# Subfolder home
+
+A relative link to a [sibling](./sibling.md) inside this folder.

--- a/tests/fixtures/notebook/subfolder/sibling.md
+++ b/tests/fixtures/notebook/subfolder/sibling.md
@@ -1,0 +1,3 @@
+# Sibling
+
+I am the sibling page.

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -107,6 +107,25 @@ Then(
   },
 );
 
+// Issue #608: a relative link inside `<dir>/index.md` must resolve against
+// `<dir>/`, not the parent of the canonicalized route. Scoped to <article>
+// because the sidebar nav also surfaces a child link to the same target —
+// and that path is auto-generated from the route hierarchy, so it stays
+// correct even when the bug is live. Only the article-body anchor exercises
+// the relative-URL resolver we're testing.
+Then(
+  "the article link with text {string} has href containing {string}",
+  async function (this: EmanoteWorld, linkText: string, needle: string) {
+    const link = this.page.locator(`article a:has-text("${linkText}")`).first();
+    await link.waitFor({ state: "attached", timeout: 5_000 });
+    const href = await link.getAttribute("href");
+    assert.ok(
+      href && href.includes(needle),
+      `Article link "${linkText}" expected href to contain ${JSON.stringify(needle)}, got ${JSON.stringify(href)}.`,
+    );
+  },
+);
+
 const POPOVER_SEL = "#emanote-footnote-popover";
 
 When(


### PR DESCRIPTION
**Relative URLs inside `<dir>/index.md` now resolve against `<dir>/`, not its parent.** Closes #608. Previously, Emanote canonicalized `subfolder/index.md` to route `subfolder` (dropping the trailing `index` slug), and then derived the link-resolution base by taking that route's parent — which landed one folder too high. So `[foo](./foo.md)` inside `subfolder/index.md` resolved to `foo.md` at the root instead of `subfolder/foo.md`.

The fix derives the base from the note's on-disk source filepath (`takeDirectory`) rather than its canonicalized route. A new `noteResolveLinkBase :: Note -> Maybe (R 'Folder)` lives in `Emanote.Model.Note`, and `modelResolveLinkBase :: Model -> LMLRoute -> Maybe (R 'Folder)` in `Emanote.Model.Type` wraps the model lookup so the four splice callsites (`Url.urlResolvingSplice` and three in `Pandoc.Renderer.Embed`) collapse to a single function call. *Synthesized notes (placeholders, missing-note pages) lack an on-disk path and fall back to `noteParent` — they don't trigger the bug since they have no canonicalized source to drift from.*

Five new unit tests in `RelSpec` cover top-level files, subfolder index files, deeply nested index files, sibling non-index files, and an end-to-end `parseUnresolvedRelTarget` resolution from `subfolder/index.md`. An additional **e2e scenario** runs in both `live` and `static` modes against a `subfolder/index.md` + `subfolder/sibling.md` fixture, asserting the article-body anchor's href resolves to `subfolder/sibling.html`. *The selector is scoped to `<article>` because the sidebar nav surfaces a child link to the same target — and that path is auto-generated from the route hierarchy, so it stays correct even when the bug is live.*

> The post-implement Hickey review flagged the lookup-and-fallback algorithm as inlined identically at four splice sites. The second commit extracts `modelResolveLinkBase` to encode the rule once. Lowy review was clean.