### PR TITLE
Halve e2e CI minutes by sharing the build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,17 +18,45 @@ jobs:
           # TODO: Define this in Vira or make it part of our flake?
           nix build github:hercules-ci/flake.parts-website#checks.x86_64-linux.linkcheck --override-input emanote .
 
-  e2e-tests:
+  # Build emanote once and ship the Nix closure as an artifact so the
+  # downstream e2e-tests job can run both `live` and `static` modes
+  # against the same binary without rebuilding (previously the matrix
+  # rebuilt twice in parallel — ~4 min each).
+  build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        mode: [live, static]
+    outputs:
+      bin: ${{ steps.build.outputs.bin }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v33
+      - name: Build emanote
+        id: build
+        run: |
+          OUT="$(nix build --no-link --print-out-paths .#default)"
+          echo "bin=$OUT/bin/emanote" >> "$GITHUB_OUTPUT"
+          nix-store --export $(nix-store -qR "$OUT") | gzip > emanote-closure.nar.gz
+      - name: Upload emanote closure
+        uses: actions/upload-artifact@v4
+        with:
+          name: emanote-closure
+          path: emanote-closure.nar.gz
+          retention-days: 1
+
+  e2e-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v33
+      - name: Download emanote closure
+        uses: actions/download-artifact@v4
+        with:
+          name: emanote-closure
+      - name: Import emanote closure
+        run: gunzip -c emanote-closure.nar.gz | nix-store --import > /dev/null
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -42,21 +70,22 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('tests/package-lock.json') }}
-      - name: Build emanote
-        id: build
-        run: |
-          BIN="$(nix build --no-link --print-out-paths .#default)/bin/emanote"
-          echo "bin=$BIN" >> "$GITHUB_OUTPUT"
       - name: Install test dependencies
         working-directory: tests
         run: |
           npm ci
           npx playwright install --with-deps chromium
-      - name: E2E (${{ matrix.mode }})
+      - name: E2E (live)
         working-directory: tests
         env:
-          EMANOTE_BIN: ${{ steps.build.outputs.bin }}
-          EMANOTE_MODE: ${{ matrix.mode }}
+          EMANOTE_BIN: ${{ needs.build.outputs.bin }}
+          EMANOTE_MODE: live
+        run: npm test
+      - name: E2E (static)
+        working-directory: tests
+        env:
+          EMANOTE_BIN: ${{ needs.build.outputs.bin }}
+          EMANOTE_MODE: static
         run: npm test
 
   website:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,10 @@ jobs:
         id: build
         run: |
           OUT="$(nix build --no-link --print-out-paths .#default)"
+          # Fail the build job if the derivation no longer places the
+          # binary at <out>/bin/emanote — otherwise the mismatch would
+          # surface 30+ minutes later as an obscure test failure.
+          test -x "$OUT/bin/emanote" || { echo "expected emanote binary at $OUT/bin/emanote" >&2; exit 1; }
           echo "bin=$OUT/bin/emanote" >> "$GITHUB_OUTPUT"
           nix-store --export $(nix-store -qR "$OUT") | gzip > emanote-closure.nar.gz
       - name: Upload emanote closure

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,11 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
+      # The two modes are intentionally serialized and share identical
+      # setup (Nix install, artifact import, node, playwright). If they
+      # ever need to diverge — different timeout, different env, a
+      # service container — restore the matrix or split into separate
+      # jobs rather than growing inline conditionals here.
       - name: E2E (live)
         working-directory: tests
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,12 @@ jobs:
         with:
           name: emanote-closure
       - name: Import emanote closure
-        run: gunzip -c emanote-closure.nar.gz | nix-store --import > /dev/null
+        run: |
+          gunzip -c emanote-closure.nar.gz | nix-store --import > /dev/null
+          # nix-store --import accepts a syntactically valid but
+          # incomplete closure without complaint; assert the binary is
+          # actually executable before proceeding to test setup.
+          test -x "${{ needs.build.outputs.bin }}" || { echo "imported closure missing emanote binary at ${{ needs.build.outputs.bin }}" >&2; exit 1; }
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      EMANOTE_BIN: ${{ needs.build.outputs.bin }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -65,7 +67,7 @@ jobs:
           # nix-store --import accepts a syntactically valid but
           # incomplete closure without complaint; assert the binary is
           # actually executable before proceeding to test setup.
-          test -x "${{ needs.build.outputs.bin }}" || { echo "imported closure missing emanote binary at ${{ needs.build.outputs.bin }}" >&2; exit 1; }
+          test -x "$EMANOTE_BIN" || { echo "imported closure missing emanote binary at $EMANOTE_BIN" >&2; exit 1; }
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -92,13 +94,11 @@ jobs:
       - name: E2E (live)
         working-directory: tests
         env:
-          EMANOTE_BIN: ${{ needs.build.outputs.bin }}
           EMANOTE_MODE: live
         run: npm test
       - name: E2E (static)
         working-directory: tests
         env:
-          EMANOTE_BIN: ${{ needs.build.outputs.bin }}
           EMANOTE_MODE: static
         run: npm test
 


### PR DESCRIPTION
The e2e workflow fanned out as a 2-entry matrix on `mode: [live, static]`, which **rebuilt emanote twice in parallel — ~8 actions-minutes per run for a 5-second test**. The new shape: a `build` job runs `nix build` once and uploads its Nix closure as a workflow artifact; `e2e-tests` imports the closure and runs both modes serially against the same binary.

*Wall-clock is roughly unchanged* (the bottleneck is still the ~4-minute Haskell rebuild), but actions-minutes drop ~50%, and a flaky test re-run no longer drags a fresh build along with it — re-running just `e2e-tests` picks up the already-uploaded closure.

> **Mode divergence**: the previous matrix was a one-row seam for per-mode customization. The two E2E steps are now hard-coded with a tradeoff comment in the workflow — if `live` ever needs a different timeout, env var, or service container, restore the matrix or split into separate jobs rather than growing inline conditionals.

A few follow-up commits add a build-side `test -x` guard (a relocated binary now fails locally instead of leaking into a 30-minute test run), the same guard post-`nix-store --import` (since import accepts an incomplete closure without complaint), and lift `EMANOTE_BIN` to the job's `env:` so the two E2E steps differ visibly only in `EMANOTE_MODE`.