### PR TITLE
Stop reloading Tailwind during morph navigation

### DIFF
--- a/emanote/src/Emanote/View/Common.hs
+++ b/emanote/src/Emanote/View/Common.hs
@@ -238,7 +238,12 @@ commonSplices withCtx model meta routeTitle = do
               <> ".forEach(s => s.setAttribute('im-preserve', 'true'));"
               <> "});"
       H.script $ H.toHtml preserveScript
+      -- Tailwind's browser CDN installs a document-wide MutationObserver.
+      -- Ema's script reloader would otherwise execute it again on every
+      -- morph, multiplying observers and making morph navigation wait behind
+      -- repeated Tailwind rebuilds before EMAHotReload is observable.
       H.script
+        ! H.dataAttribute "ema-skip" "true"
         ! A.src (H.toValue localCdnUrl)
         $ mempty
 


### PR DESCRIPTION
**Morph navigation no longer re-executes the Tailwind browser compiler** on every route switch. The live-server Tailwind CDN script installs a document-wide `MutationObserver`; Ema's generic script reloader was running that script again after morphs, multiplying observers and making the calendar route wait behind repeated Tailwind rebuild work before the test harness could observe navigation completion.

The fix marks the live Tailwind CDN script with Ema's existing `data-ema-skip="true"` contract. The original Tailwind observer remains active and still sees morphed DOM changes; it just is not duplicated by `reloadScripts`.

Validation run locally:

- `just e2e-morph` - 42 passed
- `just e2e-live` - 42 passed
- `just e2e-static` - 39 passed, 3 skipped

_Generated by Codex (model `gpt-5`)._