### PR TITLE
ci: disable flake-parts-docs job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   flake-parts-docs:
+    # Temporarily disabled — re-enable by removing the `if: false` guard.
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Gates the `flake-parts-docs` CI job with `if: false` so it no longer runs on push/PR. The job definition is left intact (not deleted) so it can be re-enabled by removing the single-line guard.

## Test plan

- [ ] CI run on this PR shows the `flake-parts-docs` job as skipped (no execution)
- [ ] Other jobs (`build`, `e2e-tests`) continue to run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)