### PR TITLE
Slim TOC scrollbar and tighten entry padding

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Resolve relative URLs inside `<dir>/index.md` against `<dir>/` instead of its parent ([#651](https://github.com/srid/emanote/pull/651), closes [#608](https://github.com/srid/emanote/issues/608))
 - Raw HTML blocks containing a literal `</div>` no longer crash the renderer with `div cannot contain text looking like its end tag` (closes [#119](https://github.com/srid/emanote/issues/119)). Fixed upstream in [srid/heist-extra#13](https://github.com/srid/heist-extra/pull/13) by switching the raw-HTML wrapper to a unique `<rawhtml>` element with `display: contents`.
 - A malformed `*.yaml` file (e.g. a non-string mapping key like `[]: foo`) no longer takes the live server down with `BadInput "NonStringKey []"`. The parse error is folded into `SData` itself and surfaced as a banner on the notes whose meta cascade actually depends on the bad file — a broken `subfolder/index.yaml` shows up under `/subfolder/*`, not on every page (closes [#285](https://github.com/srid/emanote/issues/285)).
+- TOC sidebar: tightened entry padding and styled the overflow scrollbar (Firefox `scrollbar-width: thin` + WebKit pseudo-element) so long tables of contents no longer surface the chunky OS-default bar (closes [#668](https://github.com/srid/emanote/issues/668)).
 
 ## 1.4.0.0 (2025-08-18)
 

--- a/emanote/default/templates/components/toc.tpl
+++ b/emanote/default/templates/components/toc.tpl
@@ -1,5 +1,8 @@
+<!-- Slim the overflow scrollbar (#668) so long TOCs don't show the chunky
+     OS-default bar. Firefox honours `scrollbar-*`; WebKit needs the
+     pseudo-element. -->
 <nav id="toc"
-  class="hidden leading-relaxed md:block md:sticky md:top-0 md:max-h-screen md:overflow-y-auto">
+  class="hidden leading-relaxed md:block md:sticky md:top-0 md:max-h-screen md:overflow-y-auto [scrollbar-width:thin] [scrollbar-color:var(--color-gray-300)_transparent] dark:[scrollbar-color:var(--color-gray-700)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-gray-700">
   <div class="text-gray-700 dark:text-gray-300 text-sm pt-2">
     <h3 class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-3 px-2">On this page</h3>
     <ema:note:toc>
@@ -8,7 +11,7 @@
           <toc:entry>
             <li class="truncate" title="${toc:title}">
               <a href="${ema:note:url}#${toc:anchor}"
-                class="--ema-toc block rounded-md px-2 py-1.5 hover:bg-primary-50 dark:hover:bg-primary-950 hover:text-primary-700 dark:hover:text-primary-300 transition-colors">
+                class="--ema-toc block rounded-md px-2 py-1 hover:bg-primary-50 dark:hover:bg-primary-950 hover:text-primary-700 dark:hover:text-primary-300 transition-colors">
                 <toc:title />
               </a>
               <toc:childs />


### PR DESCRIPTION
**Long tables of contents no longer surface the OS-default chunky scrollbar** glued to the right edge of the page. The right-rail TOC keeps the same sticky/overflow behaviour — once content crosses the viewport it's still scrollable — but the rail itself is now a thin, theme-coloured 1.5px track with a rounded gray thumb. Closes [#668](https://github.com/srid/emanote/issues/668).

Two complementary moves: scrollbar styling is expressed inline as Tailwind arbitrary-property utilities on the `#toc` element (`[scrollbar-width:thin]`, `[&::-webkit-scrollbar]:w-1.5`, etc.) so Firefox's `scrollbar-*` properties and WebKit's `::-webkit-scrollbar-*` pseudo-elements both apply without touching `styles.tpl`. Entry vertical padding drops from `py-1.5` to `py-1`, which is enough that most pages stop overflowing in the first place — the slim bar is what handles the genuinely long ones. *Theme-aware colours flow through `var(--color-gray-300)` / `var(--color-gray-700)` so dark mode matches without a second rule.*

### Try it locally

```sh
nix run github:srid/emanote/fix-toc-scrollbar-668 -- -L $PWD/docs run --port 9012
```

---

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._