### PR TITLE
Encode special tag links safely

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 **Bug fixes**
 
+- Tags whose names start with `#` now link to their tag index with `%23` in the generated URL instead of emitting a literal fragment marker (closes [#199](https://github.com/srid/emanote/issues/199)).
 - Wiki link custom titles now render HTML entities like `&nbsp;` the same way regular Markdown link labels do. Previously `[[note|Spivak&nbsp;(2014)]]` rendered the entity text literally as `&nbsp;` (closes [#441](https://github.com/srid/emanote/issues/441)).
 - Atom feed: a feed query that matches no notes no longer crashes the build; an empty-but-valid Atom document is emitted instead. Configuration errors (missing/invalid query block, missing `page.siteUrl`) still fail loudly ([#490](https://github.com/srid/emanote/issues/490), [#650](https://github.com/srid/emanote/pull/650))
 - Markdown links to a static `.xml` asset (e.g. `[Test](./test.xml)`) now resolve to the file. Previously a `.xml` URL was always interpreted as the Atom feed of a same-named note, leaving asset links broken when no such feed-enabled note existed. The missing-link page now also tailors its "you may create…" hint to the URL extension instead of always suggesting `<url>.md` / `<url>.org` (closes [#547](https://github.com/srid/emanote/issues/547))

--- a/emanote/default/templates/components/metadata.tpl
+++ b/emanote/default/templates/components/metadata.tpl
@@ -1,14 +1,11 @@
 <ema:metadata>
   <section
     class="flex flex-wrap items-end justify-center my-4 space-x-2 space-y-2 font-mono text-sm">
-    <with var="tags">
-      <!-- FIXME: The use of -/tags is wrong, because we should use routeUrl using Ema's encoder 
-        Perhaps Emanote should inject tagMetas with urls.
-      -->
+    <with var="tagMetas">
       <a title="Tag" class="px-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-50 dark:hover:bg-gray-600 hover:text-primary-500"
-        href="-/tags/${value}${ema:urlStrategySuffix}">
+        href="${url}">
         <!-- DoNotFormat -->
-        #<value />
+        #<value var="value" />
         <!-- DoNotFormat -->
       </a>
     </with>

--- a/emanote/default/templates/components/metadata.tpl
+++ b/emanote/default/templates/components/metadata.tpl
@@ -1,13 +1,13 @@
-<ema:metadata>
-  <section
-    class="flex flex-wrap items-end justify-center my-4 space-x-2 space-y-2 font-mono text-sm">
-    <with var="tagMetas">
+<section
+  class="flex flex-wrap items-end justify-center my-4 space-x-2 space-y-2 font-mono text-sm">
+  <ema:tagMetas>
+    <ema:each-tagMeta>
       <a title="Tag" class="px-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-50 dark:hover:bg-gray-600 hover:text-primary-500"
-        href="${url}">
+        href="${tag:url}">
         <!-- DoNotFormat -->
-        #<value var="value" />
+        #<tag:value />
         <!-- DoNotFormat -->
       </a>
-    </with>
-  </section>
-</ema:metadata>
+    </ema:each-tagMeta>
+  </ema:tagMetas>
+</section>

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -195,6 +195,7 @@ library
     Emanote.Pandoc.Renderer.Callout
     Emanote.Pandoc.Renderer.Embed
     Emanote.Pandoc.Renderer.Query
+    Emanote.Pandoc.Renderer.Tag
     Emanote.Pandoc.Renderer.Url
     Emanote.Prelude
     Emanote.Route

--- a/emanote/src/Emanote.hs
+++ b/emanote/src/Emanote.hs
@@ -31,6 +31,7 @@ import Emanote.Pandoc.Renderer
 import Emanote.Pandoc.Renderer.Callout qualified as PF
 import Emanote.Pandoc.Renderer.Embed qualified as PF
 import Emanote.Pandoc.Renderer.Query qualified as PF
+import Emanote.Pandoc.Renderer.Tag qualified as PF
 import Emanote.Pandoc.Renderer.Url qualified as PF
 import Emanote.Prelude (log, logE, logW)
 import Emanote.Route.ModelRoute (LMLRoute, lmlRouteCase)
@@ -151,7 +152,8 @@ defaultEmanotePandocRenderers :: EmanotePandocRenderers Model.Model LMLRoute
 defaultEmanotePandocRenderers =
   let blockRenderers =
         PandocRenderers
-          [ PF.embedInlineWikiLinkResolvingSplice -- embedInlineWikiLinkResolvingSplice should be first to recognize inline Link elements first
+          [ PF.tagLinkSplice
+          , PF.embedInlineWikiLinkResolvingSplice -- embedInlineWikiLinkResolvingSplice should be first to recognize inline Link elements first
           , PF.urlResolvingSplice
           ]
           [ PF.embedBlockWikiLinkResolvingSplice
@@ -161,7 +163,8 @@ defaultEmanotePandocRenderers =
           ]
       inlineRenderers =
         PandocRenderers
-          [ PF.embedInlineWikiLinkResolvingSplice -- embedInlineWikiLinkResolvingSplice should be first to recognize inline Link elements first
+          [ PF.tagLinkSplice
+          , PF.embedInlineWikiLinkResolvingSplice -- embedInlineWikiLinkResolvingSplice should be first to recognize inline Link elements first
           , PF.urlResolvingSplice
           ]
           mempty

--- a/emanote/src/Emanote.hs
+++ b/emanote/src/Emanote.hs
@@ -153,7 +153,8 @@ defaultEmanotePandocRenderers =
   let blockRenderers =
         PandocRenderers
           [ PF.tagLinkSplice
-          , PF.embedInlineWikiLinkResolvingSplice -- embedInlineWikiLinkResolvingSplice should be first to recognize inline Link elements first
+          , -- Keep the embed resolver before the generic URL resolver so inline embed links render as embeds.
+            PF.embedInlineWikiLinkResolvingSplice
           , PF.urlResolvingSplice
           ]
           [ PF.embedBlockWikiLinkResolvingSplice
@@ -164,7 +165,8 @@ defaultEmanotePandocRenderers =
       inlineRenderers =
         PandocRenderers
           [ PF.tagLinkSplice
-          , PF.embedInlineWikiLinkResolvingSplice -- embedInlineWikiLinkResolvingSplice should be first to recognize inline Link elements first
+          , -- Keep the embed resolver before the generic URL resolver so inline embed links render as embeds.
+            PF.embedInlineWikiLinkResolvingSplice
           , PF.urlResolvingSplice
           ]
           mempty

--- a/emanote/src/Emanote/Pandoc/BuiltinFilters.hs
+++ b/emanote/src/Emanote/Pandoc/BuiltinFilters.hs
@@ -4,8 +4,7 @@ module Emanote.Pandoc.BuiltinFilters (
 
 import Emanote.Pandoc.ExternalLink (setExternalLinkIcon)
 import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as HT
-import Emanote.Route (encodeRoute)
-import Emanote.Route.SiteRoute.Type (encodeTagIndexR)
+import Emanote.Route.SiteRoute.Type (encodeTagIndexUrl)
 import Relude
 import Text.Pandoc.Definition qualified as B
 import Text.Pandoc.Walk qualified as W
@@ -32,7 +31,7 @@ linkifyInlineTags =
       x
   where
     tagUrl =
-      toText . encodeRoute . encodeTagIndexR . toList . HT.deconstructTag
+      toText . encodeTagIndexUrl . toList . HT.deconstructTag
 
 -- Undo font-family on emoji spans, so the browser uses an emoji font.
 -- Ref: https://github.com/jgm/commonmark-hs/blob/3d545d7afa6c91820b4eebf3efeeb80bf1b27128/commonmark-extensions/src/Commonmark/Extensions/Emoji.hs#L30-L33

--- a/emanote/src/Emanote/Pandoc/BuiltinFilters.hs
+++ b/emanote/src/Emanote/Pandoc/BuiltinFilters.hs
@@ -3,35 +3,15 @@ module Emanote.Pandoc.BuiltinFilters (
 ) where
 
 import Emanote.Pandoc.ExternalLink (setExternalLinkIcon)
-import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as HT
-import Emanote.Route.SiteRoute.Type (encodeTagIndexUrl)
 import Relude
 import Text.Pandoc.Definition qualified as B
 import Text.Pandoc.Walk qualified as W
 
 preparePandoc :: (W.Walkable B.Inline b) => b -> b
 preparePandoc =
-  linkifyInlineTags
-    >>> fixEmojiFontFamily
+  fixEmojiFontFamily
     >>> setExternalLinkIcon
     >>> flattenNestedLinks
-
--- HashTag.hs generates a Span for inline tags.
--- Here, we must link them to the special tag index page.
-linkifyInlineTags :: (W.Walkable B.Inline b) => b -> b
-linkifyInlineTags =
-  W.walk $ \case
-    inline@(B.Span attr is) ->
-      if
-        | Just inlineTag <- HT.getTagFromInline inline ->
-            B.Span attr [B.Link mempty is (tagUrl inlineTag, "Tag")]
-        | otherwise ->
-            inline
-    x ->
-      x
-  where
-    tagUrl =
-      toText . encodeTagIndexUrl . toList . HT.deconstructTag
 
 -- Undo font-family on emoji spans, so the browser uses an emoji font.
 -- Ref: https://github.com/jgm/commonmark-hs/blob/3d545d7afa6c91820b4eebf3efeeb80bf1b27128/commonmark-extensions/src/Commonmark/Extensions/Emoji.hs#L30-L33

--- a/emanote/src/Emanote/Pandoc/Renderer/Tag.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Tag.hs
@@ -12,6 +12,11 @@ import Heist.Extra.Splices.Pandoc.Ctx (ctxSansCustomSplicing)
 import Relude
 import Text.Pandoc.Definition qualified as B
 
+{- | Render semantic hashtag spans as links to their tag index page.
+
+This lives in the renderer rather than 'preparePandoc' so tag URLs use the
+model-aware site route encoder.
+-}
 tagLinkSplice :: PandocInlineRenderer Model R.LMLRoute
 tagLinkSplice model _nr (ctxSansCustomSplicing -> ctx) _route inline = do
   tag <- HT.getTagFromInline inline

--- a/emanote/src/Emanote/Pandoc/Renderer/Tag.hs
+++ b/emanote/src/Emanote/Pandoc/Renderer/Tag.hs
@@ -1,0 +1,20 @@
+module Emanote.Pandoc.Renderer.Tag (
+  tagLinkSplice,
+) where
+
+import Emanote.Model (Model)
+import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as HT
+import Emanote.Pandoc.Renderer (PandocInlineRenderer)
+import Emanote.Route qualified as R
+import Emanote.Route.SiteRoute.Class qualified as SR
+import Heist.Extra.Splices.Pandoc qualified as HP
+import Heist.Extra.Splices.Pandoc.Ctx (ctxSansCustomSplicing)
+import Relude
+import Text.Pandoc.Definition qualified as B
+
+tagLinkSplice :: PandocInlineRenderer Model R.LMLRoute
+tagLinkSplice model _nr (ctxSansCustomSplicing -> ctx) _route inline = do
+  tag <- HT.getTagFromInline inline
+  B.Span attr inlines <- pure inline
+  let tagUrl = SR.siteRouteUrl model $ SR.tagIndexRoute $ toList $ HT.deconstructTag tag
+  pure $ HP.rpInline ctx $ B.Span attr [B.Link mempty inlines (tagUrl, "Tag")]

--- a/emanote/src/Emanote/Route/SiteRoute/Type.hs
+++ b/emanote/src/Emanote/Route/SiteRoute/Type.hs
@@ -8,6 +8,7 @@ module Emanote.Route.SiteRoute.Type (
   decodeVirtualRoute,
   encodeVirtualRoute,
   encodeTagIndexR,
+  encodeTagIndexUrl,
 ) where
 
 import Data.Aeson (ToJSON)
@@ -127,3 +128,15 @@ encodeExportR = \case
 encodeTagIndexR :: [HT.TagNode] -> R.R 'Ext.Html
 encodeTagIndexR tagNodes =
   R.R $ "-" :| "tags" : fmap (fromString . toString . HT.unTagNode) tagNodes
+
+encodeTagIndexUrl :: [HT.TagNode] -> FilePath
+encodeTagIndexUrl =
+  R.encodeRoute . mapRouteSlugs encodeSlugForUrl . encodeTagIndexR
+  where
+    encodeSlugForUrl :: Slug.Slug -> Slug.Slug
+    encodeSlugForUrl =
+      fromString . toString . Slug.encodeSlug
+
+    mapRouteSlugs :: (Slug.Slug -> Slug.Slug) -> R.R ext -> R.R ext
+    mapRouteSlugs f (R.R slugs) =
+      R.R $ fmap f slugs

--- a/emanote/src/Emanote/Route/SiteRoute/Type.hs
+++ b/emanote/src/Emanote/Route/SiteRoute/Type.hs
@@ -7,8 +7,6 @@ module Emanote.Route.SiteRoute.Type (
   ResourceRoute (..),
   decodeVirtualRoute,
   encodeVirtualRoute,
-  encodeTagIndexR,
-  encodeTagIndexUrl,
 ) where
 
 import Data.Aeson (ToJSON)
@@ -128,15 +126,3 @@ encodeExportR = \case
 encodeTagIndexR :: [HT.TagNode] -> R.R 'Ext.Html
 encodeTagIndexR tagNodes =
   R.R $ "-" :| "tags" : fmap (fromString . toString . HT.unTagNode) tagNodes
-
-encodeTagIndexUrl :: [HT.TagNode] -> FilePath
-encodeTagIndexUrl =
-  R.encodeRoute . mapRouteSlugs encodeSlugForUrl . encodeTagIndexR
-  where
-    encodeSlugForUrl :: Slug.Slug -> Slug.Slug
-    encodeSlugForUrl =
-      fromString . toString . Slug.encodeSlug
-
-    mapRouteSlugs :: (Slug.Slug -> Slug.Slug) -> R.R ext -> R.R ext
-    mapRouteSlugs f (R.R slugs) =
-      R.R $ fmap f slugs

--- a/emanote/src/Emanote/View/Common.hs
+++ b/emanote/src/Emanote/View/Common.hs
@@ -22,6 +22,7 @@ import Emanote.Model.SData qualified as SData
 import Emanote.Model.Title qualified as Tit
 import Emanote.Model.Type (Model)
 import Emanote.Model.Type qualified as M
+import Emanote.Pandoc.Markdown.Syntax.HashTag qualified as HT
 import Emanote.Pandoc.Renderer (EmanotePandocRenderers (..), PandocRenderers (..))
 import Emanote.Pandoc.Renderer qualified as Renderer
 import Emanote.Pandoc.Renderer.Embed qualified as Embed
@@ -119,6 +120,17 @@ defaultRouteMeta model =
       meta = Meta.getEffectiveRouteMeta r model
    in (r, meta)
 
+templateMeta :: Model -> Aeson.Value -> Aeson.Value
+templateMeta model meta =
+  SData.modifyAeson (one "tagMetas") (const $ Just $ Aeson.toJSON tagMetas) meta
+  where
+    tagMetas =
+      SData.lookupAeson @[HT.Tag] mempty (one "tags") meta <&> \tag ->
+        Aeson.object
+          [ "value" Aeson..= HT.unTag tag
+          , "url" Aeson..= SR.siteRouteUrl model (SR.tagIndexRoute $ toList $ HT.deconstructTag tag)
+          ]
+
 commonSplices ::
   (HasCallStack) =>
   ((RenderCtx -> HI.Splice Identity) -> HI.Splice Identity) ->
@@ -157,7 +169,7 @@ commonSplices withCtx model meta routeTitle = do
   "ema:version" ##
     HI.textSplice (toText $ showVersion Paths_emanote.version)
   "ema:metadata" ##
-    HJ.bindJson meta
+    HJ.bindJson (templateMeta model meta)
   "ema:title" ##
     withCtx
       $ \ctx ->

--- a/emanote/src/Emanote/View/Common.hs
+++ b/emanote/src/Emanote/View/Common.hs
@@ -120,16 +120,18 @@ defaultRouteMeta model =
       meta = Meta.getEffectiveRouteMeta r model
    in (r, meta)
 
-templateMeta :: Model -> Aeson.Value -> Aeson.Value
-templateMeta model meta =
-  SData.modifyAeson (one "tagMetas") (const $ Just $ Aeson.toJSON tagMetas) meta
-  where
-    tagMetas =
-      SData.lookupAeson @[HT.Tag] mempty (one "tags") meta <&> \tag ->
-        Aeson.object
-          [ "value" Aeson..= HT.unTag tag
-          , "url" Aeson..= SR.siteRouteUrl model (SR.tagIndexRoute $ toList $ HT.deconstructTag tag)
-          ]
+tagMetas :: Model -> Aeson.Value -> [(Text, Text)]
+tagMetas model meta =
+  SData.lookupAeson @[HT.Tag] mempty (one "tags") meta <&> \tag ->
+    ( HT.unTag tag
+    , SR.siteRouteUrl model (SR.tagIndexRoute $ toList $ HT.deconstructTag tag)
+    )
+
+tagMetasSplice :: Model -> Aeson.Value -> HI.Splice Identity
+tagMetasSplice model meta =
+  Splices.listSplice (tagMetas model meta) "ema:each-tagMeta" $ \(value, url) -> do
+    "tag:value" ## HI.textSplice value
+    "tag:url" ## HI.textSplice url
 
 commonSplices ::
   (HasCallStack) =>
@@ -169,7 +171,9 @@ commonSplices withCtx model meta routeTitle = do
   "ema:version" ##
     HI.textSplice (toText $ showVersion Paths_emanote.version)
   "ema:metadata" ##
-    HJ.bindJson (templateMeta model meta)
+    HJ.bindJson meta
+  "ema:tagMetas" ##
+    tagMetasSplice model meta
   "ema:title" ##
     withCtx
       $ \ctx ->

--- a/emanote/test/Emanote/Pandoc/BuiltinFiltersSpec.hs
+++ b/emanote/test/Emanote/Pandoc/BuiltinFiltersSpec.hs
@@ -10,14 +10,6 @@ import Text.Pandoc.Walk qualified as W
 
 spec :: Spec
 spec = do
-  -- Regression test for https://github.com/srid/emanote/issues/199.
-  -- Tags may themselves start with '#', so the generated URL must encode the
-  -- tag slug before the browser sees it as a fragment marker.
-  describe "preparePandoc links special tags (#199)" $ do
-    it "escapes a leading hash inside the tag"
-      $ links "##§1"
-      `shouldBe` [("-/tags/%23%C2%A71.html", "##§1")]
-
   -- Regression test for https://github.com/srid/emanote/issues/349.
   -- `preparePandoc`'s last pass (`flattenNestedLinks`) unwraps any Link
   -- nested inside a parent Link's label — the autolink-extension artifact

--- a/emanote/test/Emanote/Pandoc/BuiltinFiltersSpec.hs
+++ b/emanote/test/Emanote/Pandoc/BuiltinFiltersSpec.hs
@@ -10,6 +10,14 @@ import Text.Pandoc.Walk qualified as W
 
 spec :: Spec
 spec = do
+  -- Regression test for https://github.com/srid/emanote/issues/199.
+  -- Tags may themselves start with '#', so the generated URL must encode the
+  -- tag slug before the browser sees it as a fragment marker.
+  describe "preparePandoc links special tags (#199)" $ do
+    it "escapes a leading hash inside the tag"
+      $ links "##§1"
+      `shouldBe` [("-/tags/%23%C2%A71.html", "##§1")]
+
   -- Regression test for https://github.com/srid/emanote/issues/349.
   -- `preparePandoc`'s last pass (`flattenNestedLinks`) unwraps any Link
   -- nested inside a parent Link's label — the autolink-extension artifact

--- a/tests/features/smoke.feature
+++ b/tests/features/smoke.feature
@@ -68,6 +68,10 @@ Feature: Smoke
     And the article link with text "https://issue349-case4.example.com" has href containing "issue349-case4-target.example.com"
     And the article body has exactly 4 hyperlinks to issue-349 case targets
 
+  Scenario: Tags beginning with # link to their encoded tag index (regression: #199)
+    When I open "/special-tags.html"
+    Then the page has 2 tag links with text "##§1" whose href contains "-/tags/%23%C2%A71"
+
   Scenario: A malformed YAML file is surfaced as a banner on its sibling note (regression: #285)
     When I open "/broken-285.html"
     Then the page rendered without an Ema exception

--- a/tests/fixtures/notebook/special-tags.md
+++ b/tests/fixtures/notebook/special-tags.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - "#§1"
+---
+
+# Special tags
+
+Inline special tag: ##§1

--- a/tests/step_definitions/smoke_steps.ts
+++ b/tests/step_definitions/smoke_steps.ts
@@ -305,6 +305,36 @@ Then(
   },
 );
 
+Then(
+  "the page has {int} tag links with text {string} whose href contains {string}",
+  async function (
+    this: EmanoteWorld,
+    expectedCount: number,
+    linkText: string,
+    hrefNeedle: string,
+  ) {
+    const hrefs = await this.page.$$eval(
+      'a[title="Tag"]',
+      (anchors, text) =>
+        anchors
+          .filter((a) => (a.textContent ?? "").trim() === text)
+          .map((a) => a.getAttribute("href") ?? ""),
+      linkText,
+    );
+    assert.strictEqual(
+      hrefs.length,
+      expectedCount,
+      `Expected ${expectedCount} tag links with text ${JSON.stringify(linkText)}, got ${hrefs.length}: ${JSON.stringify(hrefs)}.`,
+    );
+    const offenders = hrefs.filter((href) => !href.includes(hrefNeedle));
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      `Every tag link ${JSON.stringify(linkText)} should contain ${JSON.stringify(hrefNeedle)}; got ${JSON.stringify(hrefs)}. Literal '#' in the path is interpreted as a fragment, so the tag route must emit '%23'.`,
+    );
+  },
+);
+
 const POPOVER_SEL = "#emanote-footnote-popover";
 
 When(


### PR DESCRIPTION
**Tags that begin with `#` now link to their tag index with an encoded path**, so browsers no longer treat the tag name as a fragment. This closes the long-standing `##...`/structure-note case from #199 and removes the template-side manual `-/tags/${value}` URL construction that caused one of the broken paths.

The route policy now lives in the renderer boundary instead of the generic Pandoc preparation pass. Inline tag spans stay semantic until render time, where they use the model-aware `siteRouteUrl`, and metadata tag pills consume a dedicated tag-view splice rather than mixing derived URLs into raw metadata.

### Verification

- `nix develop -c cabal build all`
- `nix develop -c cabal test all`
- `EMANOTE_MODE=live npm test -- --name 'Tags beginning with # link to their encoded tag index'`
- `EMANOTE_MODE=static npm test -- --name 'Tags beginning with # link to their encoded tag index'`
- `EMANOTE_MODE=morph npm test -- --name 'Tags beginning with # link to their encoded tag index'`

Closes #199

### Try it locally

```sh
nix run github:srid/emanote/fix-issue-199-special-tag-links
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `GPT-5`)._