### PR TITLE
Slim large notebooks with deferred notes

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -29,6 +29,10 @@
 - TOC sidebar: tightened entry padding and styled the overflow scrollbar (Firefox `scrollbar-width: thin` + WebKit pseudo-element) so long tables of contents no longer surface the chunky OS-default bar (closes [#668](https://github.com/srid/emanote/issues/668)).
 - Live server: assets bundled under `_emanote-static/` (skylighting CSS, self-hosted fonts, inverted-tree CSS, emanote-logo, Stork CSS+JS) now cache-bust with `?t=<mtime>` instead of being served bare. Edits to any of these files in `emanote run` invalidate the browser cache without a manual restart. Templates use a new `<emanoteStaticUrl path="…">${url}</emanoteStaticUrl>` splice; the older `${ema:emanoteStaticLayerUrl}` continues to work for third-party templates but skips the cache buster (closes [#666](https://github.com/srid/emanote/issues/666)).
 
+**Performance improvements**
+
+- Large Markdown notebooks use substantially less live-server memory by storing simple notes in a deferred form and compacting repeated startup wikilink relations while preserving backlink contexts on demand (closes [#66](https://github.com/srid/emanote/issues/66)).
+
 ## 1.4.0.0 (2025-08-18)
 
 **Notable features**

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -108,6 +108,7 @@ common library-common
     , commonmark-wikilink    >=0.2
     , containers
     , data-default
+    , deepseq
     , deriving-aeson
     , directory
     , ema                    >=0.10.1
@@ -254,6 +255,7 @@ test-suite test
     build-depends: emanote
     other-modules:
       Emanote.Model.Link.RelSpec
+      Emanote.Model.NoteSpec
       Emanote.Model.QuerySpec
       Emanote.Model.TocSpec
       Emanote.Pandoc.ExternalLinkSpec

--- a/emanote/src/Emanote/Model/Graph.hs
+++ b/emanote/src/Emanote/Model/Graph.hs
@@ -12,7 +12,7 @@ import Emanote.Model.Link.Resolve qualified as Resolve
 import Emanote.Model.Meta (lookupRouteMeta)
 import Emanote.Model.Note qualified as MN
 import Emanote.Model.Note qualified as N
-import Emanote.Model.Type (Model, modelIndexRoute, modelNotes, modelRels, parentLmlRoute)
+import Emanote.Model.Type (Model, modelIndexRoute, modelLookupNoteByRoute', modelNotes, modelRels, parentLmlRoute)
 import Emanote.Route qualified as R
 import Emanote.Route.SiteRoute qualified as SR
 import Optics.Operators as Lens ((^.))
@@ -204,9 +204,13 @@ modelLookupBacklinks r model =
   sortOn (Calendar.backlinkSortKey model . fst)
     $ groupNE
     $ backlinkRels r model
-    <&> \rel ->
-      (rel ^. Rel.relFrom, rel ^. Rel.relCtx)
+    >>= backlinkContexts
   where
+    backlinkContexts rel =
+      expandedBacklinkContexts r model rel
+        <&> \rel' ->
+          (rel' ^. Rel.relFrom, rel' ^. Rel.relCtx)
+
     groupNE :: forall a b. (Ord a) => [(a, b)] -> [(a, NonEmpty b)]
     groupNE =
       Map.toList . foldl' f Map.empty
@@ -217,20 +221,33 @@ modelLookupBacklinks r model =
             Nothing -> Map.insert x (one y) m
             Just ys -> Map.insert x (ys <> one y) m
 
+expandedBacklinkContexts :: R.LMLRoute -> Model -> Rel.Rel -> [Rel.Rel]
+expandedBacklinkContexts targetR model rel =
+  case modelLookupNoteByRoute' (rel ^. Rel.relFrom) model of
+    Just sourceNote
+      | Just deferred <- MN.noteDeferred sourceNote ->
+          filter (isBacklinkTo targetR model)
+            . Ix.toList
+            $ Rel.noteTextRels sourceNote (deferred ^. MN.deferredNoteText)
+    _ ->
+      [rel]
+
 -- | Rels pointing *to* this route
 backlinkRels :: R.LMLRoute -> Model -> [Rel.Rel]
 backlinkRels r model =
   let allPossibleLinks = Rel.unresolvedRelsTo $ toModelRoute r
       rels = Ix.toList $ (model ^. modelRels) @+ allPossibleLinks
-   in filter isUnambiguousBacklink rels
+   in filter (isBacklinkTo r model) rels
   where
     toModelRoute = R.ModelRoute_LML R.LMLView_Html
-    -- Check that 'rel' points to 'r' even after resolving any ambiguous wiki links
-    isUnambiguousBacklink rel = isJust $ do
-      SR.SiteRoute_ResourceRoute (SR.ResourceRoute_LML _ r') <-
-        Rel.getResolved $ Resolve.resolveRel model rel
-      guard $ r == r'
-      pass
+
+-- Check that 'rel' points to 'r' even after resolving any ambiguous wiki links.
+isBacklinkTo :: R.LMLRoute -> Model -> Rel.Rel -> Bool
+isBacklinkTo r model rel = isJust $ do
+  SR.SiteRoute_ResourceRoute (SR.ResourceRoute_LML _ r') <-
+    Rel.getResolved $ Resolve.resolveRel model rel
+  guard $ r == r'
+  pass
 
 -- | Rels pointing *from* this route
 frontlinkRels :: R.LMLRoute -> Model -> [Rel.Rel]

--- a/emanote/src/Emanote/Model/Graph.hs
+++ b/emanote/src/Emanote/Model/Graph.hs
@@ -143,6 +143,7 @@ folgezettelTreesFrom model fromRoute =
     loop fromRoute allRoutes
   where
     allRoutes = Set.fromList $ fmap N._noteRoute $ Ix.toList $ model ^. modelNotes
+    childRoutesByParent = folgezettelChildMap model
     -- Run in a state monad of unvisited routes, taking visited routes as argument.
     go :: (MonadState (Set R.LMLRoute) m) => Set R.LMLRoute -> R.LMLRoute -> m (Tree R.LMLRoute)
     go visitedRoutes route
@@ -151,9 +152,34 @@ folgezettelTreesFrom model fromRoute =
           pure $ Node route []
       | otherwise = do
           modify $ Set.delete route
-          let children = folgezettelChildrenFor model route
+          let children = ordNub $ Map.findWithDefault mempty route childRoutesByParent
           cs <- go (Set.insert route visitedRoutes) `traverse` children
           pure $ Node route cs
+
+folgezettelChildMap :: Model -> Map R.LMLRoute [R.LMLRoute]
+folgezettelChildMap model =
+  Map.fromListWith (<>)
+    $ relationEdges
+    <> folderEdges
+  where
+    relationEdges = do
+      rel <- Ix.toList $ model ^. modelRels
+      let source = rel ^. Rel.relFrom
+      case rel ^. Rel.relTo of
+        Rel.URTWikiLink (WL.WikiLinkBranch, wl) -> do
+          child <- maybeToList $ lookupNoteByWikiLink model source wl
+          pure (source, one child)
+        Rel.URTWikiLink (WL.WikiLinkTag, wl) -> do
+          parent <- maybeToList $ lookupNoteByWikiLink model source wl
+          pure (parent, one source)
+        _ ->
+          mempty
+    folderEdges = do
+      note <- Ix.toList $ model ^. modelNotes
+      parentFolder <- maybeToList $ N.noteParent note
+      let parentRoute = R.defaultLmlRoute parentFolder
+      guard $ folderFolgezettelEnabledFor model parentRoute
+      pure (parentRoute, one $ note ^. MN.noteRoute)
 
 folderFolgezettelEnabledFor :: Model -> R.LMLRoute -> Bool
 folderFolgezettelEnabledFor model r =

--- a/emanote/src/Emanote/Model/Link/Rel.hs
+++ b/emanote/src/Emanote/Model/Link/Rel.hs
@@ -10,7 +10,7 @@ import Data.IxSet.Typed qualified as Ix
 import Data.List.NonEmpty qualified as NEL
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
-import Emanote.Model.Note (Note, noteDoc, noteNeedsFullParse, noteResolveLinkBase, noteRoute, noteSourceText)
+import Emanote.Model.Note (Note, deferredNoteText, noteDeferred, noteDoc, noteResolveLinkBase, noteRoute)
 import Emanote.Route (LMLRoute, ModelRoute)
 import Emanote.Route qualified as R
 import Emanote.Route.SiteRoute.Type qualified as SR
@@ -67,31 +67,51 @@ makeLenses ''Rel
 
 noteRels :: Note -> IxRel
 noteRels note =
-  case (note ^. noteNeedsFullParse, note ^. noteSourceText) of
-    (True, Just s) ->
-      textRels note s
-    _ ->
+  case noteDeferred note of
+    Just deferred ->
+      deduplicateRelTargets $ noteTextRels note (deferred ^. deferredNoteText)
+    Nothing ->
       extractLinks . LC.queryLinksWithContext $ note ^. noteDoc
   where
+    parentR = noteResolveLinkBase note
+    noteR = note ^. noteRoute
+
     extractLinks :: Map Text (NonEmpty ([(Text, Text)], [B.Block])) -> IxRel
     extractLinks m =
       Ix.fromList
         $ flip concatMap (Map.toList m)
         $ \(url, instances) -> do
           flip mapMaybe (toList instances) $ \(attrs, ctx) -> do
-            let parentR = noteResolveLinkBase note
             (target, _manchor) <- parseUnresolvedRelTarget parentR attrs url
-            pure $ Rel (note ^. noteRoute) target ctx
+            pure $ Rel noteR target ctx
 
-textRels :: Note -> Text -> IxRel
-textRels note =
+-- | Keep one representative relation per unresolved target for the startup model.
+deduplicateRelTargets :: IxRel -> IxRel
+deduplicateRelTargets =
+  Ix.fromList . Map.elems . foldl' insertRel Map.empty . Ix.toList
+  where
+    insertRel rels rel =
+      Map.insertWith keepOld (rel ^. relTo) rel rels
+    keepOld _new old =
+      old
+
+-- | Extract every wikilink relation from simple Markdown source text.
+noteTextRels :: Note -> Text -> IxRel
+noteTextRels note =
   Ix.fromList . concatMap lineRels . lines
   where
+    parentR = noteResolveLinkBase note
+    noteR = note ^. noteRoute
+
     lineRels line =
-      flip mapMaybe (wikiLinksInLine line) $ \(attrs, url) -> do
-        let parentR = noteResolveLinkBase note
-        (target, _manchor) <- parseUnresolvedRelTarget parentR attrs url
-        pure $ Rel (note ^. noteRoute) target [B.Para [B.Str $ T.strip line]]
+      case wikiLinksInLine line of
+        [] ->
+          []
+        links ->
+          let ctx = [B.Para [B.Str $ T.strip line]]
+           in flip mapMaybe links $ \(attrs, url) -> do
+                (target, _manchor) <- parseUnresolvedRelTarget parentR attrs url
+                pure $ Rel noteR target ctx
 
 wikiLinksInLine :: Text -> [([(Text, Text)], Text)]
 wikiLinksInLine =

--- a/emanote/src/Emanote/Model/Link/Rel.hs
+++ b/emanote/src/Emanote/Model/Link/Rel.hs
@@ -10,7 +10,7 @@ import Data.IxSet.Typed qualified as Ix
 import Data.List.NonEmpty qualified as NEL
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
-import Emanote.Model.Note (Note, noteDoc, noteResolveLinkBase, noteRoute)
+import Emanote.Model.Note (Note, noteDoc, noteNeedsFullParse, noteResolveLinkBase, noteRoute, noteSourceText)
 import Emanote.Route (LMLRoute, ModelRoute)
 import Emanote.Route qualified as R
 import Emanote.Route.SiteRoute.Type qualified as SR
@@ -67,7 +67,11 @@ makeLenses ''Rel
 
 noteRels :: Note -> IxRel
 noteRels note =
-  extractLinks . LC.queryLinksWithContext $ note ^. noteDoc
+  case (note ^. noteNeedsFullParse, note ^. noteSourceText) of
+    (True, Just s) ->
+      textRels note s
+    _ ->
+      extractLinks . LC.queryLinksWithContext $ note ^. noteDoc
   where
     extractLinks :: Map Text (NonEmpty ([(Text, Text)], [B.Block])) -> IxRel
     extractLinks m =
@@ -78,6 +82,39 @@ noteRels note =
             let parentR = noteResolveLinkBase note
             (target, _manchor) <- parseUnresolvedRelTarget parentR attrs url
             pure $ Rel (note ^. noteRoute) target ctx
+
+textRels :: Note -> Text -> IxRel
+textRels note =
+  Ix.fromList . concatMap lineRels . lines
+  where
+    lineRels line =
+      flip mapMaybe (wikiLinksInLine line) $ \(attrs, url) -> do
+        let parentR = noteResolveLinkBase note
+        (target, _manchor) <- parseUnresolvedRelTarget parentR attrs url
+        pure $ Rel (note ^. noteRoute) target [B.Para [B.Str $ T.strip line]]
+
+wikiLinksInLine :: Text -> [([(Text, Text)], Text)]
+wikiLinksInLine =
+  go
+  where
+    go line =
+      case T.breakOn "[[" line of
+        (_, "") -> []
+        (before, rest) ->
+          case T.breakOn "]]" (T.drop 2 rest) of
+            (_, "") -> []
+            (target0, after) ->
+              let target = T.takeWhile (/= '|') target0
+                  attrs = [("data-wikilink-type", wikiLinkType before after)]
+               in (attrs, target) : go (T.drop 2 after)
+
+    wikiLinkType before after
+      | T.isPrefixOf "]]#" after = "WikiLinkBranch"
+      | otherwise =
+          case snd <$> T.unsnoc before of
+            Just '!' -> "WikiLinkEmbed"
+            Just '#' -> "WikiLinkTag"
+            _ -> "WikiLinkNormal"
 
 {- | All `UnresolvedRelTarget`s that could resolve to the given
 `ModelRoute`. The `URTResource` form is built from the canonical URL

--- a/emanote/src/Emanote/Model/Note.hs
+++ b/emanote/src/Emanote/Model/Note.hs
@@ -6,17 +6,18 @@
 module Emanote.Model.Note where
 
 import Commonmark.Extensions.WikiLink qualified as WL
-import Control.Monad.Logger (MonadLogger)
+import Control.Monad.Logger (LoggingT (runLoggingT), MonadLogger, MonadLoggerIO (askLoggerIO))
 import Control.Monad.Writer (MonadWriter (tell), WriterT, runWriterT)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Optics qualified as AO
-import Data.Char (isDigit)
+import Data.Char (isAlphaNum, isDigit)
 import Data.Default (Default (def))
 import Data.IxSet.Typed (Indexable (..), IxSet, ixFun, ixList)
 import Data.IxSet.Typed qualified as Ix
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Time.Calendar (toGregorian)
+import Data.Yaml qualified as Yaml
 import Emanote.Model.Calendar.Parser qualified as Calendar
 import Emanote.Model.Note.Filter (applyPandocFilters)
 import Emanote.Model.SData qualified as SData
@@ -50,24 +51,26 @@ data Feed = Feed
   , _feedLimit :: Maybe Word
   }
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (Aeson.ToJSON, Aeson.FromJSON)
+  deriving anyclass (Aeson.FromJSON, Aeson.ToJSON, NFData)
 
 data Note = Note
   { _noteRoute :: R.LMLRoute
   , _noteSource :: Maybe (Loc, FilePath)
   -- ^ The layer from which this note came. Nothing if the note was auto-generated.
   , _noteDoc :: Pandoc
+  , _noteSourceText :: Maybe Text
+  , _noteNeedsFullParse :: Bool
   , _noteMeta :: Aeson.Value
   , _noteTitle :: Tit.Title
   , _noteErrors :: [Text]
   , _noteFeed :: Maybe Feed
   }
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (Aeson.ToJSON)
+  deriving anyclass (Aeson.ToJSON, NFData)
 
 newtype RAncestor = RAncestor {unRAncestor :: R 'R.Folder}
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (Aeson.ToJSON)
+  deriving anyclass (Aeson.ToJSON, NFData)
 
 type NoteIxs =
   '[ -- Route to this note
@@ -342,7 +345,7 @@ mkNoteWith r src doc' meta errs =
   let (doc'', tit) = queryNoteTitle r doc' meta
       feed = queryNoteFeed meta
       doc = if null errs then doc'' else pandocPrepend (errorDiv "Emanote Errors 😔" errs) doc''
-   in Note r src doc meta tit errs feed
+   in Note r src doc Nothing False meta tit errs feed
   where
     -- Prepend to block to the beginning of a Pandoc document (never before H1)
     pandocPrepend :: B.Block -> Pandoc -> Pandoc
@@ -395,6 +398,170 @@ parseNote scriptingEngine pluginBaseDir r src@(_, fp) s = do
       day <- replicateM 2 P.digit
       _ <- P.satisfy (not . isDigit)
       pure $ toText $ mconcat [year, "-", month, "-", day]
+
+parseNoteForModel ::
+  forall m.
+  (MonadIO m, MonadLogger m) =>
+  ScriptingEngine ->
+  [FilePath] ->
+  R.LMLRoute ->
+  (Loc, FilePath) ->
+  Text ->
+  m Note
+parseNoteForModel scriptingEngine pluginBaseDir r src s =
+  case r of
+    R.LMLRoute_Md _
+      | Just note <- parseSimpleMarkdownNote r src s ->
+          pure note
+    _ ->
+      parseNote scriptingEngine pluginBaseDir r src s
+
+parseNoteIfNeeded ::
+  (MonadIO m, MonadLoggerIO m) =>
+  ScriptingEngine ->
+  [FilePath] ->
+  Note ->
+  m Note
+parseNoteIfNeeded scriptingEngine pluginBaseDir note =
+  case (_noteNeedsFullParse note, _noteSource note, _noteSourceText note) of
+    (True, Just src, Just s) -> do
+      logger <- askLoggerIO
+      runLoggingT (parseNote scriptingEngine pluginBaseDir (_noteRoute note) src s) logger
+    _ ->
+      pure note
+
+parseSimpleMarkdownNote :: R.LMLRoute -> (Loc, FilePath) -> Text -> Maybe Note
+parseSimpleMarkdownNote r src@(_, fp) s = do
+  (frontmatter, body) <- rightToMaybe $ parseFrontMatter s
+  guard $ canUseSimpleMarkdownNote frontmatter body
+  let metaWithDateFromPath = case P.parse dateParser mempty (takeFileName fp) of
+        Left _ -> meta
+        Right date -> SData.modifyAeson (pure "date") (Just . fromMaybe (Aeson.String date)) meta
+      meta = applySimpleNoteMetaFilters r body frontmatter
+      doc = simpleTitleDoc r body meta
+      (doc', tit) = queryNoteTitle r doc metaWithDateFromPath
+      feed = queryNoteFeed metaWithDateFromPath
+  pure $ Note r (Just src) doc' (Just s) True metaWithDateFromPath tit mempty feed
+  where
+    dateParser = do
+      year <- replicateM 4 P.digit
+      _ <- P.char '-'
+      month <- replicateM 2 P.digit
+      _ <- P.char '-'
+      day <- replicateM 2 P.digit
+      _ <- P.satisfy (not . isDigit)
+      pure $ toText $ mconcat [year, "-", month, "-", day]
+
+parseFrontMatter :: Text -> Either Text (Aeson.Value, Text)
+parseFrontMatter s =
+  case T.stripPrefix "---\n" s of
+    Nothing ->
+      Right (defaultFrontMatter, s)
+    Just rest ->
+      case T.breakOn "\n---" rest of
+        (_, "") ->
+          Left "unterminated frontmatter"
+        (frontmatter, after) -> do
+          value <-
+            first (toText . Yaml.prettyPrintParseException)
+              $ Yaml.decodeEither' @(Maybe Aeson.Value) (encodeUtf8 frontmatter)
+          let body = T.dropWhile (`elem` ['\r', '\n']) $ T.drop 4 after
+          Right (withAesonDefault defaultFrontMatter value, body)
+  where
+    withAesonDefault default_ mv =
+      fromMaybe default_ mv
+        `SData.mergeAeson` default_
+
+canUseSimpleMarkdownNote :: Aeson.Value -> Text -> Bool
+canUseSimpleMarkdownNote frontmatter body =
+  null (SData.lookupAeson @[FilePath] mempty ("pandoc" :| ["filters"]) frontmatter)
+    && not (maybe False _feedEnable $ queryNoteFeed frontmatter)
+    && not (hasSingleBracketMarkdown body)
+    && not (any (`T.isInfixOf` body) complexMarkers)
+  where
+    complexMarkers =
+      [ "]("
+      , "!["
+      , "```"
+      , "~~~"
+      , "[ ]"
+      , "[x]"
+      , "[X]"
+      ]
+
+hasSingleBracketMarkdown :: Text -> Bool
+hasSingleBracketMarkdown =
+  go
+  where
+    go s =
+      case T.breakOn "[" s of
+        (_, "") ->
+          False
+        (_, rest)
+          | Just afterOpen <- T.stripPrefix "[[" rest ->
+              case T.breakOn "]]" afterOpen of
+                (_, "") -> True
+                (_, afterClose) -> go $ T.drop 2 afterClose
+          | otherwise ->
+              True
+
+simpleTitleDoc :: R.LMLRoute -> Text -> Aeson.Value -> Pandoc
+simpleTitleDoc r body meta =
+  case SData.lookupAeson @Text "" (one "title") meta of
+    "" ->
+      maybe mempty (Pandoc mempty . one . header) $ firstMarkdownHeading body
+    _ ->
+      mempty
+  where
+    header titleText =
+      B.Header 1 (toText $ R.withLmlRoute R.encodeRoute r, mempty, mempty) [B.Str titleText]
+
+firstMarkdownHeading :: Text -> Maybe Text
+firstMarkdownHeading =
+  viaNonEmpty head
+    . mapMaybe headingText
+    . lines
+  where
+    headingText line = do
+      rest <- T.stripPrefix "# " $ T.stripStart line
+      pure $ T.strip rest
+
+applySimpleNoteMetaFilters :: R.LMLRoute -> Text -> Aeson.Value -> Aeson.Value
+applySimpleNoteMetaFilters r body frontmatter =
+  frontmatter
+    & AO.key "tags"
+    % AO._Array
+    .~ ( fromList
+          . fmap Aeson.toJSON
+          $ ordNub
+          $ mconcat
+            [ tagsFromFrontmatter
+            , tagsFromBody
+            , tagsForDailyNote
+            ]
+       )
+  where
+    tagsFromFrontmatter =
+      SData.lookupAeson @[HT.Tag] mempty (one "tags") frontmatter
+    tagsFromBody =
+      HT.Tag <$> simpleInlineTags body
+    tagsForDailyNote = maybe mempty dayTags $ Calendar.parseRouteDay r
+    dayTags day =
+      let (y, m, _d) = toGregorian day
+          pad2 = toText @String . printf "%02d"
+       in [HT.Tag $ "calendar/" <> show y <> "/" <> pad2 m]
+
+simpleInlineTags :: Text -> [Text]
+simpleInlineTags =
+  mapMaybe tagFromWord . words
+  where
+    tagFromWord word = do
+      tag <- T.stripPrefix "#" word
+      let tag' = T.takeWhile validTagChar tag
+      guard $ not $ T.null tag'
+      pure tag'
+    validTagChar c =
+      c == '/' || c == '-' || c == '_' || c == '.' || isAlphaNum c
 
 parseNoteOrg :: (MonadWriter [Text] m) => Text -> m (Pandoc, Aeson.Value)
 parseNoteOrg s =

--- a/emanote/src/Emanote/Model/Note.hs
+++ b/emanote/src/Emanote/Model/Note.hs
@@ -30,7 +30,7 @@ import Emanote.Route.Ext (FileType (Folder))
 import Emanote.Route.R (R)
 import Emanote.Source.Loc (Loc)
 import Network.URI.Slug (Slug)
-import Optics.Core ((%), (.~))
+import Optics.Core (Getter, to, (%), (.~))
 import Optics.TH (makeLenses)
 import Relude
 import System.FilePath (takeDirectory, takeFileName, (</>))
@@ -55,11 +55,7 @@ data Feed = Feed
 
 data Note = Note
   { _noteRoute :: R.LMLRoute
-  , _noteSource :: Maybe (Loc, FilePath)
-  -- ^ The layer from which this note came. Nothing if the note was auto-generated.
-  , _noteDoc :: Pandoc
-  , _noteSourceText :: Maybe Text
-  , _noteNeedsFullParse :: Bool
+  , _noteBody :: NoteBody
   , _noteMeta :: Aeson.Value
   , _noteTitle :: Tit.Title
   , _noteErrors :: [Text]
@@ -67,6 +63,25 @@ data Note = Note
   }
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (Aeson.ToJSON, NFData)
+
+data NoteBody
+  = NoteBodyParsed (Maybe (Loc, FilePath)) Pandoc
+  | NoteBodyDeferred DeferredNote
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (Aeson.ToJSON, NFData)
+
+data DeferredNote = DeferredNote
+  { _deferredNoteSource :: (Loc, FilePath)
+  , _deferredNoteText :: Text
+  , _deferredNoteSummaryDoc :: Pandoc
+  }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (Aeson.ToJSON, NFData)
+
+data ParseContext = ParseContext
+  { _parseContextScriptingEngine :: ScriptingEngine
+  , _parseContextPluginBaseDirs :: [FilePath]
+  }
 
 newtype RAncestor = RAncestor {unRAncestor :: R 'R.Folder}
   deriving stock (Eq, Ord, Show, Generic)
@@ -138,7 +153,7 @@ See <https://github.com/srid/emanote/issues/608>.
 -}
 noteResolveLinkBase :: Note -> Maybe (R 'R.Folder)
 noteResolveLinkBase note =
-  case _noteSource note of
+  case noteBodySource $ _noteBody note of
     Just (_, fp) -> resolveLinkBaseFromFilePath fp
     Nothing -> noteParent note
 
@@ -345,7 +360,7 @@ mkNoteWith r src doc' meta errs =
   let (doc'', tit) = queryNoteTitle r doc' meta
       feed = queryNoteFeed meta
       doc = if null errs then doc'' else pandocPrepend (errorDiv "Emanote Errors 😔" errs) doc''
-   in Note r src doc Nothing False meta tit errs feed
+   in Note r (NoteBodyParsed src doc) meta tit errs feed
   where
     -- Prepend to block to the beginning of a Pandoc document (never before H1)
     pandocPrepend :: B.Block -> Pandoc -> Pandoc
@@ -372,17 +387,16 @@ errorDiv header errs =
 parseNote ::
   forall m.
   (MonadIO m, MonadLogger m) =>
-  ScriptingEngine ->
-  [FilePath] ->
+  ParseContext ->
   R.LMLRoute ->
   (Loc, FilePath) ->
   Text ->
   m Note
-parseNote scriptingEngine pluginBaseDir r src@(_, fp) s = do
+parseNote ParseContext {..} r src@(_, fp) s = do
   ((doc, meta), errs) <- runWriterT $ do
     case r of
       R.LMLRoute_Md _ ->
-        parseNoteMarkdown scriptingEngine pluginBaseDir r fp s
+        parseNoteMarkdown _parseContextScriptingEngine _parseContextPluginBaseDirs r fp s
       R.LMLRoute_Org _ -> do
         parseNoteOrg s
   let metaWithDateFromPath = case P.parse dateParser mempty (takeFileName fp) of
@@ -402,31 +416,29 @@ parseNote scriptingEngine pluginBaseDir r src@(_, fp) s = do
 parseNoteForModel ::
   forall m.
   (MonadIO m, MonadLogger m) =>
-  ScriptingEngine ->
-  [FilePath] ->
+  ParseContext ->
   R.LMLRoute ->
   (Loc, FilePath) ->
   Text ->
   m Note
-parseNoteForModel scriptingEngine pluginBaseDir r src s =
+parseNoteForModel parseContext r src s =
   case r of
     R.LMLRoute_Md _
       | Just note <- parseSimpleMarkdownNote r src s ->
           pure note
     _ ->
-      parseNote scriptingEngine pluginBaseDir r src s
+      parseNote parseContext r src s
 
 parseNoteIfNeeded ::
   (MonadIO m, MonadLoggerIO m) =>
-  ScriptingEngine ->
-  [FilePath] ->
+  ParseContext ->
   Note ->
   m Note
-parseNoteIfNeeded scriptingEngine pluginBaseDir note =
-  case (_noteNeedsFullParse note, _noteSource note, _noteSourceText note) of
-    (True, Just src, Just s) -> do
+parseNoteIfNeeded parseContext note =
+  case noteDeferred note of
+    Just DeferredNote {..} -> do
       logger <- askLoggerIO
-      runLoggingT (parseNote scriptingEngine pluginBaseDir (_noteRoute note) src s) logger
+      runLoggingT (parseNote parseContext (_noteRoute note) _deferredNoteSource _deferredNoteText) logger
     _ ->
       pure note
 
@@ -441,7 +453,7 @@ parseSimpleMarkdownNote r src@(_, fp) s = do
       doc = simpleTitleDoc r body meta
       (doc', tit) = queryNoteTitle r doc metaWithDateFromPath
       feed = queryNoteFeed metaWithDateFromPath
-  pure $ Note r (Just src) doc' (Just s) True metaWithDateFromPath tit mempty feed
+  pure $ Note r (NoteBodyDeferred $ DeferredNote src s doc') metaWithDateFromPath tit mempty feed
   where
     dateParser = do
       year <- replicateM 4 P.digit
@@ -670,4 +682,35 @@ applyNoteMetaFilters doc r =
               pure $ SData.oneAesonText (toList key) val
           )
 
+noteSource :: Getter Note (Maybe (Loc, FilePath))
+noteSource =
+  to (noteBodySource . _noteBody)
+
+noteDoc :: Getter Note Pandoc
+noteDoc =
+  to (noteBodyDoc . _noteBody)
+
+noteDeferred :: Note -> Maybe DeferredNote
+noteDeferred note =
+  case _noteBody note of
+    NoteBodyDeferred deferred ->
+      Just deferred
+    NoteBodyParsed _ _ ->
+      Nothing
+
+noteBodySource :: NoteBody -> Maybe (Loc, FilePath)
+noteBodySource = \case
+  NoteBodyParsed src _ ->
+    src
+  NoteBodyDeferred DeferredNote {..} ->
+    Just _deferredNoteSource
+
+noteBodyDoc :: NoteBody -> Pandoc
+noteBodyDoc = \case
+  NoteBodyParsed _ doc ->
+    doc
+  NoteBodyDeferred DeferredNote {..} ->
+    _deferredNoteSummaryDoc
+
+makeLenses ''DeferredNote
 makeLenses ''Note

--- a/emanote/src/Emanote/Model/Title.hs
+++ b/emanote/src/Emanote/Model/Title.hs
@@ -27,7 +27,7 @@ data Title
   = TitlePlain Text
   | TitlePandoc [B.Inline]
   deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (NFData, ToJSON)
 
 instance Eq Title where
   (==) =

--- a/emanote/src/Emanote/Model/Type.hs
+++ b/emanote/src/Emanote/Model/Type.hs
@@ -43,6 +43,7 @@ import Optics.Core (Prism')
 import Optics.Operators ((%~), (.~), (^.))
 import Optics.TH (makeLenses)
 import Relude
+import Text.Pandoc.Scripting (ScriptingEngine)
 
 data Status = Status_Loading | Status_Ready
   deriving stock (Eq, Show)
@@ -54,6 +55,8 @@ data ModelT encF = Model
   , _modelRoutePrism :: encF (Prism' FilePath SiteRoute)
   , _modelPandocRenderers :: EmanotePandocRenderers Model LMLRoute
   -- ^ Dictates how exactly to render `Pandoc` to Heist nodes.
+  , _modelScriptingEngine :: Maybe ScriptingEngine
+  , _modelPluginBaseDirs :: [FilePath]
   , _modelCompileTailwind :: Bool
   , _modelInstanceID :: UUID
   -- ^ An unique ID for this process's model. ID changes across processes.
@@ -94,14 +97,16 @@ withRoutePrism enc Model {..} =
   let _modelRoutePrism = Identity enc
    in Model {..}
 
-emptyModel :: Set Loc -> Ema.CLI.Action -> EmanotePandocRenderers Model LMLRoute -> Bool -> UUID -> Stork.IndexVar -> ModelEma
-emptyModel layers act ren ctw instanceId storkVar =
+emptyModel :: Set Loc -> Ema.CLI.Action -> EmanotePandocRenderers Model LMLRoute -> Maybe ScriptingEngine -> [FilePath] -> Bool -> UUID -> Stork.IndexVar -> ModelEma
+emptyModel layers act ren scriptingEngine pluginBaseDirs ctw instanceId storkVar =
   Model
     { _modelStatus = Status_Loading
     , _modelLayers = layers
     , _modelEmaCLIAction = act
     , _modelRoutePrism = Const ()
     , _modelPandocRenderers = ren
+    , _modelScriptingEngine = scriptingEngine
+    , _modelPluginBaseDirs = pluginBaseDirs
     , _modelCompileTailwind = ctw
     , _modelInstanceID = instanceId
     , -- Inject a placeholder `index.md` to account for the use case of emanote
@@ -138,6 +143,29 @@ modelInsertNote note =
     %~ updateIxMulti r (Task.noteTasks note)
   where
     r = note ^. N.noteRoute
+
+modelInsertNotes :: [Note] -> ModelT f -> ModelT f
+modelInsertNotes [] =
+  id
+modelInsertNotes notes =
+  modelNotes
+    %~ ( \oldNotes ->
+          let withoutOld = flipfoldl' Ix.deleteIx oldNotes routes
+              withNew = Ix.fromList notes `Ix.union` withoutOld
+              withAncestors =
+                foldl' (\acc note -> injectAncestors (N.noteAncestors note) acc) withNew notes
+           in flipfoldl' dropRedundantAncestor withAncestors routes
+       )
+      >>> modelRels
+    %~ replaceMulti routes newRels
+      >>> modelTasks
+    %~ replaceMulti routes newTasks
+  where
+    routes = fmap (^. N.noteRoute) notes
+    newRels =
+      Ix.fromList $ notes >>= Ix.toList . Rel.noteRels
+    newTasks =
+      Ix.fromList $ notes >>= Ix.toList . Task.noteTasks
 
 {- | If a placeholder route was added already, but the newly added note is a
  non-Markdown, removce that markdown placeholder route.
@@ -220,6 +248,15 @@ deleteIxMulti ::
 deleteIxMulti r rels =
   let candidates = Ix.toList $ Ix.getEQ r rels
    in flipfoldl' Ix.delete rels candidates
+
+replaceMulti ::
+  (Ix.Indexable ixs a, Ix.IsIndexOf ix ixs) =>
+  [ix] ->
+  Ix.IxSet ixs a ->
+  Ix.IxSet ixs a ->
+  Ix.IxSet ixs a
+replaceMulti routes new old =
+  new `Ix.union` flipfoldl' deleteIxMulti old routes
 
 modelLookupStaticFile :: FilePath -> ModelT f -> Maybe StaticFile
 modelLookupStaticFile fp m = do

--- a/emanote/src/Emanote/Model/Type.hs
+++ b/emanote/src/Emanote/Model/Type.hs
@@ -19,6 +19,7 @@ import Emanote.Model.Link.Rel qualified as Rel
 import Emanote.Model.Note (
   IxNote,
   Note,
+  ParseContext,
   noteHasFeed,
  )
 import Emanote.Model.Note qualified as N
@@ -43,7 +44,6 @@ import Optics.Core (Prism')
 import Optics.Operators ((%~), (.~), (^.))
 import Optics.TH (makeLenses)
 import Relude
-import Text.Pandoc.Scripting (ScriptingEngine)
 
 data Status = Status_Loading | Status_Ready
   deriving stock (Eq, Show)
@@ -55,8 +55,7 @@ data ModelT encF = Model
   , _modelRoutePrism :: encF (Prism' FilePath SiteRoute)
   , _modelPandocRenderers :: EmanotePandocRenderers Model LMLRoute
   -- ^ Dictates how exactly to render `Pandoc` to Heist nodes.
-  , _modelScriptingEngine :: Maybe ScriptingEngine
-  , _modelPluginBaseDirs :: [FilePath]
+  , _modelParseContext :: Maybe ParseContext
   , _modelCompileTailwind :: Bool
   , _modelInstanceID :: UUID
   -- ^ An unique ID for this process's model. ID changes across processes.
@@ -97,16 +96,15 @@ withRoutePrism enc Model {..} =
   let _modelRoutePrism = Identity enc
    in Model {..}
 
-emptyModel :: Set Loc -> Ema.CLI.Action -> EmanotePandocRenderers Model LMLRoute -> Maybe ScriptingEngine -> [FilePath] -> Bool -> UUID -> Stork.IndexVar -> ModelEma
-emptyModel layers act ren scriptingEngine pluginBaseDirs ctw instanceId storkVar =
+emptyModel :: Set Loc -> Ema.CLI.Action -> EmanotePandocRenderers Model LMLRoute -> Maybe ParseContext -> Bool -> UUID -> Stork.IndexVar -> ModelEma
+emptyModel layers act ren parseContext ctw instanceId storkVar =
   Model
     { _modelStatus = Status_Loading
     , _modelLayers = layers
     , _modelEmaCLIAction = act
     , _modelRoutePrism = Const ()
     , _modelPandocRenderers = ren
-    , _modelScriptingEngine = scriptingEngine
-    , _modelPluginBaseDirs = pluginBaseDirs
+    , _modelParseContext = parseContext
     , _modelCompileTailwind = ctw
     , _modelInstanceID = instanceId
     , -- Inject a placeholder `index.md` to account for the use case of emanote
@@ -130,19 +128,8 @@ inLiveServer :: Model -> Bool
 inLiveServer = Ema.CLI.isLiveServer . _modelEmaCLIAction
 
 modelInsertNote :: Note -> ModelT f -> ModelT f
-modelInsertNote note =
-  modelNotes
-    %~ ( Ix.updateIx r note
-          -- Insert folder placeholder automatically for ancestor paths
-          >>> injectAncestors (N.noteAncestors note)
-          >>> dropRedundantAncestor r
-       )
-      >>> modelRels
-    %~ updateIxMulti r (Rel.noteRels note)
-      >>> modelTasks
-    %~ updateIxMulti r (Task.noteTasks note)
-  where
-    r = note ^. N.noteRoute
+modelInsertNote =
+  modelInsertNotes . one
 
 modelInsertNotes :: [Note] -> ModelT f -> ModelT f
 modelInsertNotes [] =
@@ -226,18 +213,6 @@ modelDeleteNote k model =
       let folderR = R.withLmlRoute coerce k
       guard $ N.hasChildNotes folderR $ model ^. modelNotes
       pure folderR
-
--- | Like `Ix.updateIx`, but works for multiple items.
-updateIxMulti ::
-  (Ix.IsIndexOf ix ixs, Ix.Indexable ixs a) =>
-  ix ->
-  Ix.IxSet ixs a ->
-  Ix.IxSet ixs a ->
-  Ix.IxSet ixs a
-updateIxMulti r new rels =
-  let old = rels @= r
-      deleteMany = foldr Ix.delete
-   in new `Ix.union` (rels `deleteMany` old)
 
 -- | Like `Ix.deleteIx`, but works for multiple items
 deleteIxMulti ::

--- a/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
+++ b/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
@@ -7,45 +7,58 @@ import Commonmark.Extensions qualified as CE
 import Commonmark.Extensions.WikiLink qualified as WL
 import Commonmark.Simple (parseMarkdownWithFrontMatter)
 import Data.Aeson qualified as Aeson
+import Data.Text qualified as T
 import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as IT
 import Emanote.Pandoc.Markdown.Syntax.Highlight qualified as IH
 import Relude
 import Text.Pandoc.Definition (Pandoc)
 
 parseMarkdown :: FilePath -> Text -> Either Text (Maybe Aeson.Value, Pandoc)
-parseMarkdown =
-  parseMarkdownWithFrontMatter @Aeson.Value
-    $
-    -- As the commonmark documentation states, pipeTableSpec should be placed after
-    -- fancyListSpec and defaultSyntaxSpec to avoid bad results when parsing
-    -- non-table lines.
-    -- see https://github.com/jgm/commonmark-hs/issues/52
-    baseExtsSansPipeTable
-    <> gfmExtensionsSansPipeTable
-    <> CE.pipeTableSpec
-    <> WL.wikilinkSpec
-    -- ASK: Can we conditionally disable this?
-    -- cf. https://github.com/srid/emanote/issues/167
-    <> IT.hashTagSpec
-    <> IH.highlightSpec
+parseMarkdown fp md =
+  parseMarkdownWithFrontMatter @Aeson.Value (syntaxSpecFor md) fp md
   where
-    baseExtsSansPipeTable =
-      mconcat
-        [ CE.fancyListSpec
-        , CE.footnoteSpec
-        , CE.mathSpec
-        , CE.smartPunctuationSpec
-        , CE.definitionListSpec
-        , CE.attributesSpec
-        , CE.rawAttributeSpec
-        , CE.fencedDivSpec
-        , CE.bracketedSpanSpec
-        , CE.autolinkSpec
-        , CM.defaultSyntaxSpec
-        ]
-    gfmExtensionsSansPipeTable =
-      CE.emojiSpec
-        <> CE.strikethroughSpec
-        <> CE.autolinkSpec
-        <> CE.autoIdentifiersSpec
-        <> CE.taskListSpec
+    syntaxSpecFor md' =
+      -- As the commonmark documentation states, pipeTableSpec should be placed after
+      -- fancyListSpec and defaultSyntaxSpec to avoid bad results when parsing
+      -- non-table lines.
+      -- see https://github.com/jgm/commonmark-hs/issues/52
+      baseExtsSansPipeTable md'
+        <> gfmExtensionsSansPipeTable md'
+        <> whenPresent "|" CE.pipeTableSpec
+        <> whenPresent "[[" WL.wikilinkSpec
+        <> whenPresent "#" IT.hashTagSpec
+        <> whenPresent "==" IH.highlightSpec
+      where
+        whenPresent needle spec =
+          bool mempty spec $ needle `T.isInfixOf` md'
+
+    baseExtsSansPipeTable md' =
+      let whenPresent needle spec =
+            bool mempty spec $ needle `T.isInfixOf` md'
+       in mconcat
+            [ CE.fancyListSpec
+            , whenPresent "[^" CE.footnoteSpec
+            , whenPresent "$" CE.mathSpec
+            , CE.smartPunctuationSpec
+            , whenPresent "\n:" CE.definitionListSpec
+            , whenPresent "{" CE.attributesSpec
+            , whenPresent "{" CE.rawAttributeSpec
+            , whenPresent ":::" CE.fencedDivSpec
+            , whenPresent "[" CE.bracketedSpanSpec
+            , autolinkSpecFor md'
+            , CM.defaultSyntaxSpec
+            ]
+
+    gfmExtensionsSansPipeTable md' =
+      let whenPresent needle spec =
+            bool mempty spec $ needle `T.isInfixOf` md'
+       in mconcat
+            [ whenPresent ":" CE.emojiSpec
+            , whenPresent "~~" CE.strikethroughSpec
+            , CE.autoIdentifiersSpec
+            , bool mempty CE.taskListSpec $ any (`T.isInfixOf` md') ["[ ]", "[x]", "[X]"]
+            ]
+
+    autolinkSpecFor md' =
+      bool mempty CE.autolinkSpec
+        $ any (`T.isInfixOf` md') ["http://", "https://", "www.", "@", "<"]

--- a/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Embed.hs
@@ -15,7 +15,6 @@ import Emanote.Pandoc.Link qualified as Link
 import Emanote.Pandoc.Renderer (PandocBlockRenderer, PandocInlineRenderer)
 import Emanote.Pandoc.Renderer.Url qualified as RendererUrl
 import Emanote.Route.ModelRoute qualified as R
-import Emanote.Route.R qualified as R
 import Emanote.Route.SiteRoute qualified as SF
 import Emanote.Route.SiteRoute qualified as SR
 import Heist qualified as H

--- a/emanote/src/Emanote/Route/ModelRoute.hs
+++ b/emanote/src/Emanote/Route/ModelRoute.hs
@@ -34,21 +34,21 @@ type StaticFileRoute = R 'AnyExt
 
 data LMLView = LMLView_Html | LMLView_Atom
   deriving stock (Eq, Show, Ord, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (NFData, ToJSON)
 
 -- | A R to anywhere in `Model`
 data ModelRoute
   = ModelRoute_StaticFile StaticFileRoute
   | ModelRoute_LML LMLView LMLRoute
   deriving stock (Eq, Show, Ord, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (NFData, ToJSON)
 
 -- | R to a note file in LML (lightweight markup language) format
 data LMLRoute
   = LMLRoute_Md (R ('LMLType 'Md))
   | LMLRoute_Org (R ('LMLType 'Org))
   deriving stock (Eq, Show, Ord, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (NFData, ToJSON)
 
 defaultLmlRoute :: R (ext :: FileType a) -> LMLRoute
 defaultLmlRoute =

--- a/emanote/src/Emanote/Route/R.hs
+++ b/emanote/src/Emanote/Route/R.hs
@@ -17,6 +17,10 @@ import Text.Show qualified (Show (show))
 newtype R (ext :: FileType a) = R {unRoute :: NonEmpty Slug}
   deriving stock (Eq, Ord, Typeable, Data)
 
+instance NFData (R ext) where
+  rnf =
+    rnf . fmap Slug.unSlug . unRoute
+
 instance (HasExt ext) => ToJSON (R ext) where
   toJSON = toJSON . encodeRoute
 

--- a/emanote/src/Emanote/Source/Dynamic.hs
+++ b/emanote/src/Emanote/Source/Dynamic.hs
@@ -17,7 +17,7 @@ import Data.UUID.V4 qualified as UUID
 import Ema (Dynamic (..))
 import Ema.CLI qualified
 import Emanote.CLI qualified as CLI
-import Emanote.Model.Note (Note)
+import Emanote.Model.Note (Note, ParseContext (ParseContext))
 import Emanote.Model.Stork.Index qualified as Stork
 import Emanote.Model.Type qualified as Model
 import Emanote.Pandoc.Renderer (EmanotePandocRenderers)
@@ -57,15 +57,15 @@ emanoteSiteInput cliAct EmanoteConfig {..} = do
   storkIndex <- Stork.newIndex
   scriptingEngine <- getEngine
   let layers = Loc.userLayers ((CLI.path &&& CLI.mountPoint) <$> CLI.layers _emanoteConfigCli) <> one defaultLayer
-      pluginBaseDirs = Loc.userLayersToSearch layers
-      initialModel = Model.emptyModel layers cliAct _emanoteConfigPandocRenderers (Just scriptingEngine) pluginBaseDirs _emanoteCompileTailwind instanceId storkIndex
+      parseContext = ParseContext scriptingEngine (Loc.userLayersToSearch layers)
+      initialModel = Model.emptyModel layers cliAct _emanoteConfigPandocRenderers (Just parseContext) _emanoteCompileTailwind instanceId storkIndex
   Dynamic
     <$> UM.unionMount
       (layers & Set.map (id &&& Loc.locPath))
       Pattern.filePatterns
       Pattern.ignorePatterns
       initialModel
-      (mapFsChanges $ Patch.patchModels layers _emanoteConfigNoteFn storkIndex scriptingEngine)
+      (mapFsChanges $ Patch.patchModels _emanoteConfigNoteFn storkIndex parseContext)
 
 type ChangeHandler tag model m =
   tag ->

--- a/emanote/src/Emanote/Source/Dynamic.hs
+++ b/emanote/src/Emanote/Source/Dynamic.hs
@@ -55,21 +55,21 @@ emanoteSiteInput cliAct EmanoteConfig {..} = do
   defaultLayer <- Loc.defaultLayer <$> liftIO Paths_emanote.getDataDir
   instanceId <- liftIO UUID.nextRandom
   storkIndex <- Stork.newIndex
-  let layers = Loc.userLayers ((CLI.path &&& CLI.mountPoint) <$> CLI.layers _emanoteConfigCli) <> one defaultLayer
-      initialModel = Model.emptyModel layers cliAct _emanoteConfigPandocRenderers _emanoteCompileTailwind instanceId storkIndex
   scriptingEngine <- getEngine
+  let layers = Loc.userLayers ((CLI.path &&& CLI.mountPoint) <$> CLI.layers _emanoteConfigCli) <> one defaultLayer
+      pluginBaseDirs = Loc.userLayersToSearch layers
+      initialModel = Model.emptyModel layers cliAct _emanoteConfigPandocRenderers (Just scriptingEngine) pluginBaseDirs _emanoteCompileTailwind instanceId storkIndex
   Dynamic
     <$> UM.unionMount
       (layers & Set.map (id &&& Loc.locPath))
       Pattern.filePatterns
       Pattern.ignorePatterns
       initialModel
-      (mapFsChanges $ Patch.patchModel layers _emanoteConfigNoteFn storkIndex scriptingEngine)
+      (mapFsChanges $ Patch.patchModels layers _emanoteConfigNoteFn storkIndex scriptingEngine)
 
 type ChangeHandler tag model m =
   tag ->
-  FilePath ->
-  UM.FileAction (NonEmpty (Loc, FilePath)) ->
+  Map FilePath (UM.FileAction (NonEmpty (Loc, FilePath))) ->
   m (model -> model)
 
 mapFsChanges :: (MonadIO m, MonadLogger m) => ChangeHandler tag model m -> UM.Change Loc tag -> m (model -> model)
@@ -91,7 +91,7 @@ mapFsChangesOnExt ::
   tag ->
   Map FilePath (UM.FileAction (NonEmpty (Loc, FilePath))) ->
   m (model -> model)
-mapFsChangesOnExt h fpType fps = do
-  uncurry (h fpType) `chainM` Map.toList fps
+mapFsChangesOnExt h =
+  h
 
 makeLenses ''EmanoteConfig

--- a/emanote/src/Emanote/Source/Loc.hs
+++ b/emanote/src/Emanote/Source/Loc.hs
@@ -33,7 +33,7 @@ data Loc
   | -- | The default location (ie., emanote default layer)
     LocDefault FilePath
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (Aeson.ToJSON)
+  deriving anyclass (Aeson.ToJSON, NFData)
 
 {- | List of user layers, highest precedent being at first.
 

--- a/emanote/src/Emanote/Source/Patch.hs
+++ b/emanote/src/Emanote/Source/Patch.hs
@@ -12,6 +12,7 @@ import Data.List.NonEmpty qualified as NEL
 import Data.Map.Strict qualified as Map
 import Data.Time (defaultTimeLocale, formatTime, getCurrentTime)
 import Emanote.Model qualified as M
+import Emanote.Model.Note (ParseContext)
 import Emanote.Model.Note qualified as N
 import Emanote.Model.SData qualified as SD
 import Emanote.Model.StaticFile (readStaticFileInfo)
@@ -24,64 +25,57 @@ import Emanote.Prelude (
   logE,
  )
 import Emanote.Route qualified as R
-import Emanote.Source.Loc (Loc, locResolve, userLayersToSearch)
+import Emanote.Source.Loc (Loc, locResolve)
 import Emanote.Source.Pattern (filePatterns, ignorePatterns)
 import Heist.Extra.TemplateState qualified as T
 import Optics.Operators ((%~), (^.))
 import Relude
 import Relude.Extra (traverseToSnd)
 import System.UnionMount qualified as UM
-import Text.Pandoc.Scripting (ScriptingEngine)
 import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.Directory (doesDirectoryExist)
 
 patchModels ::
   (MonadIO m, MonadLogger m, MonadLoggerIO m) =>
-  Set Loc ->
   (N.Note -> N.Note) ->
   Stork.IndexVar ->
-  -- | Lua scripting engine
-  ScriptingEngine ->
+  ParseContext ->
   -- | Type of the files being changed
   R.FileType R.SourceExt ->
   Map FilePath (UM.FileAction (NonEmpty (Loc, FilePath))) ->
   m (ModelEma -> ModelEma)
-patchModels layers noteF storkIndexTVar scriptingEngine fpType actions = do
+patchModels noteF storkIndexTVar parseContext fpType actions = do
   logger <- askLoggerIO
   now <- liftIO getCurrentTime
   let newLogger loc src lvl s =
         logger loc src lvl $ fromString (formatTime defaultTimeLocale "[%H:%M:%S] " now) <> s
-  runLoggingT (patchModels' layers noteF storkIndexTVar scriptingEngine fpType actions) newLogger
+  runLoggingT (patchModels' noteF storkIndexTVar parseContext fpType actions) newLogger
 
 patchModels' ::
   (MonadIO m, MonadLogger m) =>
-  Set Loc ->
   (N.Note -> N.Note) ->
   Stork.IndexVar ->
-  -- | Lua scripting engine
-  ScriptingEngine ->
+  ParseContext ->
   -- | Type of the files being changed
   R.FileType R.SourceExt ->
   Map FilePath (UM.FileAction (NonEmpty (Loc, FilePath))) ->
   m (ModelEma -> ModelEma)
-patchModels' layers noteF storkIndexTVar scriptingEngine fpType actions =
+patchModels' noteF storkIndexTVar parseContext fpType actions =
   case fpType of
     R.LMLType lmlType ->
-      patchLmlModels layers noteF storkIndexTVar scriptingEngine lmlType actions
+      patchLmlModels noteF storkIndexTVar parseContext lmlType actions
     _ ->
-      uncurry (patchModel' layers noteF storkIndexTVar scriptingEngine fpType) `chainM` Map.toList actions
+      uncurry (patchNonLmlModel fpType) `chainM` Map.toList actions
 
 patchLmlModels ::
   (MonadIO m, MonadLogger m) =>
-  Set Loc ->
   (N.Note -> N.Note) ->
   Stork.IndexVar ->
-  -- | Lua scripting engine
-  ScriptingEngine ->
+  ParseContext ->
   R.LML ->
   Map FilePath (UM.FileAction (NonEmpty (Loc, FilePath))) ->
   m (ModelEma -> ModelEma)
-patchLmlModels layers noteF storkIndexTVar scriptingEngine lmlType actions = do
+patchLmlModels noteF storkIndexTVar parseContext lmlType actions = do
   unless (Map.null actions)
     $ Stork.clearStorkIndex storkIndexTVar
   (notes, deletes) <-
@@ -94,7 +88,7 @@ patchLmlModels layers noteF storkIndexTVar scriptingEngine lmlType actions = do
             UM.Refresh refreshAction overlays -> do
               let fpAbs = head overlays
               s <- readRefreshedFile refreshAction $ locResolve fpAbs
-              note <- N.parseNoteForModel scriptingEngine (userLayersToSearch layers) r fpAbs (decodeUtf8 s)
+              note <- N.parseNoteForModel parseContext r fpAbs (decodeUtf8 s)
               note' <- liftIO . evaluateWHNF . force $ noteF note
               pure $ Left note'
             UM.Delete -> do
@@ -105,11 +99,9 @@ patchLmlModels layers noteF storkIndexTVar scriptingEngine lmlType actions = do
 -- | Map a filesystem change to the corresponding model change.
 patchModel ::
   (MonadIO m, MonadLogger m, MonadLoggerIO m) =>
-  Set Loc ->
   (N.Note -> N.Note) ->
   Stork.IndexVar ->
-  -- | Lua scripting engine
-  ScriptingEngine ->
+  ParseContext ->
   -- | Type of the file being changed
   R.FileType R.SourceExt ->
   -- | Path to the file being changed
@@ -117,22 +109,12 @@ patchModel ::
   -- | Specific change to the file, along with its paths from other "layers"
   UM.FileAction (NonEmpty (Loc, FilePath)) ->
   m (ModelEma -> ModelEma)
-patchModel layers noteF storkIndexTVar scriptingEngine fpType fp action = do
-  logger <- askLoggerIO
-  now <- liftIO getCurrentTime
-  -- Prefix all patch logging with timestamp.
-  let newLogger loc src lvl s =
-        logger loc src lvl $ fromString (formatTime defaultTimeLocale "[%H:%M:%S] " now) <> s
-  runLoggingT (patchModel' layers noteF storkIndexTVar scriptingEngine fpType fp action) newLogger
+patchModel noteF storkIndexTVar parseContext fpType fp action =
+  patchModels noteF storkIndexTVar parseContext fpType (one (fp, action))
 
 -- | Map a filesystem change to the corresponding model change.
-patchModel' ::
+patchNonLmlModel ::
   (MonadIO m, MonadLogger m) =>
-  Set Loc ->
-  (N.Note -> N.Note) ->
-  Stork.IndexVar ->
-  -- | Lua scripting engine
-  ScriptingEngine ->
   -- | Type of the file being changed
   R.FileType R.SourceExt ->
   -- | Path to the file being changed
@@ -140,33 +122,10 @@ patchModel' ::
   -- | Specific change to the file, along with its paths from other "layers"
   UM.FileAction (NonEmpty (Loc, FilePath)) ->
   m (ModelEma -> ModelEma)
-patchModel' layers noteF storkIndexTVar scriptingEngine fpType fp action = do
+patchNonLmlModel fpType fp action = do
   case fpType of
-    R.LMLType lmlType -> do
-      case R.mkLMLRouteFromKnownFilePath lmlType fp of
-        Nothing ->
-          pure id -- Impossible
-        Just r -> do
-          -- Stork doesn't support incremental building of index, so we must
-          -- clear it to pave way for a rebuild later when requested.
-          --
-          -- From https://github.com/jameslittle230/stork/discussions/112#discussioncomment-252861
-          --
-          -- > Stork also doesn't support incremental index updates today --
-          -- you'd have to re-index everything when users added a new document,
-          -- which might be prohibitively long.
-          Stork.clearStorkIndex storkIndexTVar
-
-          case action of
-            UM.Refresh refreshAction overlays -> do
-              let fpAbs = head overlays
-              s <- readRefreshedFile refreshAction $ locResolve fpAbs
-              note <- N.parseNoteForModel scriptingEngine (userLayersToSearch layers) r fpAbs (decodeUtf8 s)
-              note' <- liftIO . evaluateWHNF . force $ noteF note
-              pure $ M.modelInsertNote note'
-            UM.Delete -> do
-              log $ "Removing note: " <> toText fp
-              pure $ M.modelDeleteNote r
+    R.LMLType _ ->
+      pure id
     R.Yaml ->
       case R.mkRouteFromFilePath' True fp of
         Nothing ->

--- a/emanote/src/Emanote/Source/Patch.hs
+++ b/emanote/src/Emanote/Source/Patch.hs
@@ -1,6 +1,7 @@
 -- | Patch model state depending on file change event.
 module Emanote.Source.Patch (
   patchModel,
+  patchModels,
   filePatterns,
   ignorePatterns,
 ) where
@@ -8,6 +9,7 @@ module Emanote.Source.Patch (
 import Control.Monad.Logger (LoggingT (runLoggingT), MonadLogger, MonadLoggerIO (askLoggerIO))
 import Data.ByteString qualified as BS
 import Data.List.NonEmpty qualified as NEL
+import Data.Map.Strict qualified as Map
 import Data.Time (defaultTimeLocale, formatTime, getCurrentTime)
 import Emanote.Model qualified as M
 import Emanote.Model.Note qualified as N
@@ -16,6 +18,7 @@ import Emanote.Model.StaticFile (readStaticFileInfo)
 import Emanote.Model.Stork.Index qualified as Stork
 import Emanote.Model.Type (ModelEma)
 import Emanote.Prelude (
+  chainM,
   log,
   logD,
   logE,
@@ -31,6 +34,73 @@ import System.UnionMount qualified as UM
 import Text.Pandoc.Scripting (ScriptingEngine)
 import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.Directory (doesDirectoryExist)
+
+patchModels ::
+  (MonadIO m, MonadLogger m, MonadLoggerIO m) =>
+  Set Loc ->
+  (N.Note -> N.Note) ->
+  Stork.IndexVar ->
+  -- | Lua scripting engine
+  ScriptingEngine ->
+  -- | Type of the files being changed
+  R.FileType R.SourceExt ->
+  Map FilePath (UM.FileAction (NonEmpty (Loc, FilePath))) ->
+  m (ModelEma -> ModelEma)
+patchModels layers noteF storkIndexTVar scriptingEngine fpType actions = do
+  logger <- askLoggerIO
+  now <- liftIO getCurrentTime
+  let newLogger loc src lvl s =
+        logger loc src lvl $ fromString (formatTime defaultTimeLocale "[%H:%M:%S] " now) <> s
+  runLoggingT (patchModels' layers noteF storkIndexTVar scriptingEngine fpType actions) newLogger
+
+patchModels' ::
+  (MonadIO m, MonadLogger m) =>
+  Set Loc ->
+  (N.Note -> N.Note) ->
+  Stork.IndexVar ->
+  -- | Lua scripting engine
+  ScriptingEngine ->
+  -- | Type of the files being changed
+  R.FileType R.SourceExt ->
+  Map FilePath (UM.FileAction (NonEmpty (Loc, FilePath))) ->
+  m (ModelEma -> ModelEma)
+patchModels' layers noteF storkIndexTVar scriptingEngine fpType actions =
+  case fpType of
+    R.LMLType lmlType ->
+      patchLmlModels layers noteF storkIndexTVar scriptingEngine lmlType actions
+    _ ->
+      uncurry (patchModel' layers noteF storkIndexTVar scriptingEngine fpType) `chainM` Map.toList actions
+
+patchLmlModels ::
+  (MonadIO m, MonadLogger m) =>
+  Set Loc ->
+  (N.Note -> N.Note) ->
+  Stork.IndexVar ->
+  -- | Lua scripting engine
+  ScriptingEngine ->
+  R.LML ->
+  Map FilePath (UM.FileAction (NonEmpty (Loc, FilePath))) ->
+  m (ModelEma -> ModelEma)
+patchLmlModels layers noteF storkIndexTVar scriptingEngine lmlType actions = do
+  unless (Map.null actions)
+    $ Stork.clearStorkIndex storkIndexTVar
+  (notes, deletes) <-
+    fmap partitionEithers $ forM (Map.toList actions) $ \(fp, action) -> do
+      case R.mkLMLRouteFromKnownFilePath lmlType fp of
+        Nothing ->
+          pure $ Right id
+        Just r ->
+          case action of
+            UM.Refresh refreshAction overlays -> do
+              let fpAbs = head overlays
+              s <- readRefreshedFile refreshAction $ locResolve fpAbs
+              note <- N.parseNoteForModel scriptingEngine (userLayersToSearch layers) r fpAbs (decodeUtf8 s)
+              note' <- liftIO . evaluateWHNF . force $ noteF note
+              pure $ Left note'
+            UM.Delete -> do
+              log $ "Removing note: " <> toText fp
+              pure $ Right $ M.modelDeleteNote r
+  pure $ foldr (>>>) (M.modelInsertNotes notes) deletes
 
 -- | Map a filesystem change to the corresponding model change.
 patchModel ::
@@ -91,8 +161,9 @@ patchModel' layers noteF storkIndexTVar scriptingEngine fpType fp action = do
             UM.Refresh refreshAction overlays -> do
               let fpAbs = head overlays
               s <- readRefreshedFile refreshAction $ locResolve fpAbs
-              note <- N.parseNote scriptingEngine (userLayersToSearch layers) r fpAbs (decodeUtf8 s)
-              pure $ M.modelInsertNote $ noteF note
+              note <- N.parseNoteForModel scriptingEngine (userLayersToSearch layers) r fpAbs (decodeUtf8 s)
+              note' <- liftIO . evaluateWHNF . force $ noteF note
+              pure $ M.modelInsertNote note'
             UM.Delete -> do
               log $ "Removing note: " <> toText fp
               pure $ M.modelDeleteNote r

--- a/emanote/src/Emanote/View/Export/Content.hs
+++ b/emanote/src/Emanote/View/Export/Content.hs
@@ -94,7 +94,7 @@ generateNoteHeader model note =
 -- | Read note content from file
 readNoteContent :: Note.Note -> IO (Maybe Text)
 readNoteContent note =
-  case Note._noteSource note of
+  case note ^. Note.noteSource of
     Nothing -> pure Nothing -- Note has no source file (auto-generated)
     Just locAndFile -> do
       let actualFilePath = locResolve locAndFile

--- a/emanote/src/Emanote/View/Feed.hs
+++ b/emanote/src/Emanote/View/Feed.hs
@@ -6,13 +6,13 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Optics (key, _String)
 import Emanote.Model (Model)
 import Emanote.Model.Meta (getEffectiveRouteMeta)
-import Emanote.Model.Note (Feed (..), Note (..), lookupMeta)
+import Emanote.Model.Note (Feed (..), Note (..), lookupMeta, noteDoc)
 import Emanote.Model.Query (Query, parseQuery, runQuery)
 import Emanote.Model.SData (lookupAeson)
 import Emanote.Model.Title (toPlain)
 import Emanote.Route.SiteRoute
 import Emanote.Route.SiteRoute.Class (noteFeedSiteRoute)
-import Optics.Operators ((^?))
+import Optics.Operators ((^.), (^?))
 import Optics.Optic ((%))
 import Relude
 import Text.Atom.Feed qualified as Atom
@@ -48,7 +48,7 @@ getNoteDate :: Note -> Atom.Date
 getNoteDate note = fromMaybe "1970-01-01" $ _noteMeta note ^? key "date" % _String
 
 getNoteQuery :: Note -> Either LText Query
-getNoteQuery note = case _noteDoc note of
+getNoteQuery note = case note ^. noteDoc of
   Pandoc _meta [] -> Left "empty note"
   Pandoc _meta blocks -> go blocks
   where

--- a/emanote/src/Emanote/View/Template.hs
+++ b/emanote/src/Emanote/View/Template.hs
@@ -220,11 +220,7 @@ renderLmlHtml model0 note0 = do
 
 parseNoteIfNeeded :: (MonadIO m, MonadLoggerIO m) => Model -> MN.Note -> m MN.Note
 parseNoteIfNeeded model =
-  case model ^. M.modelScriptingEngine of
-    Nothing ->
-      pure
-    Just scriptingEngine ->
-      MN.parseNoteIfNeeded scriptingEngine (model ^. M.modelPluginBaseDirs)
+  maybe pure MN.parseNoteIfNeeded (model ^. M.modelParseContext)
 
 parseEmbeddedNotesIfNeeded :: (MonadIO m, MonadLoggerIO m) => Model -> MN.Note -> m Model
 parseEmbeddedNotesIfNeeded model note =
@@ -236,9 +232,8 @@ parseEmbeddedNotesIfNeeded model note =
       let embeddedNotes =
             filter
               ( \embeddedNote ->
-                  embeddedNote
-                    ^. MN.noteNeedsFullParse
-                      && Set.notMember (embeddedNote ^. MN.noteRoute) seen
+                  isJust (MN.noteDeferred embeddedNote)
+                    && Set.notMember (embeddedNote ^. MN.noteRoute) seen
               )
               $ embeddedNotesFrom model' currentNote
       parsedNotes <- traverse (parseNoteIfNeeded model') embeddedNotes

--- a/emanote/src/Emanote/View/Template.hs
+++ b/emanote/src/Emanote/View/Template.hs
@@ -1,7 +1,9 @@
 module Emanote.View.Template (emanoteSiteOutput, render) where
 
+import Commonmark.Extensions.WikiLink qualified as WL
 import Control.Monad.Logger (MonadLoggerIO)
 import Data.Aeson.Types qualified as Aeson
+import Data.IxSet.Typed qualified as Ix
 import Data.List (partition)
 import Data.Map.Syntax ((##))
 import Data.Set qualified as Set
@@ -12,6 +14,8 @@ import Emanote.Model (Model, ModelEma)
 import Emanote.Model qualified as M
 import Emanote.Model.Calendar qualified as Calendar
 import Emanote.Model.Graph qualified as G
+import Emanote.Model.Link.Rel qualified as Rel
+import Emanote.Model.Link.Resolve qualified as Resolve
 import Emanote.Model.Meta qualified as Meta
 import Emanote.Model.Note qualified as MN
 import Emanote.Model.SData qualified as SData
@@ -74,35 +78,36 @@ render m = \case
             & setErrorPageMeta
             & MN.noteTitle
             .~ "! Missing link"
-    pure $ Ema.AssetGenerated Ema.Html $ renderLmlHtml m note404
+    Ema.AssetGenerated Ema.Html <$> renderLmlHtml m note404
   SR.SiteRoute_AmbiguousR urlPath notes -> do
     let noteAmb =
           MN.ambiguousNoteURL urlPath notes
             & setErrorPageMeta
             & MN.noteTitle
             .~ "! Ambiguous link"
-    pure $ Ema.AssetGenerated Ema.Html $ renderLmlHtml m noteAmb
-  SR.SiteRoute_ResourceRoute r -> pure $ renderResourceRoute m r
+    Ema.AssetGenerated Ema.Html <$> renderLmlHtml m noteAmb
+  SR.SiteRoute_ResourceRoute r -> renderResourceRoute m r
   SR.SiteRoute_VirtualRoute r -> renderVirtualRoute m r
   where
     setErrorPageMeta =
       MN.noteMeta .~ SData.mergeAesons (withTemplateName "/templates/error" :| [withSiteTitle "Emanote Error"])
 
-renderResourceRoute :: Model -> SR.ResourceRoute -> Ema.Asset LByteString
+renderResourceRoute :: (MonadIO m, MonadLoggerIO m) => Model -> SR.ResourceRoute -> m (Ema.Asset LByteString)
 renderResourceRoute m = \case
   SR.ResourceRoute_LML view r -> do
     case M.modelLookupNoteByRoute (view, r) m of
-      Just (R.LMLView_Html, note) ->
-        Ema.AssetGenerated Ema.Html $ renderLmlHtml m note
-      Just (R.LMLView_Atom, note) ->
-        case renderFeed m note of
+      Just (R.LMLView_Html, note) -> do
+        Ema.AssetGenerated Ema.Html <$> renderLmlHtml m note
+      Just (R.LMLView_Atom, note) -> do
+        note' <- parseNoteIfNeeded m note
+        case renderFeed m note' of
           Left err -> error $ toStrict $ "Bad feed: " <> show r <> ": " <> err
-          Right feed -> Ema.AssetGenerated Ema.Other feed
+          Right feed -> pure $ Ema.AssetGenerated Ema.Other feed
       Nothing ->
         -- This should never be reached because decodeRoute looks up the model.
         error $ "Bad route: " <> show r
   SR.ResourceRoute_StaticFile _ fpAbs ->
-    Ema.AssetStatic fpAbs
+    pure $ Ema.AssetStatic fpAbs
 
 renderVirtualRoute :: (MonadIO m, MonadLoggerIO m) => Model -> SR.VirtualRoute -> m (Ema.Asset LByteString)
 renderVirtualRoute m = \case
@@ -146,8 +151,10 @@ patchMeta meta =
   where
     siteUrl = SData.lookupAeson @Text "" ("page" :| ["siteUrl"]) meta
 
-renderLmlHtml :: Model -> MN.Note -> LByteString
-renderLmlHtml model note = do
+renderLmlHtml :: (MonadIO m, MonadLoggerIO m) => Model -> MN.Note -> m LByteString
+renderLmlHtml model0 note0 = do
+  note <- parseNoteIfNeeded model0 note0
+  model <- parseEmbeddedNotesIfNeeded model0 note
   let r = note ^. MN.noteRoute
       meta = patchMeta $ Meta.getEffectiveRouteMetaWith (note ^. MN.noteMeta) r model
       doc = prependDataErrors (Meta.cascadeYamlErrors model r) (note ^. MN.noteDoc)
@@ -161,7 +168,7 @@ renderLmlHtml model note = do
         if M.inLiveServer model && model ^. M.modelStatus == M.Status_Loading
           then (loaderHead <>)
           else id
-  withDoctype . withLoadingMessage . C.renderModelTemplate model (lookupTemplateName meta) $ do
+  pure $ withDoctype . withLoadingMessage . C.renderModelTemplate model (lookupTemplateName meta) $ do
     let ctx = C.mkTemplateRenderCtx model r meta
     C.commonSplices (C.withLinkInlineCtx ctx) model meta (note ^. MN.noteTitle)
     -- Template flags
@@ -211,6 +218,41 @@ renderLmlHtml model note = do
         $ \ctx' ->
           renderToc ctx' toc
 
+parseNoteIfNeeded :: (MonadIO m, MonadLoggerIO m) => Model -> MN.Note -> m MN.Note
+parseNoteIfNeeded model =
+  case model ^. M.modelScriptingEngine of
+    Nothing ->
+      pure
+    Just scriptingEngine ->
+      MN.parseNoteIfNeeded scriptingEngine (model ^. M.modelPluginBaseDirs)
+
+parseEmbeddedNotesIfNeeded :: (MonadIO m, MonadLoggerIO m) => Model -> MN.Note -> m Model
+parseEmbeddedNotesIfNeeded model note =
+  go Set.empty model [note]
+  where
+    go _ model' [] =
+      pure model'
+    go seen model' (currentNote : rest) = do
+      let embeddedNotes =
+            filter
+              ( \embeddedNote ->
+                  embeddedNote
+                    ^. MN.noteNeedsFullParse
+                      && Set.notMember (embeddedNote ^. MN.noteRoute) seen
+              )
+              $ embeddedNotesFrom model' currentNote
+      parsedNotes <- traverse (parseNoteIfNeeded model') embeddedNotes
+      let seen' = flipfoldl' Set.insert seen $ fmap (^. MN.noteRoute) embeddedNotes
+          model'' = M.modelInsertNotes parsedNotes model'
+      go seen' model'' (rest <> parsedNotes)
+
+    embeddedNotesFrom model' currentNote =
+      ordNubOn (^. MN.noteRoute) $ do
+        rel <- Ix.toList $ Rel.noteRels currentNote
+        Rel.URTWikiLink (WL.WikiLinkEmbed, wl) <- one $ rel ^. Rel.relTo
+        Rel.RRTFound (Left (_view, embeddedNote)) <- one $ Resolve.resolveWikiLinkMustExist model' (currentNote ^. MN.noteRoute) wl
+        pure embeddedNote
+
 backlinksSplice :: Model -> [(R.LMLRoute, NonEmpty [B.Block])] -> HI.Splice Identity
 backlinksSplice model (bs :: [(R.LMLRoute, NonEmpty [B.Block])]) =
   Splices.listSplice bs "backlink"
@@ -236,6 +278,8 @@ If there is no 'current route', all sub-trees are marked as active/open.
 -}
 routeTreeSplices :: (Monad n) => C.TemplateRenderCtx n -> Maybe R.LMLRoute -> Model -> H.Splices (HI.Splice Identity)
 routeTreeSplices tCtx mCurrentRoute model = do
+  let activeAncestorRoutes =
+        maybe Set.empty (Set.fromList . concatMap Tree.flatten . G.modelFolgezettelAncestorTree model) mCurrentRoute
   "ema:route-tree" ##
     Splices.treeSplice getOrder (model ^. M.modelFolgezettelTree)
       $ \(last -> nodeRoute) children -> do
@@ -247,10 +291,7 @@ routeTreeSplices tCtx mCurrentRoute model = do
               -- Active tree checking is applicable only when there is an
               -- active route (i.e., mr is a Just)
               flip (maybe True) mCurrentRoute $ \r ->
-                -- FIXME: Performance! (exponential complexity)
-                let folgeAnc = Set.fromList $ concatMap Tree.flatten $ G.modelFolgezettelAncestorTree model r
-                    isFolgeAnc = Set.member nodeRoute folgeAnc
-                 in r == nodeRoute || isFolgeAnc
+                r == nodeRoute || Set.member nodeRoute activeAncestorRoutes
             openTree =
               isActiveTree -- Active tree is always open
                 || not (getCollapsed nodeRoute)

--- a/emanote/test/Emanote/Model/NoteSpec.hs
+++ b/emanote/test/Emanote/Model/NoteSpec.hs
@@ -18,8 +18,8 @@ spec = do
     it "keeps simple Markdown shallow while preserving title, tags, and wikilinks" $ do
       let note = parseSimpleNote "note.md" simpleMarkdown
 
-      note ^. MN.noteNeedsFullParse `shouldBe` True
-      note ^. MN.noteSourceText `shouldBe` Just simpleMarkdown
+      isJust (MN.noteDeferred note) `shouldBe` True
+      fmap (^. MN.deferredNoteText) (MN.noteDeferred note) `shouldBe` Just simpleMarkdown
       Tit.toPlain (note ^. MN.noteTitle) `shouldBe` "Note title"
       MN.noteTags note
         `shouldMatchList` [ TT.Tag "frontmatter"
@@ -31,6 +31,17 @@ spec = do
                           , Rel.URTWikiLink (WL.WikiLinkTag, wiki "tagged")
                           , Rel.URTWikiLink (WL.WikiLinkBranch, wiki "child")
                           ]
+
+    it "deduplicates repeated simple Markdown wikilink targets in the startup model" $ do
+      let markdown = "# Note title\nFirst [[target]].\nSecond [[target]].\n"
+          note = parseSimpleNote "note.md" markdown
+
+      fmap (^. Rel.relTo) (Ix.toList $ Rel.noteRels note)
+        `shouldBe` [Rel.URTWikiLink (WL.WikiLinkNormal, wiki "target")]
+      fmap (^. Rel.relTo) (Ix.toList $ Rel.noteTextRels note markdown)
+        `shouldBe` [ Rel.URTWikiLink (WL.WikiLinkNormal, wiki "target")
+                   , Rel.URTWikiLink (WL.WikiLinkNormal, wiki "target")
+                   ]
 
     it "leaves Markdown requiring full document semantics to the full parser" $ do
       MN.parseSimpleMarkdownNote (route "linked.md") (source "linked.md") "# Title\n[x](https://example.com)\n"

--- a/emanote/test/Emanote/Model/NoteSpec.hs
+++ b/emanote/test/Emanote/Model/NoteSpec.hs
@@ -1,0 +1,79 @@
+module Emanote.Model.NoteSpec where
+
+import Commonmark.Extensions.WikiLink qualified as WL
+import Data.IxSet.Typed qualified as Ix
+import Data.TagTree qualified as TT
+import Emanote.Model.Link.Rel qualified as Rel
+import Emanote.Model.Note qualified as MN
+import Emanote.Model.Title qualified as Tit
+import Emanote.Route qualified as R
+import Emanote.Source.Loc (Loc (LocUser))
+import Optics.Operators ((^.))
+import Relude
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "parseSimpleMarkdownNote" $ do
+    it "keeps simple Markdown shallow while preserving title, tags, and wikilinks" $ do
+      let note = parseSimpleNote "note.md" simpleMarkdown
+
+      note ^. MN.noteNeedsFullParse `shouldBe` True
+      note ^. MN.noteSourceText `shouldBe` Just simpleMarkdown
+      Tit.toPlain (note ^. MN.noteTitle) `shouldBe` "Note title"
+      MN.noteTags note
+        `shouldMatchList` [ TT.Tag "frontmatter"
+                          , TT.Tag "body-tag"
+                          , TT.Tag "nested/tag"
+                          ]
+      fmap (^. Rel.relTo) (Ix.toList $ Rel.noteRels note)
+        `shouldMatchList` [ Rel.URTWikiLink (WL.WikiLinkNormal, wiki "target")
+                          , Rel.URTWikiLink (WL.WikiLinkTag, wiki "tagged")
+                          , Rel.URTWikiLink (WL.WikiLinkBranch, wiki "child")
+                          ]
+
+    it "leaves Markdown requiring full document semantics to the full parser" $ do
+      MN.parseSimpleMarkdownNote (route "linked.md") (source "linked.md") "# Title\n[x](https://example.com)\n"
+        `shouldBe` Nothing
+      MN.parseSimpleMarkdownNote (route "reference.md") (source "reference.md") "# Title\n[x][ref]\n\n[ref]: other.md\n"
+        `shouldBe` Nothing
+      MN.parseSimpleMarkdownNote (route "task.md") (source "task.md") "# Title\n- [ ] task\n"
+        `shouldBe` Nothing
+      MN.parseSimpleMarkdownNote (route "filtered.md") (source "filtered.md") filteredMarkdown
+        `shouldBe` Nothing
+  where
+    simpleMarkdown =
+      unlines
+        [ "---"
+        , "tags: [frontmatter]"
+        , "---"
+        , "# Note title"
+        , "Body #body-tag #nested/tag links to [[target|Target]], #[[tagged]], and [[child]]#."
+        ]
+
+    filteredMarkdown =
+      unlines
+        [ "---"
+        , "pandoc:"
+        , "  filters: [filter.lua]"
+        , "---"
+        , "# Title"
+        ]
+
+parseSimpleNote :: FilePath -> Text -> MN.Note
+parseSimpleNote fp body =
+  fromMaybe (error "expected simple Markdown note")
+    $ MN.parseSimpleMarkdownNote (route fp) (source fp) body
+
+route :: FilePath -> R.LMLRoute
+route fp =
+  fromMaybe (error $ "bad route: " <> toText fp)
+    $ R.mkLMLRouteFromKnownFilePath R.Md fp
+
+source :: FilePath -> (Loc, FilePath)
+source fp =
+  (LocUser 1 "/tmp/emanote-test" Nothing, fp)
+
+wiki :: Text -> WL.WikiLink
+wiki slug =
+  WL.mkWikiLinkFromSlugs (fromString (toString slug) :| [])

--- a/measurements/issue-66-memory.md
+++ b/measurements/issue-66-memory.md
@@ -1,0 +1,66 @@
+# Issue 66 memory measurements
+
+This file tracks measurements for [issue #66](https://github.com/srid/emanote/issues/66).
+
+## Reported issue facts
+
+The GitHub issue reports:
+
+- Notebook size: 69M.
+- Markdown file count: 4561.
+- Startup load time: about 1 minute.
+- Resident memory: about 4.7 GB.
+
+## Local environment
+
+- Machine: AMD Ryzen 7 8845HS, 16 logical CPUs.
+- OS source for RSS: `/proc/$PID/status`, field `VmRSS`.
+- Measurement cadence: 1 sample per second.
+- The temporary notebooks were generated under `/tmp` and removed/recreated for each run.
+- Python, curl, and shell tooling came from `nix develop`.
+
+## Workload
+
+The current local workload is smaller than the issue reporter's notebook but large enough to reproduce more than 1 GiB resident memory:
+
+- Markdown file count: 2401 (`index.md` plus 2400 notes).
+- Notebook size on disk: 19M.
+- Startup content: every note has YAML front matter, repeated Markdown, code fences, tags, and six wikilinks.
+- Update phase: 3 rounds, 240 rewritten notes per round, 720 rewritten notes total.
+- Server command shape:
+
+```sh
+emanote --allow-broken-internal-links -L "$NB" run --host 127.0.0.1 --port "$PORT"
+```
+
+## Runs so far
+
+| Run | Binary | RTS | Startup readiness | First idle RSS | Peak RSS | Peak phase | Final RSS | Notes |
+| --- | --- | --- | --- | ---: | ---: | --- | ---: | --- |
+| Baseline | `/nix/store/rym5k9jidv5rrgg59b0cxkljr5r314wh-emanote-1.6.0.0/bin/emanote` | default `-N` | first idle sample at 42s; exact curl-success timestamp was not captured | 1244.6 MiB | 1293.3 MiB | final-idle | 1293.3 MiB | `/tmp/emanote-issue66-baseline-1g-v2/rss.tsv` |
+| Strict-note-force patch | `/nix/store/pmy698y05hkn1bqkv0s6m744ap6i04hf-emanote-1.6.0.0/bin/emanote` | default `-N` | 26s | 1231.0 MiB | 1283.5 MiB | update-round-3 | 1283.5 MiB | `/tmp/emanote-issue66-fixed-1g-v2/rss.tsv` |
+| Strict-note-force patch | `/nix/store/pmy698y05hkn1bqkv0s6m744ap6i04hf-emanote-1.6.0.0/bin/emanote` | `+RTS -N1 -RTS` | 24s | 1216.3 MiB | 1216.3 MiB | update-round-3 | 1216.3 MiB | `/tmp/emanote-issue66-fixed-n1/rss.tsv` |
+
+## Current factual conclusions
+
+- The local reproduction crossed 1 GiB RSS: the baseline run peaked at 1293.3 MiB.
+- The local reproduction includes updates, not only startup: 720 notes were rewritten after the server became ready.
+- The first strictness patch does compile and slightly changes the measured RSS on this workload, but it does not make Emanote slim. Baseline peak was 1293.3 MiB; strict-note-force peak with default RTS was 1283.5 MiB.
+- Running with one RTS capability reduced peak RSS to 1216.3 MiB on the strict-note-force binary, which is still above 1 GiB for this workload.
+- The next decision needs heap profile data. The strictness patch alone is not enough evidence for a real fix.
+
+## Profiling plan
+
+The profiling executable was built with:
+
+```sh
+nix develop -c cabal build exe:emanote --enable-profiling --enable-library-profiling --ghc-options='-fprof-auto -rtsopts'
+```
+
+Next measurements to add:
+
+- Heap profile by cost centre on the 2401-file workload.
+- Heap profile by closure type on the same workload.
+- Exact baseline startup readiness time from a rerun that records the curl-success timestamp.
+- Before/after RSS and startup time after any code change justified by the heap profile.
+

--- a/measurements/issue-66-memory.md
+++ b/measurements/issue-66-memory.md
@@ -16,31 +16,55 @@ The GitHub issue reports:
 - Machine: AMD Ryzen 7 8845HS, 16 logical CPUs.
 - OS source for RSS: `/proc/$PID/status`, field `VmRSS`.
 - Measurement cadence: 1 sample per second.
-- The temporary notebooks were generated under `/tmp` and removed/recreated for each run.
-- Python, curl, and shell tooling came from `nix develop`.
-
-## Workload
-
-The current local workload is smaller than the issue reporter's notebook but large enough to reproduce more than 1 GiB resident memory:
-
-- Markdown file count: 2401 (`index.md` plus 2400 notes).
-- Notebook size on disk: 19M.
-- Startup content: every note has YAML front matter, repeated Markdown, code fences, tags, and six wikilinks.
-- Update phase: 3 rounds, 240 rewritten notes per round, 720 rewritten notes total.
+- Python, curl-equivalent HTTP requests, and shell tooling came from `nix develop`.
 - Server command shape:
 
 ```sh
 emanote --allow-broken-internal-links -L "$NB" run --host 127.0.0.1 --port "$PORT"
 ```
 
-## Runs so far
+## Workloads
 
-| Run | Binary | RTS | Startup readiness | First idle RSS | Peak RSS | Peak phase | Final RSS | Notes |
-| --- | --- | --- | --- | ---: | ---: | --- | ---: | --- |
-| Baseline | `/nix/store/rym5k9jidv5rrgg59b0cxkljr5r314wh-emanote-1.6.0.0/bin/emanote` | default `-N` | first idle sample at 42s; exact curl-success timestamp was not captured | 1244.6 MiB | 1293.3 MiB | final-idle | 1293.3 MiB | `/tmp/emanote-issue66-baseline-1g-v2/rss.tsv` |
-| Strict-note-force patch | `/nix/store/pmy698y05hkn1bqkv0s6m744ap6i04hf-emanote-1.6.0.0/bin/emanote` | default `-N` | 26s | 1231.0 MiB | 1283.5 MiB | update-round-3 | 1283.5 MiB | `/tmp/emanote-issue66-fixed-1g-v2/rss.tsv` |
-| Strict-note-force patch | `/nix/store/pmy698y05hkn1bqkv0s6m744ap6i04hf-emanote-1.6.0.0/bin/emanote` | `+RTS -N1 -RTS` | 24s | 1216.3 MiB | 1216.3 MiB | update-round-3 | 1216.3 MiB | `/tmp/emanote-issue66-fixed-n1/rss.tsv` |
-| Per-note compacted `Pandoc` experiment | `/nix/store/viw7fvfd0255wx8ap07qd2dc4hj343ig-emanote-1.6.0.0/bin/emanote` | default `-N` | not used as candidate | not used as candidate | 12601.0 MiB before manual kill | update-round-2 | not recorded | `/tmp/emanote-issue66-compact-v1/rss.tsv`; rejected because RSS became much worse |
+Two generated notebooks were used:
+
+| Workload | Markdown files | Size on disk | Update phase |
+| --- | ---: | ---: | --- |
+| Local reproduction | 2401 (`index.md` plus 2400 notes) | 19M | 3 rounds, 240 rewritten notes per round, 720 rewrites total |
+| Issue-sized check | 4561 (`index.md` plus 4560 notes) | 72M | 3 rounds, 456 rewritten notes per round, 1368 rewrites total |
+
+Each note has YAML front matter, repeated Markdown text, inline tags, blockquotes, and six wikilinks. `index.md` links to every note so root rendering exercises the full route tree and title lookup path.
+
+## RSS and startup results
+
+![Peak RSS comparison](https://quickchart.io/chart?c=%7Btype%3A%27bar%27%2Cdata%3A%7Blabels%3A%5B%27Baseline%202401%20timeout%27%2C%27Fixed%202401%27%2C%27Fixed%204561%2F72M%27%5D%2Cdatasets%3A%5B%7Blabel%3A%27Peak%20RSS%20MiB%27%2Cdata%3A%5B1478.5%2C448.7%2C697.7%5D%7D%5D%7D%7D)
+
+| Run | Binary | Workload | Startup readiness | First idle RSS | First `/` render | Peak RSS | Peak phase | Final RSS | Raw data |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- | ---: | --- |
+| Baseline reproduction | `/nix/store/rym5k9jidv5rrgg59b0cxkljr5r314wh-emanote-1.6.0.0/bin/emanote` | 2401 files, 19M | no response before 300s timeout | not reached | not reached | 1478.5 MiB | startup | not reached | `/tmp/emanote-issue66-baseline-current-harness-v1/rss.tsv` |
+| Fixed | `/nix/store/f79k867pp1brmrjhrrdvix98sd3lk5lc-emanote-1.6.0.0/bin/emanote` | 2401 files, 19M | 2s | 326.4 MiB | 2.287s / 6389899 bytes | 448.7 MiB | final-idle | 448.7 MiB | `/tmp/emanote-issue66-final-2401-v3/rss.tsv` |
+| Fixed, issue-sized | `/nix/store/f79k867pp1brmrjhrrdvix98sd3lk5lc-emanote-1.6.0.0/bin/emanote` | 4561 files, 72M | 6s | 581.4 MiB | 5.592s / 12107419 bytes | 697.7 MiB | final-idle | 697.7 MiB | `/tmp/emanote-issue66-final-4561-69m-v3/rss.tsv` |
+
+Earlier baseline runs also reproduced the >1 GiB condition:
+
+| Run | Binary | Workload | Startup readiness | First idle RSS | Peak RSS | Raw data |
+| --- | --- | --- | ---: | ---: | ---: | --- |
+| Baseline | `/nix/store/rym5k9jidv5rrgg59b0cxkljr5r314wh-emanote-1.6.0.0/bin/emanote` | 2401 files, 19M | first idle sample at 42s; exact curl-success timestamp was not captured | 1244.6 MiB | 1293.3 MiB | `/tmp/emanote-issue66-baseline-1g-v2/rss.tsv` |
+| Strict-note-force only | `/nix/store/pmy698y05hkn1bqkv0s6m744ap6i04hf-emanote-1.6.0.0/bin/emanote` | 2401 files, 19M | 26s | 1231.0 MiB | 1283.5 MiB | `/tmp/emanote-issue66-fixed-1g-v2/rss.tsv` |
+
+## Output integrity checks
+
+The issue-sized fixed run was checked after measurement with the same generated 4561-file notebook:
+
+| Check | Result |
+| --- | ---: |
+| Readiness | 6s |
+| Unique `note-NNNN` tokens in rendered `/` | 4560 |
+| Rendered `/` contains `note-0001` | True |
+| Rendered `/` contains `note-4560` | True |
+| Rendered `/` bytes | 12107419 |
+| Rendered `/note-0001` has heading | True |
+| Rendered `/note-0001` has body text | True |
+| Rendered `/note-0001` bytes | 4978447 |
 
 ## Heap profile
 
@@ -50,7 +74,7 @@ The profiling executable was built with:
 nix develop -c cabal build exe:emanote --enable-profiling --enable-library-profiling --ghc-options='-fprof-auto -rtsopts'
 ```
 
-The profiled workload used the same 2401-file notebook shape as the RSS runs above. The readiness probe requested `/`, so render/index work is present in the cost-centre profile.
+The profiled workload used the same 2401-file notebook shape as the RSS runs. The readiness probe requested `/`, so render/index work is present in the cost-centre profile.
 
 | Profile | Path | Startup readiness | Profiler RSS peak | Sampled heap peak | Peak sample time |
 | --- | --- | ---: | ---: | ---: | ---: |
@@ -87,14 +111,34 @@ Top closure-type entries at the 382.2 MiB sampled-heap peak:
 | 4.7 MiB | `SMALL_MUT_ARR_PTRS_FROZEN_CLEAN` |
 | 3.8 MiB | `Map` |
 
-The profile does not support treating laziness alone as the root cause: forcing parsed notes reduced RSS by only 9.8 MiB on the default-RTS run. The sampled heap is dominated by retained `List`, `Text`, `ARR_WORDS`, and `Inline` payloads produced by parsing, link traversal, and rendering paths. The next code experiment should therefore reduce retained Pandoc/link-context payload and then re-measure with the same workload.
+## Code changes made
+
+The fix avoids retaining full Pandoc documents for simple Markdown notes at model-build time. A simple Markdown note now stores route, title, metadata, tags, source text, and lightweight wikilink relations; the full Pandoc parse is deferred until that note is rendered.
+
+Other code changes:
+
+- Batch model updates for groups of changed LML files so `modelNotes`, `modelRels`, and `modelTasks` are replaced together.
+- Build folgezettel child adjacency once per tree construction instead of scanning relations for every node.
+- Compute the active folgezettel ancestor set once per route-tree render.
+- Enable only the Markdown syntax extensions whose marker text appears in the document.
+- Fully parse lazy notes before rendering HTML, Atom feeds, and embedded-note templates, including nested embeds.
+
+## Experiments rejected
+
+These were measured and not used as the final fix:
+
+| Experiment | Result |
+| --- | --- |
+| Force parsed notes with `NFData` only | Peak RSS changed from 1293.3 MiB to 1283.5 MiB on the earlier 2401-file workload. This did not materially fix the issue. |
+| Per-note `GHC.Compact` storage | Reached 12601.0 MiB RSS during update-round-2 before manual kill: `/tmp/emanote-issue66-compact-v1/rss.tsv`. |
+| Drop retained backlink context only | Peak/final 1332.8 MiB: `/tmp/emanote-issue66-no-relctx-v2/rss.tsv`. |
+| Drop stored note body only | Peak/final 1424.6 MiB: `/tmp/emanote-issue66-drop-doc-v1/rss.tsv`. |
+| Drop stored note body and backlink context | Peak/final 1333.2 MiB: `/tmp/emanote-issue66-drop-doc-no-relctx-v1/rss.tsv`. |
+| RTS `-N1 -c` controls | Reduced RSS in some runs, but this PR does not rely on RTS defaults as the fix. |
 
 ## Current factual conclusions
 
-- The local reproduction crossed 1 GiB RSS: the baseline run peaked at 1293.3 MiB.
-- The local reproduction includes updates, not only startup: 720 notes were rewritten after the server became ready.
-- The first strictness patch does compile and slightly changes the measured RSS on this workload, but it does not make Emanote slim. Baseline peak was 1293.3 MiB; strict-note-force peak with default RTS was 1283.5 MiB.
-- Running with one RTS capability reduced peak RSS to 1216.3 MiB on the strict-note-force binary, which is still above 1 GiB for this workload.
-- Per-note `GHC.Compact` storage is not viable for this workload: that experiment reached 12601.0 MiB RSS during update-round-2 before it was killed.
-- Exact baseline startup readiness time still needs a rerun that records the curl-success timestamp.
-- Before/after RSS and startup time must be rerun after any code change justified by the heap profile.
+- The memory issue was reproduced locally above 1 GiB RSS: the baseline reached 1478.5 MiB while still in startup on the same 2401-file generated notebook, and an earlier baseline run peaked at 1293.3 MiB.
+- Heap profiling showed the retained heap was dominated by `List`, `Text`, `ARR_WORDS`, and `Inline` values from Pandoc parsing/link traversal/rendering, not by a laziness-only leak.
+- The code-level lazy model parse reduced the 2401-file workload from a baseline that failed to answer before 300s to 2s readiness and 448.7 MiB peak RSS.
+- On the issue-sized 4561-file, 72M generated notebook, the fixed binary reached readiness in 6s and peaked at 697.7 MiB after 1368 note rewrites.

--- a/measurements/issue-66-memory.md
+++ b/measurements/issue-66-memory.md
@@ -40,16 +40,9 @@ emanote --allow-broken-internal-links -L "$NB" run --host 127.0.0.1 --port "$POR
 | Baseline | `/nix/store/rym5k9jidv5rrgg59b0cxkljr5r314wh-emanote-1.6.0.0/bin/emanote` | default `-N` | first idle sample at 42s; exact curl-success timestamp was not captured | 1244.6 MiB | 1293.3 MiB | final-idle | 1293.3 MiB | `/tmp/emanote-issue66-baseline-1g-v2/rss.tsv` |
 | Strict-note-force patch | `/nix/store/pmy698y05hkn1bqkv0s6m744ap6i04hf-emanote-1.6.0.0/bin/emanote` | default `-N` | 26s | 1231.0 MiB | 1283.5 MiB | update-round-3 | 1283.5 MiB | `/tmp/emanote-issue66-fixed-1g-v2/rss.tsv` |
 | Strict-note-force patch | `/nix/store/pmy698y05hkn1bqkv0s6m744ap6i04hf-emanote-1.6.0.0/bin/emanote` | `+RTS -N1 -RTS` | 24s | 1216.3 MiB | 1216.3 MiB | update-round-3 | 1216.3 MiB | `/tmp/emanote-issue66-fixed-n1/rss.tsv` |
+| Per-note compacted `Pandoc` experiment | `/nix/store/viw7fvfd0255wx8ap07qd2dc4hj343ig-emanote-1.6.0.0/bin/emanote` | default `-N` | not used as candidate | not used as candidate | 12601.0 MiB before manual kill | update-round-2 | not recorded | `/tmp/emanote-issue66-compact-v1/rss.tsv`; rejected because RSS became much worse |
 
-## Current factual conclusions
-
-- The local reproduction crossed 1 GiB RSS: the baseline run peaked at 1293.3 MiB.
-- The local reproduction includes updates, not only startup: 720 notes were rewritten after the server became ready.
-- The first strictness patch does compile and slightly changes the measured RSS on this workload, but it does not make Emanote slim. Baseline peak was 1293.3 MiB; strict-note-force peak with default RTS was 1283.5 MiB.
-- Running with one RTS capability reduced peak RSS to 1216.3 MiB on the strict-note-force binary, which is still above 1 GiB for this workload.
-- The next decision needs heap profile data. The strictness patch alone is not enough evidence for a real fix.
-
-## Profiling plan
+## Heap profile
 
 The profiling executable was built with:
 
@@ -57,10 +50,51 @@ The profiling executable was built with:
 nix develop -c cabal build exe:emanote --enable-profiling --enable-library-profiling --ghc-options='-fprof-auto -rtsopts'
 ```
 
-Next measurements to add:
+The profiled workload used the same 2401-file notebook shape as the RSS runs above. The readiness probe requested `/`, so render/index work is present in the cost-centre profile.
 
-- Heap profile by cost centre on the 2401-file workload.
-- Heap profile by closure type on the same workload.
-- Exact baseline startup readiness time from a rerun that records the curl-success timestamp.
-- Before/after RSS and startup time after any code change justified by the heap profile.
+| Profile | Path | Startup readiness | Profiler RSS peak | Sampled heap peak | Peak sample time |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Cost centre (`-hc -i1 -p`) | `/tmp/emanote-issue66-prof-current-hc/emanote.hp` | not separately recorded | 1868.6 MiB | 383.0 MiB | 61.51s |
+| Closure type (`-hy -i1 -p`) | `/tmp/emanote-issue66-prof-current-hy/emanote.hp` | 67s | 1893.5 MiB | 382.2 MiB | 61.51s |
 
+Top cost-centre entries at the 383.0 MiB sampled-heap peak:
+
+| Sampled heap | Cost centre label |
+| ---: | --- |
+| 80.6 MiB | `(7041)walkBlockM/walkPandoc...` |
+| 65.9 MiB | `(6159)text/defaultInlinePar...` |
+| 20.9 MiB | `(8629)hashTag/hashTagSpec...` |
+| 16.6 MiB | `(12221)rawApply/applyNodes...` |
+| 15.2 MiB | `(4876)normalize/tokenize...` |
+| 14.8 MiB | `(7050)walkInlineM/walkBlock...` |
+| 12.7 MiB | `(6707)wikilinkInline/wikilink...` |
+| 9.2 MiB | `(7900)unChunks/mkInlinePars...` |
+| 8.6 MiB | `(9007)hashTag.classes/hashTag...` |
+| 8.6 MiB | `(9015)linkifyInlineTags...` |
+
+Top closure-type entries at the 382.2 MiB sampled-heap peak:
+
+| Sampled heap | Closure type |
+| ---: | --- |
+| 139.7 MiB | `List` |
+| 79.7 MiB | `Text` |
+| 53.2 MiB | `ARR_WORDS` |
+| 34.9 MiB | `Inline` |
+| 13.1 MiB | `Tuple2` |
+| 11.6 MiB | `HeistState` |
+| 8.3 MiB | `->List` |
+| 8.1 MiB | `Tuple3` |
+| 4.7 MiB | `SMALL_MUT_ARR_PTRS_FROZEN_CLEAN` |
+| 3.8 MiB | `Map` |
+
+The profile does not support treating laziness alone as the root cause: forcing parsed notes reduced RSS by only 9.8 MiB on the default-RTS run. The sampled heap is dominated by retained `List`, `Text`, `ARR_WORDS`, and `Inline` payloads produced by parsing, link traversal, and rendering paths. The next code experiment should therefore reduce retained Pandoc/link-context payload and then re-measure with the same workload.
+
+## Current factual conclusions
+
+- The local reproduction crossed 1 GiB RSS: the baseline run peaked at 1293.3 MiB.
+- The local reproduction includes updates, not only startup: 720 notes were rewritten after the server became ready.
+- The first strictness patch does compile and slightly changes the measured RSS on this workload, but it does not make Emanote slim. Baseline peak was 1293.3 MiB; strict-note-force peak with default RTS was 1283.5 MiB.
+- Running with one RTS capability reduced peak RSS to 1216.3 MiB on the strict-note-force binary, which is still above 1 GiB for this workload.
+- Per-note `GHC.Compact` storage is not viable for this workload: that experiment reached 12601.0 MiB RSS during update-round-2 before it was killed.
+- Exact baseline startup readiness time still needs a rerun that records the curl-success timestamp.
+- Before/after RSS and startup time must be rerun after any code change justified by the heap profile.

--- a/measurements/issue-66-memory.md
+++ b/measurements/issue-66-memory.md
@@ -17,6 +17,7 @@ The GitHub issue reports:
 - OS source for RSS: `/proc/$PID/status`, field `VmRSS`.
 - Measurement cadence: 1 sample per second.
 - Python, curl-equivalent HTTP requests, and shell tooling came from `nix develop`.
+- Nix store paths in the result tables identify the exact executables measured; later report-only edits can produce a different store path without changing the measured Haskell code.
 - Server command shape:
 
 ```sh
@@ -29,20 +30,20 @@ Two generated notebooks were used:
 
 | Workload | Markdown files | Size on disk | Update phase |
 | --- | ---: | ---: | --- |
-| Local reproduction | 2401 (`index.md` plus 2400 notes) | 19M | 3 rounds, 240 rewritten notes per round, 720 rewrites total |
-| Issue-sized check | 4561 (`index.md` plus 4560 notes) | 72M | 3 rounds, 456 rewritten notes per round, 1368 rewrites total |
+| Local reproduction | 2401 (`index.md` plus 2400 notes) | 18M / 17.74 MiB | 3 rounds, 240 rewritten notes per round, 720 rewrites total |
+| Issue-sized check | 4561 (`index.md` plus 4560 notes) | 82M / 81.65 MiB | 3 rounds, 456 rewritten notes per round, 1368 rewrites total |
 
 Each note has YAML front matter, repeated Markdown text, inline tags, blockquotes, and six wikilinks. `index.md` links to every note so root rendering exercises the full route tree and title lookup path.
 
 ## RSS and startup results
 
-![Peak RSS comparison](https://quickchart.io/chart?c=%7Btype%3A%27bar%27%2Cdata%3A%7Blabels%3A%5B%27Baseline%202401%20timeout%27%2C%27Fixed%202401%27%2C%27Fixed%204561%2F72M%27%5D%2Cdatasets%3A%5B%7Blabel%3A%27Peak%20RSS%20MiB%27%2Cdata%3A%5B1478.5%2C448.7%2C697.7%5D%7D%5D%7D%7D)
+![Peak RSS comparison](https://quickchart.io/chart?c=%7Btype%3A%27bar%27%2Cdata%3A%7Blabels%3A%5B%27Baseline%202401%20timeout%27%2C%27Fixed%202401%27%2C%27Fixed%204561%2F82M%27%5D%2Cdatasets%3A%5B%7Blabel%3A%27Peak%20RSS%20MiB%27%2Cdata%3A%5B1478.5%2C457.3%2C752.2%5D%7D%5D%7D%7D)
 
 | Run | Binary | Workload | Startup readiness | First idle RSS | First `/` render | Peak RSS | Peak phase | Final RSS | Raw data |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | ---: | --- |
 | Baseline reproduction | `/nix/store/rym5k9jidv5rrgg59b0cxkljr5r314wh-emanote-1.6.0.0/bin/emanote` | 2401 files, 19M | no response before 300s timeout | not reached | not reached | 1478.5 MiB | startup | not reached | `/tmp/emanote-issue66-baseline-current-harness-v1/rss.tsv` |
-| Fixed | `/nix/store/f79k867pp1brmrjhrrdvix98sd3lk5lc-emanote-1.6.0.0/bin/emanote` | 2401 files, 19M | 2s | 326.4 MiB | 2.287s / 6389899 bytes | 448.7 MiB | final-idle | 448.7 MiB | `/tmp/emanote-issue66-final-2401-v3/rss.tsv` |
-| Fixed, issue-sized | `/nix/store/f79k867pp1brmrjhrrdvix98sd3lk5lc-emanote-1.6.0.0/bin/emanote` | 4561 files, 72M | 6s | 581.4 MiB | 5.592s / 12107419 bytes | 697.7 MiB | final-idle | 697.7 MiB | `/tmp/emanote-issue66-final-4561-69m-v3/rss.tsv` |
+| Fixed | `/nix/store/g3xnnpa6llqz509rs5g2wil4vaqj0zzj-emanote-1.6.0.0/bin/emanote` | 2401 files, 18M | 3.583s | 387.3 MiB | 2.571s / 4240221 bytes | 457.3 MiB | final-idle | 457.3 MiB | `/tmp/emanote-issue66-final-2401-v8/rss.tsv` |
+| Fixed, issue-sized | `/nix/store/g3xnnpa6llqz509rs5g2wil4vaqj0zzj-emanote-1.6.0.0/bin/emanote` | 4561 files, 82M | 9.690s | 703.4 MiB | 7.688s / 8007261 bytes | 752.2 MiB | final-idle | 752.1 MiB | `/tmp/emanote-issue66-final-4561-69m-v8/rss.tsv` |
 
 Earlier baseline runs also reproduced the >1 GiB condition:
 
@@ -57,14 +58,14 @@ The issue-sized fixed run was checked after measurement with the same generated 
 
 | Check | Result |
 | --- | ---: |
-| Readiness | 6s |
+| Readiness | 9.690s |
 | Unique `note-NNNN` tokens in rendered `/` | 4560 |
 | Rendered `/` contains `note-0001` | True |
 | Rendered `/` contains `note-4560` | True |
-| Rendered `/` bytes | 12107419 |
+| Rendered `/` bytes | 8007261 |
 | Rendered `/note-0001` has heading | True |
 | Rendered `/note-0001` has body text | True |
-| Rendered `/note-0001` bytes | 4978447 |
+| Rendered `/note-0001` bytes | 5077695 |
 
 ## Heap profile
 
@@ -113,11 +114,12 @@ Top closure-type entries at the 382.2 MiB sampled-heap peak:
 
 ## Code changes made
 
-The fix avoids retaining full Pandoc documents for simple Markdown notes at model-build time. A simple Markdown note now stores route, title, metadata, tags, source text, and lightweight wikilink relations; the full Pandoc parse is deferred until that note is rendered.
+The fix avoids retaining full Pandoc documents for simple Markdown notes at model-build time. A simple Markdown note now stores route, title, metadata, tags, source text, and one representative wikilink relation per unresolved target. The full Pandoc parse is deferred until the note is rendered, and backlink pages recover repeated deferred-note contexts from the stored source text on demand.
 
 Other code changes:
 
 - Batch model updates for groups of changed LML files so `modelNotes`, `modelRels`, and `modelTasks` are replaced together.
+- Replace the ad hoc lazy-note fields with explicit `NoteBody`, `DeferredNote`, and `ParseContext` types.
 - Build folgezettel child adjacency once per tree construction instead of scanning relations for every node.
 - Compute the active folgezettel ancestor set once per route-tree render.
 - Enable only the Markdown syntax extensions whose marker text appears in the document.
@@ -134,11 +136,14 @@ These were measured and not used as the final fix:
 | Drop retained backlink context only | Peak/final 1332.8 MiB: `/tmp/emanote-issue66-no-relctx-v2/rss.tsv`. |
 | Drop stored note body only | Peak/final 1424.6 MiB: `/tmp/emanote-issue66-drop-doc-v1/rss.tsv`. |
 | Drop stored note body and backlink context | Peak/final 1333.2 MiB: `/tmp/emanote-issue66-drop-doc-no-relctx-v1/rss.tsv`. |
+| Structural `NoteBody` refactor without deferred relation deduplication | On the 4561-file, 81.65 MiB workload, peak/final RSS was 1688.7 MiB: `/tmp/emanote-issue66-final-4561-69m-v4/rss.tsv`. |
+| Sharing the line context for repeated deferred-note wikilinks only | On the same 4561-file, 81.65 MiB workload, peak/final RSS was 1711.7 MiB: `/tmp/emanote-issue66-final-4561-69m-v5/rss.tsv`. This was noise/regression, not a fix. |
 | RTS `-N1 -c` controls | Reduced RSS in some runs, but this PR does not rely on RTS defaults as the fix. |
 
 ## Current factual conclusions
 
-- The memory issue was reproduced locally above 1 GiB RSS: the baseline reached 1478.5 MiB while still in startup on the same 2401-file generated notebook, and an earlier baseline run peaked at 1293.3 MiB.
+- The memory issue was reproduced locally above 1 GiB RSS: the baseline reached 1478.5 MiB while still in startup on a 2401-file generated notebook, and an earlier baseline run peaked at 1293.3 MiB.
 - Heap profiling showed the retained heap was dominated by `List`, `Text`, `ARR_WORDS`, and `Inline` values from Pandoc parsing/link traversal/rendering, not by a laziness-only leak.
-- The code-level lazy model parse reduced the 2401-file workload from a baseline that failed to answer before 300s to 2s readiness and 448.7 MiB peak RSS.
-- On the issue-sized 4561-file, 72M generated notebook, the fixed binary reached readiness in 6s and peaked at 697.7 MiB after 1368 note rewrites.
+- The code-level lazy model parse plus deferred relation deduplication reduced the 2401-file workload from a baseline that failed to answer before 300s to 3.583s readiness and 457.3 MiB peak RSS.
+- On the 4561-file, 82M generated notebook, the fixed binary reached readiness in 9.690s and peaked at 752.2 MiB after 1368 note rewrites.
+- On the same 4561-file, 82M generated notebook, keeping every repeated deferred-note relation peaked at 1688.7 MiB. Keeping one representative relation per source note and unresolved target reduced that to 752.2 MiB.


### PR DESCRIPTION
**Large notebooks no longer require retaining every note as a full Pandoc document at startup.** Issue #66 reported 4,561 Markdown files, 69M on disk, roughly 1 minute of startup, and 4.7GB RSS; this branch reproduces the memory pressure, profiles the retained heap, and changes the model path so simple Markdown notes keep metadata, title, tags, source text, and a compact relation index. The full Pandoc parse is deferred until rendering needs the note body.

**The measured fix is code-level, not an RTS flag workaround.** The baseline 2,401-file reproduction reached 1,478.5 MiB RSS while still in startup and did not answer before a 300s readiness timeout. The final measured binary answered the 2,401-file generated notebook in 3.583s and peaked at 457.3 MiB after 720 rewrites; on the issue-sized 4,561-file / 82M generated notebook, it answered in 9.690s and peaked at 752.2 MiB after 1,368 rewrites.

**The last major reduction came from measuring relation cardinality, not guessing.** A structural deferred-note refactor without relation dedup still peaked at 1,688.7 MiB on the 4,561-file workload. Keeping one representative deferred relation per source note and unresolved target, while recovering repeated backlink contexts from source text on demand, reduced that same workload to 752.2 MiB.

**The measurement report is part of the PR** at `measurements/issue-66-memory.md`, including raw `/tmp` data paths, profiling cost centres, rejected experiments, exact workload shape, and a QuickChart RSS comparison. The implementation also batches LML model updates and replaces the ad hoc lazy-note fields with explicit `NoteBody`, `DeferredNote`, and `ParseContext` types.

> The PR intentionally keeps the dead-end measurements in the report: strictness-only, dropping retained fields after parsing, per-note compact regions, relation-context sharing without dedup, and RTS controls were measured and rejected as the fix.

Closes #66.

### Try it locally

```sh
nix build github:srid/emanote/fix-issue-66-memory
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._