### PR TITLE
e2e: add `morph` mode that route-switches via `window.ema.switchRoute`

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -8,7 +8,7 @@ just fmt
 
 ## Test command
 - `just test` — Haskell unit tests
-- `just e2e-live` / `just e2e-static` — cucumber+Playwright e2e (live and static modes)
+- `just e2e-live` / `just e2e-static` / `just e2e-morph` — cucumber+Playwright e2e (live, static, and morph modes)
 
 ## CI command
 vira ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-      # The two modes are intentionally serialized and share identical
+      # The three modes are intentionally serialized and share identical
       # setup (Nix install, artifact import, node, playwright). If they
       # ever need to diverge — different timeout, different env, a
       # service container — restore the matrix or split into separate
@@ -100,6 +100,11 @@ jobs:
         working-directory: tests
         env:
           EMANOTE_MODE: static
+        run: npm test
+      - name: E2E (morph)
+        working-directory: tests
+        env:
+          EMANOTE_MODE: morph
         run: npm test
 
   website:

--- a/justfile
+++ b/justfile
@@ -38,7 +38,12 @@ e2e-live: (_e2e "live")
 # Run e2e suite in static mode (`emanote gen` + serve)
 e2e-static: (_e2e "static")
 
-# Shared body for e2e-live / e2e-static; toggles EMANOTE_MODE.
+# Run e2e suite in morph mode (`emanote run`, every `I open` is an
+# Ema-internal route switch — exercises the morph code path that
+# `live` and `static` skip via fresh page loads).
+e2e-morph: (_e2e "morph")
+
+# Shared body for e2e-live / e2e-static / e2e-morph; toggles EMANOTE_MODE.
 [private]
 _e2e mode:
     #!/usr/bin/env bash

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -1,6 +1,6 @@
 import { Given, When, Then } from "@cucumber/cucumber";
 import { EmanoteWorld } from "../support/world.ts";
-import { morphNav, openRoute } from "../support/hooks.ts";
+import { morphNav, openRoute } from "../support/navigation.ts";
 import * as assert from "node:assert";
 
 When("I open {string}", async function (this: EmanoteWorld, url: string) {

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -1,9 +1,10 @@
 import { Given, When, Then } from "@cucumber/cucumber";
 import { EmanoteWorld } from "../support/world.ts";
+import { morphNav, openRoute } from "../support/hooks.ts";
 import * as assert from "node:assert";
 
 When("I open {string}", async function (this: EmanoteWorld, url: string) {
-  await this.page.goto(url, { waitUntil: "domcontentloaded" });
+  await openRoute(this.page, url);
 });
 
 When("I fetch {string}", async function (this: EmanoteWorld, url: string) {
@@ -458,29 +459,15 @@ Then(
   },
 );
 
-// Morph navigation: drive Ema's in-app route switch via the JS API
-// instead of clicking a link. Awaits `window.ema.ready` (PR srid/ema#181)
-// to avoid racing the WS handshake, then waits for `EMAHotReload` —
-// fired by the shim after morph + script reload completes — so the
-// next step sees the new DOM, not the in-flight one.
+// Explicit morph navigation step — for `@morph` scenarios that want to
+// assert an Ema in-app route switch independent of mode. In `morph`
+// mode `When I open` already morphs, but scenarios that need to mix a
+// fresh-load `goto` with a subsequent morph (or that want their intent
+// to be obvious in the .feature file) use this step.
 When(
   "I navigate via Ema to {string}",
   async function (this: EmanoteWorld, path: string) {
-    await this.page.evaluate(async (p) => {
-      // Wait for the shim to define window.ema (its `init()` runs
-      // synchronously on the module load, so this is usually a no-op
-      // — but the polling loop is cheap insurance against a race).
-      while (!(window as any).ema?.switchRoute) {
-        await new Promise((r) => setTimeout(r, 25));
-      }
-      await (window as any).ema.ready;
-      await new Promise<void>((resolve) => {
-        window.addEventListener("EMAHotReload", () => resolve(), {
-          once: true,
-        });
-        (window as any).ema.switchRoute(p);
-      });
-    }, path);
+    await morphNav(this.page, path);
   },
 );
 

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -459,11 +459,6 @@ Then(
   },
 );
 
-// Explicit morph navigation step — for `@morph` scenarios that want to
-// assert an Ema in-app route switch independent of mode. In `morph`
-// mode `When I open` already morphs, but scenarios that need to mix a
-// fresh-load `goto` with a subsequent morph (or that want their intent
-// to be obvious in the .feature file) use this step.
 When(
   "I navigate via Ema to {string}",
   async function (this: EmanoteWorld, path: string) {

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -1,18 +1,10 @@
 /**
  * Cucumber hooks — browser lifecycle + emanote backend launcher.
  *
- * `EMANOTE_MODE` is the only axis that distinguishes runs:
- *   - `live`   → spawn `emanote -L <fixture> run --port N`
- *   - `static` → `emanote -L <fixture> gen <tmp>` once, then serve `<tmp>`
- *                on a random port via `serve-handler`
- *   - `morph`  → same backend as `live`, but `When I open` performs an
- *                Ema-internal route switch (`window.ema.switchRoute`)
- *                instead of a fresh page load — exercises every behavior
- *                via the morph code path that fresh-load tests miss.
- *
- * Step definitions only see `baseUrl` and the `openRoute` helper exported
- * here; they never learn which mode they ran in. Any mode-specific
- * branching in a step means the boundary has leaked. Keep it encapsulated.
+ * Mode dispatch and validation live in `./mode.ts`; navigation primitives
+ * (`openRoute`, `morphNav`, morph priming) live in `./navigation.ts`.
+ * This file owns only the test-lifecycle plumbing: backend start/stop,
+ * browser context, scenario filtering, screenshot-on-failure.
  */
 
 import {
@@ -23,7 +15,7 @@ import {
   Status,
 } from "@cucumber/cucumber";
 import { chromium } from "playwright";
-import type { Browser, Page } from "playwright";
+import type { Browser } from "playwright";
 import getPort from "get-port";
 // @ts-expect-error — serve-handler ships no TS types; its runtime shape
 // is a single function and we call it with an untyped options object.
@@ -35,8 +27,8 @@ import * as path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { EmanoteWorld } from "./world.ts";
-
-type Mode = "live" | "static" | "morph";
+import { mode } from "./mode.ts";
+import { primeMorph } from "./navigation.ts";
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -44,13 +36,6 @@ function requireEnv(name: string): string {
   return v;
 }
 
-const rawMode = requireEnv("EMANOTE_MODE");
-if (rawMode !== "live" && rawMode !== "static" && rawMode !== "morph") {
-  throw new Error(
-    `EMANOTE_MODE must be "live", "static", or "morph" (got ${JSON.stringify(rawMode)})`,
-  );
-}
-const mode: Mode = rawMode;
 const emanoteBin = requireEnv("EMANOTE_BIN");
 
 const fixtureDir = path.resolve(
@@ -239,59 +224,14 @@ Before(function (this: EmanoteWorld, scenario) {
 });
 
 // Morph mode: prime each scenario by landing on `/` via a fresh load
-// and waiting for the Ema WS shim to be ready. Subsequent `I open`
-// steps then route-switch via `window.ema.switchRoute` instead of
-// reloading — see `openRoute` below. Without this priming, the first
-// `I open` would have no `window.ema` to switch through.
+// and waiting for the Ema WS shim to be ready. Subsequent `openRoute`
+// calls then route-switch via `window.ema.switchRoute` instead of
+// reloading. Without this priming, the first `openRoute` would have no
+// `window.ema` to switch through.
 Before(async function (this: EmanoteWorld) {
   if (mode !== "morph") return;
-  await this.page.goto("/", { waitUntil: "domcontentloaded" });
-  await waitForEmaReady(this.page);
+  await primeMorph(this.page);
 });
-
-/** Wait for Ema's WS shim to be ready: poll until `window.ema.switchRoute`
- *  exists, then await `window.ema.ready` (PR srid/ema#181) so the next
- *  caller doesn't race the WS handshake. The shim's `init()` runs on
- *  module load and is usually a no-op poll, but the loop is cheap
- *  insurance against page-load timing. */
-async function waitForEmaReady(page: Page): Promise<void> {
-  await page.evaluate(async () => {
-    while (!(window as any).ema?.switchRoute) {
-      await new Promise((r) => setTimeout(r, 25));
-    }
-    await (window as any).ema.ready;
-  });
-}
-
-/** Drive an Ema-internal morph navigation: wait for the WS shim, then
- *  switch the route via `window.ema.switchRoute` and wait for
- *  `EMAHotReload` (fired by the shim after morph + script reload
- *  completes) so the next step sees the new DOM, not the in-flight one. */
-export async function morphNav(page: Page, url: string): Promise<void> {
-  await waitForEmaReady(page);
-  await page.evaluate(
-    (p) =>
-      new Promise<void>((resolve) => {
-        window.addEventListener("EMAHotReload", () => resolve(), {
-          once: true,
-        });
-        (window as any).ema.switchRoute(p);
-      }),
-    url,
-  );
-}
-
-/** Open a route — the verb step definitions call. In `live` and
- *  `static` modes this is a fresh `page.goto`; in `morph` mode it's an
- *  Ema-internal route switch. Step definitions stay mode-agnostic by
- *  going through this helper. */
-export async function openRoute(page: Page, url: string): Promise<void> {
-  if (mode === "morph") {
-    await morphNav(page, url);
-  } else {
-    await page.goto(url, { waitUntil: "domcontentloaded" });
-  }
-}
 
 After(async function (this: EmanoteWorld, scenario) {
   if (scenario.result?.status === Status.FAILED) {

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -27,14 +27,8 @@ import * as path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { EmanoteWorld } from "./world.ts";
-import { mode } from "./mode.ts";
+import { mode, requireEnv } from "./mode.ts";
 import { primeMorph } from "./navigation.ts";
-
-function requireEnv(name: string): string {
-  const v = process.env[name];
-  if (!v) throw new Error(`${name} must be set`);
-  return v;
-}
 
 const emanoteBin = requireEnv("EMANOTE_BIN");
 

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -223,13 +223,10 @@ Before({ tags: MORPH_TAG }, function () {
 // Catch the inverse mistake: a scenario that uses the morph-nav step
 // without the tag would silently run in static mode and time out at
 // the step's 60s polling-loop ceiling. Fail fast at scenario start.
-//
-// In morph mode the check is meaningless — every `I open` is itself a
-// morph nav, so requiring `@morph` on every scenario would defeat the
-// purpose of the mode (which is to surface the morph code path
-// universally, not selectively). Suppress the check there.
+// The check applies in every mode — the rule "tag morph-nav scenarios
+// so they skip in static" is a static-mode invariant and morph mode
+// inherits the same authoring contract.
 Before(function (this: EmanoteWorld, scenario) {
-  if (mode === "morph") return;
   const usesMorph = scenario.pickle.steps.some((s) =>
     s.text.includes("navigate via Ema"),
   );

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -1,10 +1,6 @@
 /**
- * Cucumber hooks — browser lifecycle + emanote backend launcher.
- *
- * Mode dispatch and validation live in `./mode.ts`; navigation primitives
- * (`openRoute`, `morphNav`, morph priming) live in `./navigation.ts`.
- * This file owns only the test-lifecycle plumbing: backend start/stop,
- * browser context, scenario filtering, screenshot-on-failure.
+ * Cucumber lifecycle plumbing: backend start/stop, browser context,
+ * scenario filtering, screenshot-on-failure.
  */
 
 import {
@@ -185,26 +181,16 @@ Before(async function (this: EmanoteWorld) {
   this.page = await this.context.newPage();
 });
 
-// Cucumber tag for scenarios that exercise Ema's morph-based in-app
-// navigation. Pinned to a constant so the two hooks below and any
-// new ones agree on spelling.
 const MORPH_TAG = "@morph";
 
-// Morph navigation requires the live WebSocket. Static mode serves a
-// pre-built tree with no WS; window.ema is undefined there, so any
-// MORPH_TAG-tagged scenario would fail at the first switchRoute call.
-// Skip them up-front in static mode; live and morph modes both have
-// the WS and run them.
+// Static mode has no WebSocket and `window.ema` is undefined, so any
+// `@morph` scenario would fail at the first `switchRoute` call.
 Before({ tags: MORPH_TAG }, function () {
   if (mode === "static") return "skipped" as const;
 });
 
-// Catch the inverse mistake: a scenario that uses the morph-nav step
-// without the tag would silently run in static mode and time out at
-// the step's 60s polling-loop ceiling. Fail fast at scenario start.
-// The check applies in every mode — the rule "tag morph-nav scenarios
-// so they skip in static" is a static-mode invariant and morph mode
-// inherits the same authoring contract.
+// Inverse safety: a scenario using the morph-nav step without `@morph`
+// would silently hang in static mode until the cucumber step ceiling.
 Before(function (this: EmanoteWorld, scenario) {
   const usesMorph = scenario.pickle.steps.some((s) =>
     s.text.includes("navigate via Ema"),
@@ -217,11 +203,8 @@ Before(function (this: EmanoteWorld, scenario) {
   }
 });
 
-// Morph mode: prime each scenario by landing on `/` via a fresh load
-// and waiting for the Ema WS shim to be ready. Subsequent `openRoute`
-// calls then route-switch via `window.ema.switchRoute` instead of
-// reloading. Without this priming, the first `openRoute` would have no
-// `window.ema` to switch through.
+// In morph mode the first `openRoute` morph-switches via
+// `window.ema`, which only exists after a real page load — prime it.
 Before(async function (this: EmanoteWorld) {
   if (mode !== "morph") return;
   await primeMorph(this.page);

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -249,32 +249,39 @@ Before(function (this: EmanoteWorld, scenario) {
 Before(async function (this: EmanoteWorld) {
   if (mode !== "morph") return;
   await this.page.goto("/", { waitUntil: "domcontentloaded" });
-  await this.page.evaluate(async () => {
+  await waitForEmaReady(this.page);
+});
+
+/** Wait for Ema's WS shim to be ready: poll until `window.ema.switchRoute`
+ *  exists, then await `window.ema.ready` (PR srid/ema#181) so the next
+ *  caller doesn't race the WS handshake. The shim's `init()` runs on
+ *  module load and is usually a no-op poll, but the loop is cheap
+ *  insurance against page-load timing. */
+async function waitForEmaReady(page: Page): Promise<void> {
+  await page.evaluate(async () => {
     while (!(window as any).ema?.switchRoute) {
       await new Promise((r) => setTimeout(r, 25));
     }
     await (window as any).ema.ready;
   });
-});
+}
 
-/** Drive an Ema-internal morph navigation: switch the route via
- *  `window.ema.switchRoute` and wait for `EMAHotReload` (fired by the
- *  shim after morph + script reload completes) so the next step sees
- *  the new DOM, not the in-flight one. Awaits `window.ema.ready` (PR
- *  srid/ema#181) to avoid racing the WS handshake. */
+/** Drive an Ema-internal morph navigation: wait for the WS shim, then
+ *  switch the route via `window.ema.switchRoute` and wait for
+ *  `EMAHotReload` (fired by the shim after morph + script reload
+ *  completes) so the next step sees the new DOM, not the in-flight one. */
 export async function morphNav(page: Page, url: string): Promise<void> {
-  await page.evaluate(async (p) => {
-    while (!(window as any).ema?.switchRoute) {
-      await new Promise((r) => setTimeout(r, 25));
-    }
-    await (window as any).ema.ready;
-    await new Promise<void>((resolve) => {
-      window.addEventListener("EMAHotReload", () => resolve(), {
-        once: true,
-      });
-      (window as any).ema.switchRoute(p);
-    });
-  }, url);
+  await waitForEmaReady(page);
+  await page.evaluate(
+    (p) =>
+      new Promise<void>((resolve) => {
+        window.addEventListener("EMAHotReload", () => resolve(), {
+          once: true,
+        });
+        (window as any).ema.switchRoute(p);
+      }),
+    url,
+  );
 }
 
 /** Open a route — the verb step definitions call. In `live` and

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -5,10 +5,14 @@
  *   - `live`   → spawn `emanote -L <fixture> run --port N`
  *   - `static` → `emanote -L <fixture> gen <tmp>` once, then serve `<tmp>`
  *                on a random port via `serve-handler`
+ *   - `morph`  → same backend as `live`, but `When I open` performs an
+ *                Ema-internal route switch (`window.ema.switchRoute`)
+ *                instead of a fresh page load — exercises every behavior
+ *                via the morph code path that fresh-load tests miss.
  *
- * Step definitions only see `baseUrl` and never learn which mode they ran
- * in — any mode-specific branching in a step means the boundary has
- * leaked. Keep it encapsulated here.
+ * Step definitions only see `baseUrl` and the `openRoute` helper exported
+ * here; they never learn which mode they ran in. Any mode-specific
+ * branching in a step means the boundary has leaked. Keep it encapsulated.
  */
 
 import {
@@ -19,7 +23,7 @@ import {
   Status,
 } from "@cucumber/cucumber";
 import { chromium } from "playwright";
-import type { Browser } from "playwright";
+import type { Browser, Page } from "playwright";
 import getPort from "get-port";
 // @ts-expect-error — serve-handler ships no TS types; its runtime shape
 // is a single function and we call it with an untyped options object.
@@ -32,7 +36,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { EmanoteWorld } from "./world.ts";
 
-type Mode = "live" | "static";
+type Mode = "live" | "static" | "morph";
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -41,9 +45,9 @@ function requireEnv(name: string): string {
 }
 
 const rawMode = requireEnv("EMANOTE_MODE");
-if (rawMode !== "live" && rawMode !== "static") {
+if (rawMode !== "live" && rawMode !== "static" && rawMode !== "morph") {
   throw new Error(
-    `EMANOTE_MODE must be "live" or "static" (got ${JSON.stringify(rawMode)})`,
+    `EMANOTE_MODE must be "live", "static", or "morph" (got ${JSON.stringify(rawMode)})`,
   );
 }
 const mode: Mode = rawMode;
@@ -169,7 +173,7 @@ async function startStatic(): Promise<{
  *  here — so give this hook a deliberate 180s ceiling instead of racing
  *  the ~60s default. */
 BeforeAll({ timeout: 180_000 }, async () => {
-  const started = mode === "live" ? await startLive() : await startStatic();
+  const started = mode === "static" ? await startStatic() : await startLive();
   baseUrl = started.url;
   backend = started.resource;
   browser = await chromium.launch({
@@ -210,25 +214,80 @@ const MORPH_TAG = "@morph";
 // Morph navigation requires the live WebSocket. Static mode serves a
 // pre-built tree with no WS; window.ema is undefined there, so any
 // MORPH_TAG-tagged scenario would fail at the first switchRoute call.
-// Skip them up-front instead of letting them red-fail.
+// Skip them up-front in static mode; live and morph modes both have
+// the WS and run them.
 Before({ tags: MORPH_TAG }, function () {
-  if (mode !== "live") return "skipped" as const;
+  if (mode === "static") return "skipped" as const;
 });
 
 // Catch the inverse mistake: a scenario that uses the morph-nav step
 // without the tag would silently run in static mode and time out at
 // the step's 60s polling-loop ceiling. Fail fast at scenario start.
+//
+// In morph mode the check is meaningless — every `I open` is itself a
+// morph nav, so requiring `@morph` on every scenario would defeat the
+// purpose of the mode (which is to surface the morph code path
+// universally, not selectively). Suppress the check there.
 Before(function (this: EmanoteWorld, scenario) {
+  if (mode === "morph") return;
   const usesMorph = scenario.pickle.steps.some((s) =>
     s.text.includes("navigate via Ema"),
   );
   const tagged = scenario.pickle.tags.some((t) => t.name === MORPH_TAG);
   if (usesMorph && !tagged) {
     throw new Error(
-      `Scenario ${JSON.stringify(scenario.pickle.name)} uses 'navigate via Ema' but is not tagged ${MORPH_TAG}. Add '${MORPH_TAG}' above the Scenario keyword so it runs only in live mode (static mode has no WebSocket and window.ema is undefined).`,
+      `Scenario ${JSON.stringify(scenario.pickle.name)} uses 'navigate via Ema' but is not tagged ${MORPH_TAG}. Add '${MORPH_TAG}' above the Scenario keyword so it is skipped in static mode (no WebSocket; window.ema is undefined there).`,
     );
   }
 });
+
+// Morph mode: prime each scenario by landing on `/` via a fresh load
+// and waiting for the Ema WS shim to be ready. Subsequent `I open`
+// steps then route-switch via `window.ema.switchRoute` instead of
+// reloading — see `openRoute` below. Without this priming, the first
+// `I open` would have no `window.ema` to switch through.
+Before(async function (this: EmanoteWorld) {
+  if (mode !== "morph") return;
+  await this.page.goto("/", { waitUntil: "domcontentloaded" });
+  await this.page.evaluate(async () => {
+    while (!(window as any).ema?.switchRoute) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    await (window as any).ema.ready;
+  });
+});
+
+/** Drive an Ema-internal morph navigation: switch the route via
+ *  `window.ema.switchRoute` and wait for `EMAHotReload` (fired by the
+ *  shim after morph + script reload completes) so the next step sees
+ *  the new DOM, not the in-flight one. Awaits `window.ema.ready` (PR
+ *  srid/ema#181) to avoid racing the WS handshake. */
+export async function morphNav(page: Page, url: string): Promise<void> {
+  await page.evaluate(async (p) => {
+    while (!(window as any).ema?.switchRoute) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    await (window as any).ema.ready;
+    await new Promise<void>((resolve) => {
+      window.addEventListener("EMAHotReload", () => resolve(), {
+        once: true,
+      });
+      (window as any).ema.switchRoute(p);
+    });
+  }, url);
+}
+
+/** Open a route — the verb step definitions call. In `live` and
+ *  `static` modes this is a fresh `page.goto`; in `morph` mode it's an
+ *  Ema-internal route switch. Step definitions stay mode-agnostic by
+ *  going through this helper. */
+export async function openRoute(page: Page, url: string): Promise<void> {
+  if (mode === "morph") {
+    await morphNav(page, url);
+  } else {
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+  }
+}
 
 After(async function (this: EmanoteWorld, scenario) {
   if (scenario.result?.status === Status.FAILED) {

--- a/tests/support/mode.ts
+++ b/tests/support/mode.ts
@@ -1,0 +1,28 @@
+/**
+ * `EMANOTE_MODE` — the single axis along which e2e runs differ.
+ *
+ *   - `live`   → spawn `emanote -L <fixture> run --port N`
+ *   - `static` → `emanote -L <fixture> gen <tmp>` once, then serve `<tmp>`
+ *   - `morph`  → live backend, but `When I open` route-switches via
+ *                `window.ema.switchRoute` instead of `page.goto`
+ *
+ * Read once at module load and validated; downstream modules import the
+ * narrowed `mode` constant.
+ */
+
+export type Mode = "live" | "static" | "morph";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`${name} must be set`);
+  return v;
+}
+
+const rawMode = requireEnv("EMANOTE_MODE");
+if (rawMode !== "live" && rawMode !== "static" && rawMode !== "morph") {
+  throw new Error(
+    `EMANOTE_MODE must be "live", "static", or "morph" (got ${JSON.stringify(rawMode)})`,
+  );
+}
+
+export const mode: Mode = rawMode;

--- a/tests/support/mode.ts
+++ b/tests/support/mode.ts
@@ -12,7 +12,7 @@
 
 export type Mode = "live" | "static" | "morph";
 
-function requireEnv(name: string): string {
+export function requireEnv(name: string): string {
   const v = process.env[name];
   if (!v) throw new Error(`${name} must be set`);
   return v;

--- a/tests/support/mode.ts
+++ b/tests/support/mode.ts
@@ -5,9 +5,6 @@
  *   - `static` → `emanote -L <fixture> gen <tmp>` once, then serve `<tmp>`
  *   - `morph`  → live backend, but `When I open` route-switches via
  *                `window.ema.switchRoute` instead of `page.goto`
- *
- * Read once at module load and validated; downstream modules import the
- * narrowed `mode` constant.
  */
 
 export type Mode = "live" | "static" | "morph";

--- a/tests/support/navigation.ts
+++ b/tests/support/navigation.ts
@@ -7,8 +7,8 @@
 import type { Page } from "playwright";
 import { mode } from "./mode.ts";
 
-// `ema.ready` (srid/ema#181) resolves after the WS handshake — awaiting
-// it avoids racing the first `switchRoute` against handshake completion.
+// Wait for Ema's WS shim — `ema.ready` (srid/ema#181) resolves after
+// the WS handshake. Awaiting it avoids racing the first `switchRoute`.
 async function waitForEmaReady(page: Page): Promise<void> {
   await page.waitForFunction(() => !!(window as any).ema?.switchRoute);
   await page.evaluate(() => (window as any).ema.ready);
@@ -19,20 +19,24 @@ export async function primeMorph(page: Page): Promise<void> {
   await waitForEmaReady(page);
 }
 
+// All ready+switchRoute+EMAHotReload work in a single browser-side
+// evaluate. Splitting the await-ready and the switchRoute into separate
+// CDP round-trips opens a window where the page can navigate (morph
+// involves a script reload) and Playwright's evaluate sees the
+// execution context destroyed before EMAHotReload fires.
 export async function morphNav(page: Page, url: string): Promise<void> {
-  await waitForEmaReady(page);
-  await page.evaluate(
-    (p) =>
-      new Promise<void>((resolve) => {
-        // EMAHotReload fires once the morph + script reload finishes.
-        // Without this gate the next step sees the in-flight DOM.
-        window.addEventListener("EMAHotReload", () => resolve(), {
-          once: true,
-        });
-        (window as any).ema.switchRoute(p);
-      }),
-    url,
-  );
+  await page.evaluate(async (p) => {
+    while (!(window as any).ema?.switchRoute) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    await (window as any).ema.ready;
+    await new Promise<void>((resolve) => {
+      window.addEventListener("EMAHotReload", () => resolve(), {
+        once: true,
+      });
+      (window as any).ema.switchRoute(p);
+    });
+  }, url);
 }
 
 export async function openRoute(page: Page, url: string): Promise<void> {

--- a/tests/support/navigation.ts
+++ b/tests/support/navigation.ts
@@ -1,0 +1,63 @@
+/**
+ * Mode-aware navigation primitives. Step definitions stay mode-agnostic
+ * by going through `openRoute`; in `morph` mode the page is route-
+ * switched via `window.ema.switchRoute`, in `live` and `static` modes
+ * it's a fresh `page.goto`. The priming step (`primeMorph`) is what a
+ * Before hook runs once per scenario in morph mode so the first
+ * `openRoute` has a `window.ema` to switch through.
+ */
+
+import type { Page } from "playwright";
+import { mode } from "./mode.ts";
+
+/** Wait for Ema's WS shim to be ready: poll until `window.ema.switchRoute`
+ *  exists, then await `window.ema.ready` (PR srid/ema#181) so the next
+ *  caller doesn't race the WS handshake. The shim's `init()` runs on
+ *  module load and is usually a no-op poll, but the loop is cheap
+ *  insurance against page-load timing. */
+async function waitForEmaReady(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    while (!(window as any).ema?.switchRoute) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    await (window as any).ema.ready;
+  });
+}
+
+/** Prime morph mode for a fresh scenario: land on `/` via a real page
+ *  load and wait for the WS shim. Subsequent `openRoute` calls then
+ *  morph-switch instead of reloading. */
+export async function primeMorph(page: Page): Promise<void> {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await waitForEmaReady(page);
+}
+
+/** Drive an Ema-internal morph navigation: wait for the WS shim, then
+ *  switch the route via `window.ema.switchRoute` and wait for
+ *  `EMAHotReload` (fired by the shim after morph + script reload
+ *  completes) so the next step sees the new DOM, not the in-flight one. */
+export async function morphNav(page: Page, url: string): Promise<void> {
+  await waitForEmaReady(page);
+  await page.evaluate(
+    (p) =>
+      new Promise<void>((resolve) => {
+        window.addEventListener("EMAHotReload", () => resolve(), {
+          once: true,
+        });
+        (window as any).ema.switchRoute(p);
+      }),
+    url,
+  );
+}
+
+/** Open a route — the verb step definitions call. In `live` and
+ *  `static` modes this is a fresh `page.goto`; in `morph` mode it's an
+ *  Ema-internal route switch. Step definitions stay mode-agnostic by
+ *  going through this helper. */
+export async function openRoute(page: Page, url: string): Promise<void> {
+  if (mode === "morph") {
+    await morphNav(page, url);
+  } else {
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+  }
+}

--- a/tests/support/navigation.ts
+++ b/tests/support/navigation.ts
@@ -1,42 +1,31 @@
 /**
- * Mode-aware navigation primitives. Step definitions stay mode-agnostic
- * by going through `openRoute`; in `morph` mode the page is route-
- * switched via `window.ema.switchRoute`, in `live` and `static` modes
- * it's a fresh `page.goto`. The priming step (`primeMorph`) is what a
- * Before hook runs once per scenario in morph mode so the first
- * `openRoute` has a `window.ema` to switch through.
+ * Mode-aware navigation primitives. Step definitions go through
+ * `openRoute`; the morph branch route-switches via the Ema WS shim
+ * instead of a fresh page load.
  */
 
 import type { Page } from "playwright";
 import { mode } from "./mode.ts";
 
-/** Wait for Ema's WS shim to be ready: until `window.ema.switchRoute`
- *  exists, then await `window.ema.ready` (PR srid/ema#181) so the next
- *  caller doesn't race the WS handshake. The shim's `init()` runs on
- *  module load and is usually a no-op wait, but the gate is cheap
- *  insurance against page-load timing. */
+// `ema.ready` (srid/ema#181) resolves after the WS handshake — awaiting
+// it avoids racing the first `switchRoute` against handshake completion.
 async function waitForEmaReady(page: Page): Promise<void> {
   await page.waitForFunction(() => !!(window as any).ema?.switchRoute);
   await page.evaluate(() => (window as any).ema.ready);
 }
 
-/** Prime morph mode for a fresh scenario: land on `/` via a real page
- *  load and wait for the WS shim. Subsequent `openRoute` calls then
- *  morph-switch instead of reloading. */
 export async function primeMorph(page: Page): Promise<void> {
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await waitForEmaReady(page);
 }
 
-/** Drive an Ema-internal morph navigation: wait for the WS shim, then
- *  switch the route via `window.ema.switchRoute` and wait for
- *  `EMAHotReload` (fired by the shim after morph + script reload
- *  completes) so the next step sees the new DOM, not the in-flight one. */
 export async function morphNav(page: Page, url: string): Promise<void> {
   await waitForEmaReady(page);
   await page.evaluate(
     (p) =>
       new Promise<void>((resolve) => {
+        // EMAHotReload fires once the morph + script reload finishes.
+        // Without this gate the next step sees the in-flight DOM.
         window.addEventListener("EMAHotReload", () => resolve(), {
           once: true,
         });
@@ -46,10 +35,6 @@ export async function morphNav(page: Page, url: string): Promise<void> {
   );
 }
 
-/** Open a route — the verb step definitions call. In `live` and
- *  `static` modes this is a fresh `page.goto`; in `morph` mode it's an
- *  Ema-internal route switch. Step definitions stay mode-agnostic by
- *  going through this helper. */
 export async function openRoute(page: Page, url: string): Promise<void> {
   if (mode === "morph") {
     await morphNav(page, url);

--- a/tests/support/navigation.ts
+++ b/tests/support/navigation.ts
@@ -10,18 +10,14 @@
 import type { Page } from "playwright";
 import { mode } from "./mode.ts";
 
-/** Wait for Ema's WS shim to be ready: poll until `window.ema.switchRoute`
+/** Wait for Ema's WS shim to be ready: until `window.ema.switchRoute`
  *  exists, then await `window.ema.ready` (PR srid/ema#181) so the next
  *  caller doesn't race the WS handshake. The shim's `init()` runs on
- *  module load and is usually a no-op poll, but the loop is cheap
+ *  module load and is usually a no-op wait, but the gate is cheap
  *  insurance against page-load timing. */
 async function waitForEmaReady(page: Page): Promise<void> {
-  await page.evaluate(async () => {
-    while (!(window as any).ema?.switchRoute) {
-      await new Promise((r) => setTimeout(r, 25));
-    }
-    await (window as any).ema.ready;
-  });
+  await page.waitForFunction(() => !!(window as any).ema?.switchRoute);
+  await page.evaluate(() => (window as any).ema.ready);
 }
 
 /** Prime morph mode for a fresh scenario: land on `/` via a real page


### PR DESCRIPTION
**Morph-survival of every behavior is now a structural property of the e2e suite, not an opt-in `@morph` tag.** Before this PR, exactly one path was tested via Ema's in-app morph nav (the toc-spy scenario from #663); every other scenario reached its target via `page.goto`, so the morph code path was uncovered for everything else. That gap is how both the toc-spy bug (#667) and the Stork theme-mirror-after-morph regression ([#672 review](https://github.com/srid/emanote/pull/672)) shipped — each was invisible to the existing fresh-load tests.

`EMANOTE_MODE=morph` reuses the live backend but rewrites every `When I open` step into an Ema-internal route switch. A `Before` hook primes each scenario with `page.goto("/")` + `await window.ema.ready`, then subsequent `I open` calls go through `window.ema.switchRoute(...)` and wait for `EMAHotReload`. *Every behavior assertion in the suite now implicitly runs against "the page that landed via morph", not via fresh load.* `just e2e-morph` and a third `E2E (morph)` CI step join the existing `live` and `static` runs.

The mode-axis volatility is encapsulated in two new tiny modules: `tests/support/mode.ts` for env validation and the `Mode` union, `tests/support/navigation.ts` for `openRoute` / `morphNav` / `primeMorph`. *Step definitions stay completely mode-agnostic — they call `openRoute(page, url)` and the dispatch happens behind the boundary.* `hooks.ts` is now just Cucumber lifecycle plumbing.

> **Note for reviewers**: a subtle bug surfaced once two morph navigations ran back-to-back in a single scenario (which never happened before — `live` only morphed once per `@morph` scenario). Splitting `await ema.ready` and the `addEventListener("EMAHotReload") + switchRoute(...)` into separate `page.evaluate` round-trips opens a Node-side gap where the script-reload that morph triggers can destroy the execution context before the listener is registered. The fix in `44ac526e` keeps the entire ready→listener→switchRoute sequence in one async evaluate so it runs back-to-back in browser context.

Closes #673.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._