### PR TITLE
Fix "div cannot contain text" crash on raw HTML blocks (#119)

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Atom feed: a feed query that matches no notes no longer crashes the build; an empty-but-valid Atom document is emitted instead. Configuration errors (missing/invalid query block, missing `page.siteUrl`) still fail loudly ([#490](https://github.com/srid/emanote/issues/490), [#650](https://github.com/srid/emanote/pull/650))
 - Resolve relative URLs inside `<dir>/index.md` against `<dir>/` instead of its parent ([#651](https://github.com/srid/emanote/pull/651), closes [#608](https://github.com/srid/emanote/issues/608))
+- Raw HTML blocks containing a literal `</div>` no longer crash the renderer with `div cannot contain text looking like its end tag` (closes [#119](https://github.com/srid/emanote/issues/119)). Fixed upstream in [srid/heist-extra#13](https://github.com/srid/heist-extra/pull/13) by switching the raw-HTML wrapper to a unique `<rawhtml>` element with `display: contents`.
 
 ## 1.4.0.0 (2025-08-18)
 

--- a/flake.lock
+++ b/flake.lock
@@ -169,11 +169,11 @@
     "heist-extra": {
       "flake": false,
       "locked": {
-        "lastModified": 1776811520,
-        "narHash": "sha256-FCWJVrXjIu/du69h/rfkqXYcjA2+1CpJcxNVyDR6eyA=",
+        "lastModified": 1777123575,
+        "narHash": "sha256-4ArDqHLR82XJJE9AA3sX1w9eyChY1HRVwAzTYwRdEx8=",
         "owner": "srid",
         "repo": "heist-extra",
-        "rev": "13c70e98621740fda1d93f4a5bd766b357535377",
+        "rev": "bddc871dd0fe68c6376c6514498320b23ff9320e",
         "type": "github"
       },
       "original": {

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -39,6 +39,10 @@ Feature: Smoke
     And I click the footnote ref with index "1" inside an embedded note
     Then the footnote popup contains "EMBED_FOOTNOTE_BODY"
 
+  Scenario: Raw HTML block containing </div> renders without crashing (regression: #119)
+    When I open "/rawhtml.html"
+    Then the page contains an element with data-marker "RAWHTML_DIV_OK"
+
   Scenario: A feed-enabled note whose query matches no notes does not crash the build (regression: #490)
     When I fetch "/empty-feed.xml"
     Then the response is a valid Atom feed

--- a/tests/fixtures/notebook/rawhtml.md
+++ b/tests/fixtures/notebook/rawhtml.md
@@ -1,0 +1,14 @@
+---
+slug: rawhtml
+---
+
+# Raw HTML regression (issue #119)
+
+Pandoc treats the block below as a raw HTML block. The `</div>` literal
+inside it used to crash xmlhtml's renderer with "div cannot contain
+text looking like its end tag" — see srid/heist-extra#13 for the fix.
+The marker on the inner element is what the e2e step asserts on.
+
+<div>
+  <p data-marker="RAWHTML_DIV_OK">inside the div</p>
+</div>

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -10,6 +10,23 @@ When("I fetch {string}", async function (this: EmanoteWorld, url: string) {
   this.lastResponse = await this.page.request.get(url);
 });
 
+// #119: a raw HTML block containing a literal `</div>` used to truncate the
+// page mid-render with `div cannot contain text looking like its end tag`.
+// Asserting on a marker *inside* the raw block proves the page reached past
+// the offending node — a partial response wouldn't include the marker.
+Then(
+  "the page contains an element with data-marker {string}",
+  async function (this: EmanoteWorld, marker: string) {
+    const count = await this.page
+      .locator(`[data-marker="${marker}"]`)
+      .count();
+    assert.ok(
+      count > 0,
+      `Expected an element with data-marker="${marker}"; got ${count}. Either the raw-HTML wrapper regressed (xmlhtml's "div cannot contain text…" path) and the page was truncated, or Pandoc no longer recognises the source as a raw HTML block.`,
+    );
+  },
+);
+
 Then(
   "the response is a valid Atom feed",
   async function (this: EmanoteWorld) {


### PR DESCRIPTION
**Raw HTML blocks containing a literal `</div>` no longer crash the renderer.** The bug was in `heist-extra`'s `rawNode`, which wrapped every raw HTML blob in `<div xmlhtmlRaw>`. xmlhtml's renderer then refused to emit any such `<div>` whose text content included `</div>` — a check at `Text.XmlHtml.HTML.Render` lines 131-133 — and aborted the page mid-render with `div cannot contain text looking like its end tag`.

The fix landed upstream in [srid/heist-extra#13](https://github.com/srid/heist-extra/pull/13): the wrapper is now a unique `<rawhtml>` element with `display: contents`, so the name can't collide with anything embedded inside, and the layout-collapsing style keeps the surrounding flow untouched. *This PR is just a `flake.lock` bump* to pick up the merged fix on master, plus a changelog line citing both the user-facing issue and the upstream PR.

Closes #119.

### Try it locally

```sh
nix run github:srid/emanote/heist-extra-rawhtml-fix
```