### PR TITLE
Drop page-load reveal animation from default theme

### DIFF
--- a/emanote/default/templates/styles.tpl
+++ b/emanote/default/templates/styles.tpl
@@ -415,25 +415,3 @@
     --icon-mail: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="black" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>');
   }
 </style>
-
-<style data-category="page-load-reveal">
-  /* One orchestrated entrance on first paint: sidebar fades in; main
-     content fades and drifts up ~8px with a small stagger. Pure CSS so
-     it runs pre-paint without JS; gated on prefers-reduced-motion. */
-  @media (prefers-reduced-motion: no-preference) {
-    @keyframes ema-fade-in {
-      from { opacity: 0; }
-      to   { opacity: 1; }
-    }
-    @keyframes ema-rise-in {
-      from { opacity: 0; transform: translateY(8px); }
-      to   { opacity: 1; transform: none; }
-    }
-    #sidebar {
-      animation: ema-fade-in 400ms ease-out both;
-    }
-    main {
-      animation: ema-rise-in 480ms 60ms ease-out both;
-    }
-  }
-</style>


### PR DESCRIPTION
**The default theme no longer plays an entrance animation on every page load.** Each navigation used to fade the sidebar in over 400ms and slide `main` up 8px over 480ms with a 60ms stagger; in practice the upward drift on `main` registered as **jarring** rather than polished, especially on internal-link clicks where the destination feels like it should appear instantly.

The block lived in one self-contained `<style data-category="page-load-reveal">` in `emanote/default/templates/styles.tpl` (22 lines, two `@keyframes`, gated on `prefers-reduced-motion: no-preference`). Nothing else in the codebase referenced the keyframes or the data-category, so the deletion is atomic — no JS, no other CSS, no template hooks involved.

_Pure cosmetic removal: build clean, unit tests pass (90/90), no e2e scenarios touch the animation._

### Try it locally

```sh
nix run github:srid/emanote/drop-page-load-animation
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._