### PR TITLE
Stop morph e2e runs from blocking on server stdout

### DIFF
--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -87,7 +87,10 @@ async function startLive(): Promise<{ url: string; resource: BackendResource }> 
   const proc = spawn(
     emanoteBin,
     ["-L", fixtureDir, "run", "--port", String(port)],
-    { stdio: ["ignore", "pipe", "pipe"] },
+    // Emanote writes routine request/build output to stdout. In long morph
+    // runs, an unread stdout pipe can fill and block the server process,
+    // making later page.goto("/") calls hang even though the backend started.
+    { stdio: ["ignore", "ignore", "pipe"] },
   );
   proc.stderr?.on("data", (d: Buffer) =>
     process.stderr.write(`[emanote:live] ${d}`),


### PR DESCRIPTION
**Morph e2e runs now keep the live Emanote server responsive for the whole smoke file.** The harness used to spawn `emanote run` with stdout piped, but never read it; after enough route/render output, that pipe could fill and block the child process. The observed failure was late in `just e2e-morph`, where fresh `page.goto("/")` calls timed out while priming morph navigation.

The fix sends routine stdout to `/dev/null` while preserving stderr under the existing `[emanote:live]` prefix. That addresses the server backpressure root cause without filtering scenarios, raising timeouts, or weakening assertions.

### Verification

- `just e2e-live` — 42 scenarios / 132 steps passed
- `just e2e-static` — 39 passed, 3 `@morph` scenarios skipped as expected
- `just e2e-morph` — 42 scenarios / 132 steps passed
- `just fmt` — cabal-fmt, fourmolu, hlint, nixpkgs-fmt passed

_Generated by Codex (model `gpt-5`)._