### PR TITLE
Extract skipUnlessMode helper to unify e2e mode-tag skip hooks

### DIFF
--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -23,12 +23,7 @@ import * as path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { EmanoteWorld } from "./world.ts";
-import {
-  mode,
-  requireEnv,
-  skipUnlessMode,
-  NON_STATIC_MODES,
-} from "./mode.ts";
+import { mode, requireEnv, skipUnlessMode, NON_STATIC_MODES } from "./mode.ts";
 import { primeMorph } from "./navigation.ts";
 
 const emanoteBin = requireEnv("EMANOTE_BIN");

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -23,7 +23,12 @@ import * as path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { EmanoteWorld } from "./world.ts";
-import { mode, requireEnv, skipUnlessMode, type Mode } from "./mode.ts";
+import {
+  mode,
+  requireEnv,
+  skipUnlessMode,
+  NON_STATIC_MODES,
+} from "./mode.ts";
 import { primeMorph } from "./navigation.ts";
 
 const emanoteBin = requireEnv("EMANOTE_BIN");
@@ -182,12 +187,6 @@ AfterAll(async () => {
 });
 
 const MORPH_TAG = "@morph";
-
-// `@morph` and `@live` both require an active `emanote run` backend
-// (WebSocket / `window.ema`, or live-only behavior like the ambiguous-
-// link candidate list which is suppressed in static export). Only
-// `static` mode lacks them.
-const NON_STATIC_MODES: readonly Mode[] = ["live", "morph"];
 
 Before(async function (this: EmanoteWorld) {
   this.browser = browser;

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -23,7 +23,7 @@ import * as path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { EmanoteWorld } from "./world.ts";
-import { mode, requireEnv } from "./mode.ts";
+import { mode, requireEnv, skipUnlessMode, type Mode } from "./mode.ts";
 import { primeMorph } from "./navigation.ts";
 
 const emanoteBin = requireEnv("EMANOTE_BIN");
@@ -183,6 +183,12 @@ AfterAll(async () => {
 
 const MORPH_TAG = "@morph";
 
+// `@morph` and `@live` both require an active `emanote run` backend
+// (WebSocket / `window.ema`, or live-only behavior like the ambiguous-
+// link candidate list which is suppressed in static export). Only
+// `static` mode lacks them.
+const NON_STATIC_MODES = new Set<Mode>(["live", "morph"]);
+
 Before(async function (this: EmanoteWorld) {
   this.browser = browser;
   this.context = await browser.newContext({
@@ -192,19 +198,8 @@ Before(async function (this: EmanoteWorld) {
   this.page = await this.context.newPage();
 });
 
-// Static mode has no WebSocket and `window.ema` is undefined, so any
-// `@morph` scenario would fail at the first `switchRoute` call.
-Before({ tags: MORPH_TAG }, function () {
-  if (mode === "static") return "skipped" as const;
-});
-
-// `@live` marks scenarios that exercise behavior present only when the
-// notebook is served by `emanote run` — e.g. the ambiguous-link
-// candidate list, which is suppressed in static export. Both `live`
-// and `morph` modes use the same backend, so only `static` skips.
-Before({ tags: "@live" }, function () {
-  if (mode === "static") return "skipped" as const;
-});
+skipUnlessMode(MORPH_TAG, NON_STATIC_MODES);
+skipUnlessMode("@live", NON_STATIC_MODES);
 
 // Inverse safety: a scenario using the morph-nav step without `@morph`
 // would silently hang in static mode until the cucumber step ceiling.

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -187,7 +187,7 @@ const MORPH_TAG = "@morph";
 // (WebSocket / `window.ema`, or live-only behavior like the ambiguous-
 // link candidate list which is suppressed in static export). Only
 // `static` mode lacks them.
-const NON_STATIC_MODES = new Set<Mode>(["live", "morph"]);
+const NON_STATIC_MODES: readonly Mode[] = ["live", "morph"];
 
 Before(async function (this: EmanoteWorld) {
   this.browser = browser;

--- a/tests/support/mode.ts
+++ b/tests/support/mode.ts
@@ -7,6 +7,8 @@
  *                `window.ema.switchRoute` instead of `page.goto`
  */
 
+import { Before } from "@cucumber/cucumber";
+
 export type Mode = "live" | "static" | "morph";
 
 export function requireEnv(name: string): string {
@@ -23,3 +25,13 @@ if (rawMode !== "live" && rawMode !== "static" && rawMode !== "morph") {
 }
 
 export const mode: Mode = rawMode;
+
+/** Register a Cucumber Before hook that skips scenarios tagged `tag`
+ *  whenever the current run mode is not in `requiredModes`. The Set form
+ *  generalises to N-way gating — e.g. a future `@morph-only` would just
+ *  pass `new Set(["morph"])`. */
+export function skipUnlessMode(tag: string, requiredModes: Set<Mode>): void {
+  Before({ tags: tag }, function () {
+    if (!requiredModes.has(mode)) return "skipped" as const;
+  });
+}

--- a/tests/support/mode.ts
+++ b/tests/support/mode.ts
@@ -26,6 +26,12 @@ if (rawMode !== "live" && rawMode !== "static" && rawMode !== "morph") {
 
 export const mode: Mode = rawMode;
 
+/** Modes that run a live `emanote run` backend — i.e. provide a
+ *  WebSocket and `window.ema`, plus live-only behavior such as the
+ *  ambiguous-link candidate list. `static` is the only mode that lacks
+ *  them. New backend-capable modes get appended here. */
+export const NON_STATIC_MODES: readonly Mode[] = ["live", "morph"];
+
 /** Register a Cucumber Before hook that skips scenarios tagged `tag`
  *  whenever the current run mode is not in `requiredModes`. Generalises
  *  to N-way gating — e.g. a future `@morph-only` would pass `["morph"]`. */

--- a/tests/support/mode.ts
+++ b/tests/support/mode.ts
@@ -33,8 +33,7 @@ export const mode: Mode = rawMode;
 export const NON_STATIC_MODES: readonly Mode[] = ["live", "morph"];
 
 /** Register a Cucumber Before hook that skips scenarios tagged `tag`
- *  whenever the current run mode is not in `requiredModes`. Generalises
- *  to N-way gating — e.g. a future `@morph-only` would pass `["morph"]`. */
+ *  unless the current run mode is in `requiredModes`. */
 export function skipUnlessMode(
   tag: string,
   requiredModes: readonly Mode[],

--- a/tests/support/mode.ts
+++ b/tests/support/mode.ts
@@ -27,11 +27,13 @@ if (rawMode !== "live" && rawMode !== "static" && rawMode !== "morph") {
 export const mode: Mode = rawMode;
 
 /** Register a Cucumber Before hook that skips scenarios tagged `tag`
- *  whenever the current run mode is not in `requiredModes`. The Set form
- *  generalises to N-way gating — e.g. a future `@morph-only` would just
- *  pass `new Set(["morph"])`. */
-export function skipUnlessMode(tag: string, requiredModes: Set<Mode>): void {
+ *  whenever the current run mode is not in `requiredModes`. Generalises
+ *  to N-way gating — e.g. a future `@morph-only` would pass `["morph"]`. */
+export function skipUnlessMode(
+  tag: string,
+  requiredModes: readonly Mode[],
+): void {
   Before({ tags: tag }, function () {
-    if (!requiredModes.has(mode)) return "skipped" as const;
+    if (!requiredModes.includes(mode)) return "skipped" as const;
   });
 }


### PR DESCRIPTION
**Two near-identical `Before`-skip hooks in `tests/support/hooks.ts` collapse into a single `skipUnlessMode(tag, requiredModes)` helper alongside the `Mode` type in `tests/support/mode.ts`.** [#713](https://github.com/srid/emanote/pull/713) introduced `@live` as a sibling to `@morph`, and the two hooks ended up differing only in the tag name — a third tag would have meant a third copy.

### Before / after

```ts
// before — tests/support/hooks.ts
Before({ tags: "@morph" }, function () {
  if (mode === "static") return "skipped" as const;
});
Before({ tags: "@live" }, function () {
  if (mode === "static") return "skipped" as const;
});

// after
skipUnlessMode("@morph", NON_STATIC_MODES);
skipUnlessMode("@live", NON_STATIC_MODES);
```

`NON_STATIC_MODES: readonly Mode[] = ["live", "morph"]` lives in `mode.ts` as the named volatility axis _"modes that run a live emanote backend"_ — a future backend-capable mode appends one entry there. The `Set<Mode>` shape the issue text suggested collapsed to `readonly Mode[] + .includes()` after review: same multi-mode contract, less ceremony.

The unrelated `usesMorph && !tagged` safety check (matches step text, not a tag) stays as-is.

### Verification

| Mode   | Result                                                    |
| ------ | --------------------------------------------------------- |
| static | 46 passed, **5 correctly skipped** by the new helper      |
| live   | 51 / 51 passed                                            |
| morph  | 51 / 51 passed                                            |

Closes #716.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._