### PR TITLE
Drop dead /container redirect (closes #230)

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -35,7 +35,6 @@
 /start/install /install 301
 /start/install/nix /nix 301
 /start/install/wsl /wsl 301
-/start/install/container /container 301
 /start/neuron /neuron 301
 /start/known-issues /known-issues 301
 /start/resources /resources 301


### PR DESCRIPTION
**The Cloudflare redirect `/start/install/container` -> `/container` now points at a 404** — Docker support was removed in [`96607280`](https://github.com/srid/emanote/commit/96607280) (Sept 2025), taking `docs/start/install/container.md` along with it. The redirect rule survived the cleanup and now sends visitors to nowhere; this drops it.

[#230](https://github.com/srid/emanote/issues/230) originally asked for "Document Docker on Windows without WSL." That request is moot now that Emanote no longer ships an official container, so closing it alongside the redirect cleanup.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._