### PR TITLE
Resolve markdown links to .xml assets when no feed shadows them (#547)

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -20,6 +20,7 @@
 **Bug fixes**
 
 - Atom feed: a feed query that matches no notes no longer crashes the build; an empty-but-valid Atom document is emitted instead. Configuration errors (missing/invalid query block, missing `page.siteUrl`) still fail loudly ([#490](https://github.com/srid/emanote/issues/490), [#650](https://github.com/srid/emanote/pull/650))
+- Markdown links to a static `.xml` asset (e.g. `[Test](./test.xml)`) now resolve to the file. Previously a `.xml` URL was always interpreted as the Atom feed of a same-named note, leaving asset links broken when no such feed-enabled note existed (closes [#547](https://github.com/srid/emanote/issues/547))
 - Resolve relative URLs inside `<dir>/index.md` against `<dir>/` instead of its parent ([#651](https://github.com/srid/emanote/pull/651), closes [#608](https://github.com/srid/emanote/issues/608))
 - Raw HTML blocks containing a literal `</div>` no longer crash the renderer with `div cannot contain text looking like its end tag` (closes [#119](https://github.com/srid/emanote/issues/119)). Fixed upstream in [srid/heist-extra#13](https://github.com/srid/heist-extra/pull/13) by switching the raw-HTML wrapper to a unique `<rawhtml>` element with `display: contents`.
 

--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -20,7 +20,7 @@
 **Bug fixes**
 
 - Atom feed: a feed query that matches no notes no longer crashes the build; an empty-but-valid Atom document is emitted instead. Configuration errors (missing/invalid query block, missing `page.siteUrl`) still fail loudly ([#490](https://github.com/srid/emanote/issues/490), [#650](https://github.com/srid/emanote/pull/650))
-- Markdown links to a static `.xml` asset (e.g. `[Test](./test.xml)`) now resolve to the file. Previously a `.xml` URL was always interpreted as the Atom feed of a same-named note, leaving asset links broken when no such feed-enabled note existed (closes [#547](https://github.com/srid/emanote/issues/547))
+- Markdown links to a static `.xml` asset (e.g. `[Test](./test.xml)`) now resolve to the file. Previously a `.xml` URL was always interpreted as the Atom feed of a same-named note, leaving asset links broken when no such feed-enabled note existed. The missing-link page now also tailors its "you may create…" hint to the URL extension instead of always suggesting `<url>.md` / `<url>.org` (closes [#547](https://github.com/srid/emanote/issues/547))
 - Resolve relative URLs inside `<dir>/index.md` against `<dir>/` instead of its parent ([#651](https://github.com/srid/emanote/pull/651), closes [#608](https://github.com/srid/emanote/issues/608))
 - Raw HTML blocks containing a literal `</div>` no longer crash the renderer with `div cannot contain text looking like its end tag` (closes [#119](https://github.com/srid/emanote/issues/119)). Fixed upstream in [srid/heist-extra#13](https://github.com/srid/heist-extra/pull/13) by switching the raw-HTML wrapper to a unique `<rawhtml>` element with `display: contents`.
 

--- a/emanote/src/Emanote/Model/Link/Rel.hs
+++ b/emanote/src/Emanote/Model/Link/Rel.hs
@@ -44,7 +44,11 @@ data Rel = Rel
 -}
 data UnresolvedRelTarget
   = URTWikiLink (WL.WikiLinkType, WL.WikiLink)
-  | URTResource ModelRoute
+  | -- | One or more candidate `ModelRoute`s the URL could resolve to,
+    -- ordered by preference. A single URL can map to multiple kinds
+    -- (e.g. a @.xml@ URL → feed-enabled note OR static @.xml@ asset);
+    -- resolution picks the first candidate that exists in the model.
+    URTResource (NonEmpty ModelRoute)
   | URTVirtual SR.VirtualRoute
   deriving stock (Eq, Show, Ord, Generic)
   deriving anyclass (ToJSON)
@@ -75,13 +79,22 @@ noteRels note =
             (target, _manchor) <- parseUnresolvedRelTarget parentR attrs url
             pure $ Rel (note ^. noteRoute) target ctx
 
--- | Return all possible `UnresolvedRelTarget`s to the resource indexed by this `ModelRoute`.
+{- | All `UnresolvedRelTarget`s that could resolve to the given
+`ModelRoute`. The `URTResource` form is built from the canonical URL
+form of @r@ re-parsed via `mkModelRouteCandidates` so the candidate
+list matches what the parse path stored in the rel index — without
+that round-trip, a static-@.xml@ backlink lookup would search for
+@URTResource (one r)@ while parsed rels actually carry the joint
+@(feed-route :| [static])@ list and never match.
+-}
 unresolvedRelsTo :: ModelRoute -> [UnresolvedRelTarget]
 unresolvedRelsTo r =
   let allowedWikiLinks = WL.allowedWikiLinks . R.unRoute
       wls = either (R.withLmlRoute allowedWikiLinks . snd) allowedWikiLinks $ R.modelRouteCase r
-   in (URTWikiLink <$> toList wls)
-        <> [URTResource r]
+      resourceURTs =
+        maybeToList
+          $ viaNonEmpty URTResource (R.mkModelRouteCandidates (R.encodeModelRoute r))
+   in (URTWikiLink <$> toList wls) <> resourceURTs
 
 {- | Parse a relative URL string for later resolution.
 
@@ -95,11 +108,11 @@ parseUnresolvedRelTarget baseDir attrs url = do
       pure $ URTWikiLink wl
     Right fp ->
       fmap URTVirtual (SR.decodeVirtualRoute fp)
-        <|> fmap
+        <|> viaNonEmpty
           URTResource
           ( fp
               & relocateRelUrlUnder (R.encodeRoute <$> baseDir)
-              & R.mkModelRouteFromFilePath
+              & R.mkModelRouteCandidates
           )
   pure (res, manchor)
 

--- a/emanote/src/Emanote/Model/Link/Resolve.hs
+++ b/emanote/src/Emanote/Model/Link/Resolve.hs
@@ -67,11 +67,34 @@ resolveAmbiguity (R.withLmlRoute coerce -> currentRoute) candidates = do
 resolveModelRoute ::
   Model -> R.ModelRoute -> Rel.ResolvedRelTarget (Either (R.LMLView, MN.Note) SF.StaticFile)
 resolveModelRoute model lr =
-  bitraverse
-    (`M.modelLookupNoteByRoute` model)
-    (`M.modelLookupStaticFileByRoute` model)
-    (R.modelRouteCase lr)
-    & maybe Rel.RRTMissing Rel.RRTFound
+  case R.modelRouteCase lr of
+    -- A `.xml` URL parses to an `LMLView_Atom` route by default (so
+    -- `[atom](feed.xml)` can target a feed-enabled note). When no
+    -- such note exists, fall back to looking up a static `.xml`
+    -- asset of the same path before declaring the link broken
+    -- (regression: #547).
+    Left (R.LMLView_Atom, lmlR) ->
+      case M.modelLookupNoteByRoute (R.LMLView_Atom, lmlR) model of
+        Just hit -> Rel.RRTFound (Left hit)
+        Nothing ->
+          maybe Rel.RRTMissing (Rel.RRTFound . Right)
+            $ flip M.modelLookupStaticFileByRoute model
+            =<< xmlStaticRouteFromLml lmlR
+    other ->
+      bitraverse
+        (`M.modelLookupNoteByRoute` model)
+        (`M.modelLookupStaticFileByRoute` model)
+        other
+        & maybe Rel.RRTMissing Rel.RRTFound
+
+{- | Reinterpret an `LMLRoute` (parsed from a `.xml` URL into the
+Atom-feed slot) as an opaque `.xml` static-file route.
+-}
+xmlStaticRouteFromLml :: R.LMLRoute -> Maybe (R.R 'R.AnyExt)
+xmlStaticRouteFromLml lmlRoute =
+  R.mkRouteFromFilePath @_ @'R.AnyExt
+    $ R.encodeRoute @_ @'R.Xml
+    $ R.withLmlRoute coerce lmlRoute
 
 resourceSiteRoute :: Either (R.LMLView, MN.Note) SF.StaticFile -> SR.SiteRoute
 resourceSiteRoute =

--- a/emanote/src/Emanote/Model/Link/Resolve.hs
+++ b/emanote/src/Emanote/Model/Link/Resolve.hs
@@ -26,8 +26,8 @@ resolveUnresolvedRelTarget model currentRoute = \case
   Rel.URTWikiLink (_wlType, wl) -> do
     resolveWikiLinkMustExist model currentRoute wl
       <&> resourceSiteRoute
-  Rel.URTResource r ->
-    resolveModelRoute model r
+  Rel.URTResource candidates ->
+    resolveModelRouteCandidates model candidates
       <&> resourceSiteRoute
   Rel.URTVirtual virtualRoute -> do
     Rel.RRTFound
@@ -67,37 +67,26 @@ resolveAmbiguity (R.withLmlRoute coerce -> currentRoute) candidates = do
 resolveModelRoute ::
   Model -> R.ModelRoute -> Rel.ResolvedRelTarget (Either (R.LMLView, MN.Note) SF.StaticFile)
 resolveModelRoute model lr =
-  case R.modelRouteCase lr of
-    -- A `.xml` URL parses to an `LMLView_Atom` route by default (so
-    -- `[atom](feed.xml)` can target a feed-enabled note). When no
-    -- such note exists, fall back to looking up a static `.xml`
-    -- asset of the same path before declaring the link broken
-    -- (regression: #547).
-    Left (R.LMLView_Atom, lmlR) ->
-      case M.modelLookupNoteByRoute (R.LMLView_Atom, lmlR) model of
-        Just hit -> Rel.RRTFound (Left hit)
-        Nothing ->
-          maybe Rel.RRTMissing (Rel.RRTFound . Right)
-            $ flip M.modelLookupStaticFileByRoute model
-            =<< xmlStaticRouteFromLml lmlR
-    other ->
-      bitraverse
-        (`M.modelLookupNoteByRoute` model)
-        (`M.modelLookupStaticFileByRoute` model)
-        other
-        & maybe Rel.RRTMissing Rel.RRTFound
+  bitraverse
+    (`M.modelLookupNoteByRoute` model)
+    (`M.modelLookupStaticFileByRoute` model)
+    (R.modelRouteCase lr)
+    & maybe Rel.RRTMissing Rel.RRTFound
 
-{- | Reinterpret an `LMLRoute` (parsed from a `.xml` URL into the
-Atom-feed slot) as an opaque `.xml` static-file route. The `Maybe`
-is only there because `mkRouteFromFilePath` is partial in general; on
-the encoded path it is total (a non-empty `NonEmpty Slug` always
-encodes to a non-empty filepath that re-parses).
+{- | Try each candidate `ModelRoute` in order; the first one that
+exists in the model wins. The candidate list is built by
+`mkModelRouteCandidates` and captures the URL-to-resource-kind
+ambiguity (notably @.xml@ → feed route OR static asset; see #547).
 -}
-xmlStaticRouteFromLml :: R.LMLRoute -> Maybe (R.R 'R.AnyExt)
-xmlStaticRouteFromLml lmlRoute =
-  R.mkRouteFromFilePath @_ @'R.AnyExt
-    $ R.encodeRoute @_ @'R.Xml
-    $ R.withLmlRoute coerce lmlRoute
+resolveModelRouteCandidates ::
+  Model ->
+  NonEmpty R.ModelRoute ->
+  Rel.ResolvedRelTarget (Either (R.LMLView, MN.Note) SF.StaticFile)
+resolveModelRouteCandidates model =
+  firstFound . fmap (resolveModelRoute model)
+  where
+    firstFound (Rel.RRTMissing :| (x : xs)) = firstFound (x :| xs)
+    firstFound (other :| _) = other
 
 resourceSiteRoute :: Either (R.LMLView, MN.Note) SF.StaticFile -> SR.SiteRoute
 resourceSiteRoute =

--- a/emanote/src/Emanote/Model/Link/Resolve.hs
+++ b/emanote/src/Emanote/Model/Link/Resolve.hs
@@ -88,7 +88,10 @@ resolveModelRoute model lr =
         & maybe Rel.RRTMissing Rel.RRTFound
 
 {- | Reinterpret an `LMLRoute` (parsed from a `.xml` URL into the
-Atom-feed slot) as an opaque `.xml` static-file route.
+Atom-feed slot) as an opaque `.xml` static-file route. The `Maybe`
+is only there because `mkRouteFromFilePath` is partial in general; on
+the encoded path it is total (a non-empty `NonEmpty Slug` always
+encodes to a non-empty filepath that re-parses).
 -}
 xmlStaticRouteFromLml :: R.LMLRoute -> Maybe (R.R 'R.AnyExt)
 xmlStaticRouteFromLml lmlRoute =

--- a/emanote/src/Emanote/Model/Note.hs
+++ b/emanote/src/Emanote/Model/Note.hs
@@ -274,13 +274,36 @@ missingNote route404 urlPath =
     $ B.Para
       [ B.Str "No note has the URL "
       , B.Code B.nullAttr $ "/" <> urlPath
-      , -- TODO: org
-        B.Span (cls "font-mono text-sm")
-          $ one
-          $ B.Str
-          $ ". You may create a file with that name, ie. one of: "
-          <> oneOfLmlFilenames route404
+      , B.Str ". "
+      , B.Span (cls "font-mono text-sm") $ one $ B.Str $ missingUrlHint urlPath route404
       ]
+
+{- | Hint text to show on the missing-link page. The naive form
+("create one of: foo.xml.md, foo.xml.org") is misleading whenever the
+requested URL has a non-LML extension — `foo.xml` is far more likely
+a static asset (or feed-enabled `foo.md`) than a note literally named
+`foo.xml.md`. See #547.
+-}
+missingUrlHint :: Text -> R.R ext -> Text
+missingUrlHint urlPath route404
+  | Just stem <- T.stripSuffix ".xml" urlPath =
+      "You may create a static file `"
+        <> urlPath
+        <> "`, or a feed-enabled note `"
+        <> stem
+        <> ".md`."
+  | hasNonLmlExt urlPath =
+      "You may create a static file with that name."
+  | otherwise =
+      "You may create a file with that name, ie. one of: "
+        <> oneOfLmlFilenames route404
+
+{- | True when @url@ has an extension that is neither LML (md/org)
+nor the canonical HTML/XML cases handled elsewhere in the hint.
+-}
+hasNonLmlExt :: Text -> Bool
+hasNonLmlExt url = case T.breakOnEnd "." url of
+  (prefix, ext) -> not (T.null prefix) && ext `notElem` ["md", "org", "html", "xml"]
 
 oneOfLmlFilenames :: R ext -> Text
 oneOfLmlFilenames r =

--- a/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -50,9 +50,9 @@ embedBlockRegularLinkResolvingSplice model _nf ctx noteRoute node = do
   (inlRef, (_, _, otherAttrs), is, (url, tit)) <- Link.parseInlineRef inl
   guard $ inlRef == Link.InlineImage
   let parentR = M.modelResolveLinkBase model noteRoute
-  (Rel.URTResource mr, _mAnchor) <-
+  (Rel.URTResource candidates, _mAnchor) <-
     Rel.parseUnresolvedRelTarget parentR (otherAttrs <> one ("title", tit)) url
-  let rRel = Resolve.resolveModelRoute model mr
+  let rRel = Resolve.resolveModelRouteCandidates model candidates
   RendererUrl.renderSomeInlineRefWith Resolve.resourceSiteRoute (is, (url, tit)) rRel model ctx inl
     $ either (const Nothing) (embedStaticFileRoute model $ WL.plainify is)
 

--- a/emanote/src/Emanote/Route/ModelRoute.hs
+++ b/emanote/src/Emanote/Route/ModelRoute.hs
@@ -8,7 +8,8 @@ module Emanote.Route.ModelRoute (
   -- Some route in a generated site
   ModelRoute (..),
   modelRouteCase,
-  mkModelRouteFromFilePath,
+  mkModelRouteCandidates,
+  encodeModelRoute,
   -- Only LML routes
   LMLView (..),
   LMLRoute (..),
@@ -81,10 +82,27 @@ modelRouteCase = \case
   ModelRoute_LML view r -> Left (view, r)
   ModelRoute_StaticFile r -> Right r
 
-mkModelRouteFromFilePath :: FilePath -> Maybe ModelRoute
-mkModelRouteFromFilePath fp =
-  fmap (uncurry ModelRoute_LML) (mkLMLRouteFromFilePath fp)
-    <|> fmap ModelRoute_StaticFile (R.mkRouteFromFilePath fp)
+{- | All `ModelRoute`s a URL filepath could plausibly resolve to,
+ordered by preference.
+
+The same URL can map to multiple resource kinds — most importantly,
+@*.xml@ is both the natural URL for a feed-enabled note's Atom output
+and the natural URL for a static @.xml@ asset. Resolution at lookup
+time picks the first candidate that exists in the model; if the user
+intended one but the model only contains the other, the link still
+resolves correctly.
+-}
+mkModelRouteCandidates :: FilePath -> [ModelRoute]
+mkModelRouteCandidates fp =
+  maybeToList (uncurry ModelRoute_LML <$> mkLMLRouteFromFilePath fp)
+    <> maybeToList (ModelRoute_StaticFile <$> R.mkRouteFromFilePath fp)
+
+-- | Encode a `ModelRoute` to its on-the-wire URL filepath.
+encodeModelRoute :: ModelRoute -> FilePath
+encodeModelRoute = \case
+  ModelRoute_StaticFile r -> R.encodeRoute r
+  ModelRoute_LML LMLView_Html lmlR -> withLmlRoute R.encodeRoute lmlR
+  ModelRoute_LML LMLView_Atom lmlR -> R.encodeRoute @_ @'Xml (withLmlRoute coerce lmlR)
 
 mkLMLRouteFromFilePath :: FilePath -> Maybe (LMLView, LMLRoute)
 mkLMLRouteFromFilePath fp =

--- a/emanote/test/Emanote/Model/Link/RelSpec.hs
+++ b/emanote/test/Emanote/Model/Link/RelSpec.hs
@@ -2,7 +2,7 @@ module Emanote.Model.Link.RelSpec where
 
 import Emanote.Model.Link.Rel
 import Emanote.Model.Note qualified as MN
-import Emanote.Route.ModelRoute (mkModelRouteFromFilePath)
+import Emanote.Route.ModelRoute (mkModelRouteCandidates)
 import Emanote.Route.R (R (..))
 import Hedgehog
 import Relude
@@ -46,7 +46,7 @@ spec = do
     it "relative link from subfolder/index.md resolves under subfolder/" . hedgehog $ do
       let base = MN.resolveLinkBaseFromFilePath "subfolder/index.md"
           got = fst <$> parseUnresolvedRelTarget base [] "foo.md"
-          want = URTResource <$> mkModelRouteFromFilePath "subfolder/foo.md"
+          want = viaNonEmpty URTResource (mkModelRouteCandidates "subfolder/foo.md")
       got === want
 
 -- https://github.com/hedgehogqa/haskell-hedgehog/issues/121

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -51,6 +51,10 @@ Feature: Smoke
     When I open "/subfolder.html"
     Then the article link with text "sibling" has href containing "subfolder/sibling"
 
+  Scenario: Markdown link to a static .xml asset resolves to the file (regression: #547)
+    When I open "/xmllink.html"
+    Then the article link with text "xml asset" has href containing "test.xml"
+
   Scenario: The footnote list is hidden on screen but rendered in print mode
     When I open "/footnotes.html"
     Then no footnote list is visible on screen

--- a/tests/fixtures/notebook/test.xml
+++ b/tests/fixtures/notebook/test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>hello</root>

--- a/tests/fixtures/notebook/xmllink.md
+++ b/tests/fixtures/notebook/xmllink.md
@@ -1,0 +1,5 @@
+# XML link
+
+A regular markdown link to a static `.xml` asset:
+
+- [xml asset](./test.xml)


### PR DESCRIPTION
**A regular markdown link to a static `.xml` asset — `[Test](./test.xml)` — now resolves to the file** instead of rendering as broken. Previously every `.xml` URL was claimed exclusively by the Atom-feed slot in `mkModelRouteFromFilePath`, so when no matching feed-enabled note existed the resolver gave up at the note-lookup miss and never tried the static-file interpretation.

The fix lives in the **parser layer**, not patched into the resolver. `mkModelRouteCandidates` now returns the full list of plausible interpretations for a URL, and `URTResource` carries a `NonEmpty ModelRoute` of those candidates. Resolution is a pure first-hit-wins fold over the list — _the resolver no longer carries any extension-specific knowledge_. Backlink lookups round-trip through the same candidate builder so the URT shape matches what parse stored in the rel index.

Existing behaviour is preserved: feed links (`[atom](feed.xml)` against a feed-enabled note) hit the first candidate and resolve to the feed exactly as before; wikilinks (`[[test.xml]]`) take a different code path entirely and were never affected.

The **missing-link page** also got a fix from the same root cause: navigating to a missing `/foo.xml` used to suggest `foo.xml.md` / `foo.xml.org`, which is nonsensical. The hint now classifies the URL extension — `.xml` suggests creating the static file _or_ a feed-enabled `foo.md`; other non-LML extensions (`.css`, `.js`, …) suggest the static file alone; LML/HTML/no-extension URLs keep the existing `foo.md` / `foo.org` suggestion.

A Cucumber smoke scenario (`xmllink.md` → `test.xml`) guards the regression in both live and static modes; existing unit tests (`RelSpec.parseUnresolvedRelTarget`) still pass without modification beyond the new candidate-list shape.

Closes #547.

### Try it locally

```sh
nix build github:srid/emanote/fix-547-xml-link
```