### PR TITLE
Stop ignored folder events from warning live notebooks

### DIFF
--- a/emanote/CHANGELOG.md
+++ b/emanote/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 **Bug fixes**
 
+- Live server ignore handling no longer logs `Unhandled folder event ... on an ignored path` when Git writes under ignored dot directories such as `.git/objects/`; ignored watcher events are filtered in UnionMount before debounce.
 - Org notes can now declare Pandoc Lua filters with repeated explicit `#+PANDOC_FILTERS_PARSE: path/to/filter.lua` and `#+PANDOC_FILTERS_RENDER_HTML: path/to/filter.lua` keywords. The filters run during static generation and live rendering, and edits/creation/deletion of referenced `.lua` files re-parse dependent Org notes the same way Markdown `pandoc.filters.parse` frontmatter does (closes the Org-mode parity item in [#721](https://github.com/srid/emanote/issues/721)).
 - Wikilinks now resolve to structural source files such as `index.yaml` and Heist `.tpl` templates. These files still feed their dedicated model paths (metadata cascade and template loading), but Emanote also tracks the topmost layer copy as a static file so `![[index.yaml]]` renders as highlighted YAML and `[[my-template.tpl]]` links to the template source (closes [#720](https://github.com/srid/emanote/issues/720)).
 - Inline hashtag parsing now leaves all-numeric GitHub-style issue references such as `#221` as plain text, so they no longer link to tag pages or pollute the global tag index. Tags that contain digits, such as hierarchical `#issue/221` or `#tag221`, still work normally.

--- a/flake.lock
+++ b/flake.lock
@@ -269,15 +269,16 @@
     "unionmount": {
       "flake": false,
       "locked": {
-        "lastModified": 1778419301,
-        "narHash": "sha256-78YdPgKAo9OcmSNpktO2FOOlPwOyeiJKZm2fS86+ups=",
+        "lastModified": 1778503061,
+        "narHash": "sha256-SyJUttW4blD+1OW8yCMWndN1OxVP/pSJRmboIE9bQDM=",
         "owner": "srid",
         "repo": "unionmount",
-        "rev": "c6725e31a2e95f3fabe5783643b8c0746d31a044",
+        "rev": "f068e5c0ce497662f8822e45ae8f342f9978b178",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "fix-ignore-folder-events",
         "repo": "unionmount",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -269,16 +269,15 @@
     "unionmount": {
       "flake": false,
       "locked": {
-        "lastModified": 1778503061,
+        "lastModified": 1778504504,
         "narHash": "sha256-SyJUttW4blD+1OW8yCMWndN1OxVP/pSJRmboIE9bQDM=",
         "owner": "srid",
         "repo": "unionmount",
-        "rev": "f068e5c0ce497662f8822e45ae8f342f9978b178",
+        "rev": "7b631ebe44d1b9e3e6bc39c9acb97645ddf8b9ba",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "fix-ignore-folder-events",
         "repo": "unionmount",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     lvar.flake = false;
     heist-extra.url = "github:srid/heist-extra";
     heist-extra.flake = false;
-    unionmount.url = "github:srid/unionmount/fix-ignore-folder-events";
+    unionmount.url = "github:srid/unionmount";
     unionmount.flake = false;
     commonmark-simple.url = "github:srid/commonmark-simple/0.2.0.0";
     commonmark-simple.flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     lvar.flake = false;
     heist-extra.url = "github:srid/heist-extra";
     heist-extra.flake = false;
-    unionmount.url = "github:srid/unionmount";
+    unionmount.url = "github:srid/unionmount/fix-ignore-folder-events";
     unionmount.flake = false;
     commonmark-simple.url = "github:srid/commonmark-simple/0.2.0.0";
     commonmark-simple.flake = false;


### PR DESCRIPTION
**Live notebooks no longer warn on ignored folder events** when Git writes under paths such as `.git/objects/`. The watcher fix has landed in UnionMount, and this PR updates Emanote to the merged upstream `srid/unionmount` commit so Emanote keeps owning ignore policy while UnionMount owns event admission.

The upstream dependency PR is srid/unionmount#19. It adds a regression test for ignored live folder events, filters ignored watcher events before debounce, and passed local plus `vira ci` validation before merge.

### Try it locally

```sh
nix run github:srid/emanote/fix-unionmount-ignore-folder-events
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._