### PR TITLE
test(lua-filters): cover hot-reload when the note itself is edited

### DIFF
--- a/tests/features/lua-filters.feature
+++ b/tests/features/lua-filters.feature
@@ -52,6 +52,22 @@ Feature: Pandoc Lua filter hot-reload (issue #263)
     Then the article body contains "DEMO_FILTER:CHANGED" within 10 seconds
 
   @live @hot-reload
+  Scenario: Editing the .md note that declares a Lua filter live-updates its page
+    When I open "/lua-filter-demo.html"
+    Then the article body contains "DEMO_FILTER:HELLO"
+    When I replace "Lua Filter Demo" with "Lua Filter Demo MD_BODY_EDIT_MARKER" in "lua-filter-demo.md"
+    Then the article body contains "MD_BODY_EDIT_MARKER" within 10 seconds
+    And the article body contains "DEMO_FILTER:HELLO"
+
+  @live @hot-reload
+  Scenario: Editing the .org note that declares a Lua filter live-updates its page
+    When I open "/lua-filter-org-demo.html"
+    Then the article body contains "DEMO_FILTER:HELLO"
+    When I replace "Lua Filter Org Demo" with "Lua Filter Org Demo ORG_BODY_EDIT_MARKER" in "lua-filter-org-demo.org"
+    Then the article body contains "ORG_BODY_EDIT_MARKER" within 10 seconds
+    And the article body contains "DEMO_FILTER:HELLO"
+
+  @live @hot-reload
   Scenario: Editing a render-time .lua filter live-updates dependent notes (#721)
     When I open "/lua-filter-render-demo.html"
     Then the article body contains "RENDER_FILTER:HTML"

--- a/tests/features/lua-filters.feature
+++ b/tests/features/lua-filters.feature
@@ -61,10 +61,13 @@ Feature: Pandoc Lua filter hot-reload (issue #263)
 
   @live @hot-reload
   Scenario: Editing the .org note that declares a Lua filter live-updates its page
+    # Marker avoids underscores so Pandoc's Org reader does not consume
+    # them as `_subscript_` syntax — otherwise the rendered innerText
+    # collapses the marker and the assertion can't find it.
     When I open "/lua-filter-org-demo.html"
     Then the article body contains "DEMO_FILTER:HELLO"
-    When I replace "Lua Filter Org Demo" with "Lua Filter Org Demo ORG_BODY_EDIT_MARKER" in "lua-filter-org-demo.org"
-    Then the article body contains "ORG_BODY_EDIT_MARKER" within 10 seconds
+    When I replace "Lua Filter Org Demo" with "Lua Filter Org Demo ORGBODYEDITMARKER" in "lua-filter-org-demo.org"
+    Then the article body contains "ORGBODYEDITMARKER" within 10 seconds
     And the article body contains "DEMO_FILTER:HELLO"
 
   @live @hot-reload

--- a/tests/support/fixture.ts
+++ b/tests/support/fixture.ts
@@ -29,14 +29,18 @@ const stagedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "emanote-e2e-stage-"));
 export const stagedFixtureDir = path.join(stagedRoot, "notebook");
 fs.cpSync(sourceFixtureDir, stagedFixtureDir, { recursive: true });
 
-/** Subtrees the hot-reload scenarios mutate wholesale. The reset
- *  removes the staged copy and re-copies from source, which both
- *  restores edited files and cleans up any files a scenario created
- *  inside the subtree (e.g. a previously-missing filter). New
- *  dep-kinds add their own subtree here as they come online. */
-const mutatedSubtrees: string[] = [
+/** Notebook paths (subtrees or top-level files) the hot-reload
+ *  scenarios mutate. The reset removes each staged entry and re-copies
+ *  from source, which both restores edited files and cleans up any
+ *  files a scenario created inside a listed subtree (e.g. a
+ *  previously-missing filter). Top-level note files belong here when a
+ *  scenario edits the note itself rather than its dependency. New
+ *  dep-kinds add their own entry here as they come online. */
+const mutatedPaths: string[] = [
   "focus-mode", // UI focus-mode hot-reload fixture
   "filters", // Pandoc Lua filters (issue #263)
+  "lua-filter-demo.md", // Markdown note edits via its declared filter
+  "lua-filter-org-demo.org", // Org note edits via its declared filter
 ];
 
 /** Files that hot-reload scenarios create from scratch at the
@@ -55,14 +59,14 @@ const ephemeralFiles: string[] = [
  *  baseline. Called from the @hot-reload Before hook in
  *  `support/hooks.ts`.
  *
- *  We rm + cp each declared mutated subtree rather than walking the
+ *  We rm + cp each declared mutated path rather than walking the
  *  whole notebook so unrelated state (the static-gen output dir, the
  *  user's other notebooks) stays untouched, and so a test-created
  *  file inside a tracked subtree is cleaned up automatically without
  *  the scenario needing to declare it. Top-level ephemeral files are
  *  listed explicitly. */
 export function resetStagedNotebookMutations(): void {
-  for (const sub of mutatedSubtrees) {
+  for (const sub of mutatedPaths) {
     const staged = path.join(stagedFixtureDir, sub);
     const source = path.join(sourceFixtureDir, sub);
     fs.rmSync(staged, { recursive: true, force: true });


### PR DESCRIPTION
**Editing a Markdown or Org note that declares a Pandoc Lua filter must live-update the page the same way editing the `.lua` file does.** The existing e2e coverage only mutated the `.lua` source, so the `R.LMLType` branch of `patchModel` was untested for notes carrying a declared filter — a regression there would have shipped silently.

Two new `@live @hot-reload` scenarios in `tests/features/lua-filters.feature` open `/lua-filter-demo.html` and `/lua-filter-org-demo.html`, mutate the note body via the existing `I replace … in …` step, and assert the new marker shows up within 10 seconds while the filter-rewritten token (`DEMO_FILTER:HELLO`) remains intact. *No production code changed — the existing parse → insert → WS-push path already handles this, and the new scenarios pin it in place.*

### Notes for reviewers

- The Org scenario uses `ORGBODYEDITMARKER` (no underscores) on purpose. Pandoc's Org reader treats `text_subscript` word-internally, so `ORG_BODY_EDIT_MARKER` rendered as `ORG<sub>BODY</sub>EDIT<sub>MARKER</sub>` and the assertion couldn't find the literal string in `innerText`. The existing Org fixtures (`EMANOTELUAORGDEMO`, `EMANOTEORGRENDERFILTERTOKEN`) follow the same convention.
- `tests/support/fixture.ts` rename: `mutatedSubtrees` → `mutatedPaths`. The reset already used `fs.rmSync` + `fs.cpSync`, which handle individual files as well as directories — just renaming makes the broadened intent explicit and lets `lua-filter-demo.md` / `lua-filter-org-demo.org` join the list so a scenario can safely overwrite them.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._