### PR TITLE
Keep URLs inside Markdown link labels

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -30,6 +30,7 @@
 - TOC sidebar: tightened entry padding and styled the overflow scrollbar (Firefox `scrollbar-width: thin` + WebKit pseudo-element) so long tables of contents no longer surface the chunky OS-default bar (closes [#668](https://github.com/srid/emanote/issues/668)).
 - Markdown tables now honour Pandoc's column alignment, column widths, cell `rowspan` / `colspan`, row & cell attributes, and table footers — previously every field beyond "rows of cells" was discarded (closes [#27](https://github.com/srid/emanote/issues/27); fixed upstream in [srid/heist-extra#15](https://github.com/srid/heist-extra/pull/15)).
 - Live server: assets bundled under `_emanote-static/` (skylighting CSS, self-hosted fonts, inverted-tree CSS, emanote-logo, Stork CSS+JS) now cache-bust with `?t=<mtime>` instead of being served bare. Edits to any of these files in `emanote run` invalidate the browser cache without a manual restart. Templates use a new `<emanoteStaticUrl path="…">${url}</emanoteStaticUrl>` splice; the older `${ema:emanoteStaticLayerUrl}` continues to work for third-party templates but skips the cache buster (closes [#666](https://github.com/srid/emanote/issues/666)).
+- Markdown link labels containing URLs or email addresses now stay inside the outer link instead of rendering as separate nested hyperlinks (closes [#349](https://github.com/srid/emanote/issues/349)).
 
 ## 1.4.0.0 (2025-08-18)
 

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -257,6 +257,7 @@ test-suite test
       Emanote.Model.QuerySpec
       Emanote.Model.TocSpec
       Emanote.Pandoc.ExternalLinkSpec
+      Emanote.Pandoc.Markdown.ParserSpec
       Emanote.Pandoc.Renderer.CalloutSpec
       Emanote.Route.RSpec
       Emanote.View.FeedSpec

--- a/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
+++ b/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
@@ -10,25 +10,28 @@ import Data.Aeson qualified as Aeson
 import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as IT
 import Emanote.Pandoc.Markdown.Syntax.Highlight qualified as IH
 import Relude
-import Text.Pandoc.Definition (Pandoc)
+import Relude.Extra.Bifunctor (secondF)
+import Text.Pandoc.Definition qualified as B
+import Text.Pandoc.Walk qualified as W
 
-parseMarkdown :: FilePath -> Text -> Either Text (Maybe Aeson.Value, Pandoc)
-parseMarkdown =
-  parseMarkdownWithFrontMatter @Aeson.Value
-    $
-    -- As the commonmark documentation states, pipeTableSpec should be placed after
-    -- fancyListSpec and defaultSyntaxSpec to avoid bad results when parsing
-    -- non-table lines.
-    -- see https://github.com/jgm/commonmark-hs/issues/52
-    baseExtsSansPipeTable
-    <> gfmExtensionsSansPipeTable
-    <> CE.pipeTableSpec
-    <> WL.wikilinkSpec
-    -- ASK: Can we conditionally disable this?
-    -- cf. https://github.com/srid/emanote/issues/167
-    <> IT.hashTagSpec
-    <> IH.highlightSpec
+parseMarkdown :: FilePath -> Text -> Either Text (Maybe Aeson.Value, B.Pandoc)
+parseMarkdown fp =
+  secondF removeNestedLinks
+    . parseMarkdownWithFrontMatter @Aeson.Value parserSpec fp
   where
+    parserSpec =
+      -- As the commonmark documentation states, pipeTableSpec should be placed after
+      -- fancyListSpec and defaultSyntaxSpec to avoid bad results when parsing
+      -- non-table lines.
+      -- see https://github.com/jgm/commonmark-hs/issues/52
+      baseExtsSansPipeTable
+        <> gfmExtensionsSansPipeTable
+        <> CE.pipeTableSpec
+        <> WL.wikilinkSpec
+        -- ASK: Can we conditionally disable this?
+        -- cf. https://github.com/srid/emanote/issues/167
+        <> IT.hashTagSpec
+        <> IH.highlightSpec
     baseExtsSansPipeTable =
       mconcat
         [ CE.fancyListSpec
@@ -49,3 +52,22 @@ parseMarkdown =
         <> CE.autolinkSpec
         <> CE.autoIdentifiersSpec
         <> CE.taskListSpec
+
+-- commonmark-hs can emit illegal nested links when the autolink extension sees
+-- a URI inside explicit link text. Keep the outer link and collapse inner links
+-- back to their displayed text.
+removeNestedLinks :: B.Pandoc -> B.Pandoc
+removeNestedLinks =
+  W.walk $ \case
+    B.Link attr inlines target ->
+      B.Link attr (plainifyLinks inlines) target
+    x ->
+      x
+  where
+    plainifyLinks :: [B.Inline] -> [B.Inline]
+    plainifyLinks =
+      W.walk $ \case
+        B.Link _ inlines _ ->
+          B.Str $ WL.plainify inlines
+        x ->
+          x

--- a/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
+++ b/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
@@ -54,20 +54,50 @@ parseMarkdown fp =
         <> CE.taskListSpec
 
 -- commonmark-hs can emit illegal nested links when the autolink extension sees
--- a URI inside explicit link text. Keep the outer link and collapse inner links
--- back to their displayed text.
+-- a URI inside explicit link text. Keep the outer link and unwrap inner links
+-- back to their displayed label structure.
 removeNestedLinks :: B.Pandoc -> B.Pandoc
 removeNestedLinks =
-  W.walk $ \case
-    B.Link attr inlines target ->
-      B.Link attr (plainifyLinks inlines) target
-    x ->
-      x
+  W.walk sanitizeLink
   where
-    plainifyLinks :: [B.Inline] -> [B.Inline]
-    plainifyLinks =
-      W.walk $ \case
+    sanitizeLink :: B.Inline -> B.Inline
+    sanitizeLink = \case
+      B.Link attr inlines target ->
+        B.Link attr (sanitizeLinkLabel inlines) target
+      x ->
+        x
+
+    sanitizeLinkLabel :: [B.Inline] -> [B.Inline]
+    sanitizeLinkLabel =
+      concatMap $ \case
         B.Link _ inlines _ ->
-          B.Str $ WL.plainify inlines
-        x ->
-          x
+          sanitizeLinkLabel inlines
+        inline ->
+          one $ sanitizeInlineLabel inline
+
+    sanitizeInlineLabel :: B.Inline -> B.Inline
+    sanitizeInlineLabel = \case
+      B.Emph inlines ->
+        B.Emph $ sanitizeLinkLabel inlines
+      B.Underline inlines ->
+        B.Underline $ sanitizeLinkLabel inlines
+      B.Strong inlines ->
+        B.Strong $ sanitizeLinkLabel inlines
+      B.Strikeout inlines ->
+        B.Strikeout $ sanitizeLinkLabel inlines
+      B.Superscript inlines ->
+        B.Superscript $ sanitizeLinkLabel inlines
+      B.Subscript inlines ->
+        B.Subscript $ sanitizeLinkLabel inlines
+      B.SmallCaps inlines ->
+        B.SmallCaps $ sanitizeLinkLabel inlines
+      B.Quoted quoteType inlines ->
+        B.Quoted quoteType $ sanitizeLinkLabel inlines
+      B.Cite citations inlines ->
+        B.Cite citations $ sanitizeLinkLabel inlines
+      B.Image attr inlines target ->
+        B.Image attr (sanitizeLinkLabel inlines) target
+      B.Span attr inlines ->
+        B.Span attr $ sanitizeLinkLabel inlines
+      inline ->
+        inline

--- a/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
+++ b/emanote/src/Emanote/Pandoc/Markdown/Parser.hs
@@ -14,6 +14,7 @@ import Relude.Extra.Bifunctor (secondF)
 import Text.Pandoc.Definition qualified as B
 import Text.Pandoc.Walk qualified as W
 
+-- | Parse Emanote Markdown into Pandoc and normalize parser artifacts.
 parseMarkdown :: FilePath -> Text -> Either Text (Maybe Aeson.Value, B.Pandoc)
 parseMarkdown fp =
   secondF removeNestedLinks

--- a/emanote/test/Emanote/Pandoc/Markdown/ParserSpec.hs
+++ b/emanote/test/Emanote/Pandoc/Markdown/ParserSpec.hs
@@ -1,0 +1,41 @@
+module Emanote.Pandoc.Markdown.ParserSpec where
+
+import Commonmark.Extensions.WikiLink qualified as WL
+import Emanote.Pandoc.Markdown.Parser (parseMarkdown)
+import Hedgehog
+import Relude
+import Test.Hspec
+import Test.Hspec.Hedgehog (hedgehog)
+import Text.Pandoc.Definition qualified as B
+import Text.Pandoc.Walk qualified as W
+
+spec :: Spec
+spec = do
+  describe "parseMarkdown" $ do
+    it "does not keep autolinks nested inside link descriptions" . hedgehog $ do
+      linkTextsAndTargets issue349Markdown
+        === Right
+          [ ("https://www.website.com", "https://www.website.com#something")
+          , ("nobody@example.com", "mailto:nobody@example.com?subject=Some%20subject")
+          , ("A website similar to https://www.foo.com and https://www.bar.com", "https://www.baz.com")
+          ]
+
+issue349Markdown :: Text
+issue349Markdown =
+  unlines
+    [ "[https://www.website.com](https://www.website.com#something)"
+    , ""
+    , "[nobody@example.com](mailto:nobody@example.com?subject=Some%20subject)"
+    , ""
+    , "[A website similar to https://www.foo.com and https://www.bar.com](https://www.baz.com)"
+    ]
+
+linkTextsAndTargets :: Text -> Either Text [(Text, Text)]
+linkTextsAndTargets =
+  fmap (W.query linkTextAndTarget . snd) . parseMarkdown "<test>"
+  where
+    linkTextAndTarget :: B.Inline -> [(Text, Text)]
+    linkTextAndTarget (B.Link _ inlines (url, _)) =
+      [(WL.plainify inlines, url)]
+    linkTextAndTarget _ =
+      []


### PR DESCRIPTION
**Markdown link labels that contain URLs or email addresses now render as one link**, not as split or nested hyperlinks. CommonMark's autolink extension can emit nested Pandoc `Link` nodes for these labels, so Emanote now normalizes that parser artifact before the document reaches the renderer. Closes #349.

**The normalization lives at the Markdown parser boundary**, preserving the existing `parseMarkdown` interface for model and rendering code. It unwraps inner link targets while keeping their displayed label structure, with a parser regression spec covering the original URL, mailto, and sentence-label cases.

### Try it locally

```sh
nix run github:srid/emanote/fix/349-link-description-autolinks
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._