### PR TITLE
Render entities in wikilink titles

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 **Bug fixes**
 
+- Wiki link custom titles now render HTML entities like `&nbsp;` the same way regular Markdown link labels do. Previously `[[note|Spivak&nbsp;(2014)]]` rendered the entity text literally as `&nbsp;` (closes [#441](https://github.com/srid/emanote/issues/441)).
 - Atom feed: a feed query that matches no notes no longer crashes the build; an empty-but-valid Atom document is emitted instead. Configuration errors (missing/invalid query block, missing `page.siteUrl`) still fail loudly ([#490](https://github.com/srid/emanote/issues/490), [#650](https://github.com/srid/emanote/pull/650))
 - Markdown links to a static `.xml` asset (e.g. `[Test](./test.xml)`) now resolve to the file. Previously a `.xml` URL was always interpreted as the Atom feed of a same-named note, leaving asset links broken when no such feed-enabled note existed. The missing-link page now also tailors its "you may create…" hint to the URL extension instead of always suggesting `<url>.md` / `<url>.org` (closes [#547](https://github.com/srid/emanote/issues/547))
 - Resolve relative URLs inside `<dir>/index.md` against `<dir>/` instead of its parent ([#651](https://github.com/srid/emanote/pull/651), closes [#608](https://github.com/srid/emanote/issues/608))

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     "commonmark-wikilink": {
       "flake": false,
       "locked": {
-        "lastModified": 1755567049,
-        "narHash": "sha256-MWOb0Ojc4EQd9fOnQEveRDdbH5Cr6kjUt04uWzBPLGQ=",
+        "lastModified": 1777254858,
+        "narHash": "sha256-dxjsU2SGG2txShwdXCl18ND18Y5Qbqt3J/FlrKhrkp4=",
         "owner": "srid",
         "repo": "commonmark-wikilink",
-        "rev": "5ab01515939047b58943cc1234e7ee0cb82d1c22",
+        "rev": "e47ba496ceaf68ec119e56eb22670ae017b35a42",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "0.2.0.0",
+        "ref": "master",
         "repo": "commonmark-wikilink",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     unionmount.flake = false;
     commonmark-simple.url = "github:srid/commonmark-simple/0.2.0.0";
     commonmark-simple.flake = false;
-    commonmark-wikilink.url = "github:srid/commonmark-wikilink/0.2.0.0";
+    commonmark-wikilink.url = "github:srid/commonmark-wikilink/master";
     commonmark-wikilink.flake = false;
 
     emanote-template.url = "github:srid/emanote-template";

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -52,6 +52,10 @@ Feature: Smoke
     When I open "/subfolder.html"
     Then the article link with text "sibling" has href containing "subfolder/sibling"
 
+  Scenario: Wiki link custom titles render HTML entities (regression: #441)
+    When I open "/wikilink-entities.html"
+    Then the first article link has HTML containing "Spivak&nbsp;(2014)"
+
   Scenario: A malformed YAML file is surfaced as a banner on its sibling note (regression: #285)
     When I open "/broken-285.html"
     Then the page rendered without an Ema exception

--- a/tests/fixtures/notebook/wikilink-entities.md
+++ b/tests/fixtures/notebook/wikilink-entities.md
@@ -1,0 +1,3 @@
+# Wikilink entities
+
+[[subfolder/sibling|Spivak&nbsp;(2014)]]

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -222,6 +222,19 @@ Then(
   },
 );
 
+Then(
+  "the first article link has HTML containing {string}",
+  async function (this: EmanoteWorld, needle: string) {
+    const link = this.page.locator("article a").first();
+    await link.waitFor({ state: "attached", timeout: 5_000 });
+    const html = await link.innerHTML();
+    assert.ok(
+      html.includes(needle),
+      `First article link expected HTML to contain ${JSON.stringify(needle)}, got ${JSON.stringify(html)}.`,
+    );
+  },
+);
+
 const POPOVER_SEL = "#emanote-footnote-popover";
 
 When(


### PR DESCRIPTION
**Wikilink custom titles now decode HTML entities** the same way regular Markdown link labels do. This fixes cases like `[[note|Spivak&nbsp;(2014)]]`, which previously rendered the entity text literally in the visible title. Closes #441.

**The parser fix landed upstream in `commonmark-wikilink`** via https://github.com/srid/commonmark-wikilink/pull/9, and this branch now pins Emanote to the merged `master` commit `e47ba49`. The upstream package was prepared as `0.3.0.0`, and `vira ci` passed there on the final PR head.

**The changelog records the user-visible bug fix**, and the smoke fixture now exercises both live and static rendering paths for the entity-bearing wikilink title.

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._

### Try it locally

```sh
nix run github:srid/emanote/fix-wikilink-html-entities
```